### PR TITLE
feat(linux): add X11 custom window chrome

### DIFF
--- a/docs/design/window-chrome.md
+++ b/docs/design/window-chrome.md
@@ -1,6 +1,6 @@
 # Window Chrome Design
 
-Status: shared contract plus Windows and macOS Custom modes implemented; Linux Custom mode remains deferred
+Status: shared contract plus Windows, macOS, and Linux Custom modes implemented
 
 This document defines desktop window-chrome ownership, application-defined title-bar content, standard window controls, drag hit testing, and platform fallback behavior.
 It complements the mobile-oriented [Window Insets and System Bars Design](window-insets.md) without changing safe-area semantics.
@@ -13,7 +13,7 @@ It complements the mobile-oriented [Window Insets and System Bars Design](window
 - Keep native window metadata available to task switching, window management, system menus, and accessibility.
 - Reuse mounted layout and pointer geometry for drag and native hit testing.
 - Provide convenient per-window commands without exposing platform window objects.
-- Keep one ownership model across Windows, macOS, and future Linux client-side decorations.
+- Keep one ownership model across Windows, macOS, and Linux client-side decorations.
 
 ## Non-goals
 
@@ -305,12 +305,24 @@ System mode retains the ordinary AppKit title bar and submits no title-bar metri
 
 ## Linux mapping
 
-The current Linux backend uses X11 with window-manager decorations.
-X11 does not provide one portable contract for embedding client content into a server-decorated title bar while preserving its buttons.
+The current Linux backend uses X11.
+Custom mode removes server-side decorations through `_MOTIF_WM_HINTS` with `MWM_HINTS_DECORATIONS` and zero decorations.
+The window remains window-manager managed rather than override-redirect, so taskbar presence, snap, and window-manager keybindings keep working.
 
-Until client-side decorations are implemented, Linux resolves Custom to System, submits no title-bar metrics, and renders `WindowTitleBar` as an ordinary client-area bar.
+The framework renders the standard minimize, maximize or restore, and close controls in a `WindowControlsLayout` layer.
+Their geometry is submitted as a `WindowTitleBarMetrics.right_inset` of three times 46 DIP, matching the Windows modern interaction width because X11 has no native caption system metric.
 
-Future X11 Custom support removes server decorations, renders framework standard controls, delegates movement and resizing through `_NET_WM_MOVERESIZE`, and uses window-manager protocols for maximize, minimize, and close.
+Linux metric resolution prefers `AppOptions::window.title_bar_height`, enforces a 32-DIP minimum height, clamps to the viewport, reports zero left inset, caps the right inset at the viewport width, and tracks the maximized state.
+
+Native drag and edge or corner resize send `_NET_WM_MOVERESIZE` client messages to the root window from the pointer button event, using root-relative coordinates, the pointer button, and the event time.
+Hit testing mirrors the Windows `HTCAPTION` approach: caption-control bounds first, then resize edges, then `Runtime::IsWindowDragRegion()`, then normal client handling.
+
+The resize border prefers the window-manager-reported `_NET_FRAME_EXTENTS` subscribed through `PropertyNotify` and falls back to a fixed 6-DIP border; resize edges are skipped while maximized.
+
+Maximize, restore, and toggle use EWMH `_NET_WM_STATE` with `_NET_WM_STATE_MAXIMIZED_HORZ` and `_NET_WM_STATE_MAXIMIZED_VERT`, minimize uses `XIconifyWindow`, and close reuses the `WM_DELETE_WINDOW` protocol path.
+The maximized state is tracked through `PropertyNotify` on `_NET_WM_STATE` and drives the caption glyph swap through the shared `maximize_state_changed` path.
+
+System mode is unchanged and submits no title-bar metrics.
 
 A future Wayland backend negotiates decorations through `xdg-decoration`.
 Client-side movement and resize use `xdg_toplevel` requests with the seat and serial from the initiating pointer event; they never depend on global pointer coordinates.
@@ -345,7 +357,7 @@ The removed Windows Extended experiment has no compatibility alias or retained D
 
 Windows Custom mode uses the normal opaque renderer, full-client non-client calculation, framework controls, and native resize, drag, system-command, and maximize-button hit testing.
 macOS Custom mode uses full-size AppKit content, native traffic lights, converted left-side control geometry, native dragging, and native window commands.
-Linux continues to resolve Custom according to its platform section until client-side decorations are implemented.
+Linux Custom mode uses framework controls in a `WindowControlsLayout` layer, `_MOTIF_WM_HINTS` decoration removal, `_NET_WM_MOVERESIZE` drag and resize, EWMH and `XIconifyWindow` commands, and `PropertyNotify`-tracked maximized state.
 
 ## Testing
 
@@ -369,10 +381,11 @@ High DPI, `Alt+Space`, system-menu behavior, and Windows 11 Snap Layout still re
 
 macOS tests isolate preferred and native title-bar height, traffic-light vertical centering, left-side control reservation, narrow-viewport normalization, and zoomed-state propagation.
 Manual macOS validation remains required for native window composition, traffic-light accessibility, dragging, full-screen transitions, and cross-screen behavior before release.
-Linux Custom decorations remain deferred; the current adapter continues to use system decorations.
+Linux tests isolate metric resolution, resize-direction edge semantics including maximized skip and caption-bounds exclusion and viewport clamping, maximized-state atom detection, and frame-extents fallback.
+Manual Linux validation currently covers decoration removal, drag and edge or corner resize, caption-control interaction, and the maximized glyph swap on KWin.
 
 ## Delivery order
 
 The shared contract and Windows Custom implementation form the first delivery.
 The macOS implementation forms the second delivery and retains native traffic lights.
-Linux Custom decorations and Wayland remain later platform work under the same two-mode contract.
+Linux Custom mode is delivered under the same two-mode contract, while Wayland remains later platform work.

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -46,6 +46,16 @@ constexpr Time kDoubleClickTimeMs = 400;
 constexpr float kDoubleClickSlop = 4.0F;
 constexpr unsigned int kScrollLeftButton = 6;
 constexpr unsigned int kScrollRightButton = 7;
+// Motif WM hints flag requesting that the window manager drop server decorations.
+constexpr unsigned long kMwmHintsDecorations = 1UL << 1;
+
+struct MotifWmHints {
+  unsigned long flags;
+  unsigned long functions;
+  unsigned long decorations;
+  long input_mode;
+  unsigned long status;
+};
 
 Key TranslateKey(KeySym keysym) {
   switch (keysym) {
@@ -176,6 +186,7 @@ public:
       XMapWindow(display_, window_);
       XFlush(display_);
 
+      RefreshWindowState();
       runtime_->UpdateResourceConfiguration(Configuration());
       UpdateRuntimeViewport();
 
@@ -200,6 +211,28 @@ public:
   void RequestFrameAt(double deadline) override {
     if (const std::optional<double> scheduled = frame_state_.Request(deadline, Now(), window_ != 0)) {
       ScheduleFrame(*scheduled);
+    }
+  }
+
+  void RequestWindowCommand(huxerui::WindowCommand command) override {
+    switch (command) {
+    case huxerui::WindowCommand::Minimize:
+      XIconifyWindow(display_, window_, screen_);
+      XFlush(display_);
+      break;
+    case huxerui::WindowCommand::Maximize:
+      SetWindowMaximized(true);
+      break;
+    case huxerui::WindowCommand::Restore:
+      SetWindowMaximized(false);
+      break;
+    case huxerui::WindowCommand::ToggleMaximize:
+      ReadMaximizedState();
+      SetWindowMaximized(!maximized_);
+      break;
+    case huxerui::WindowCommand::Close:
+      RequestClose();
+      break;
     }
   }
 
@@ -327,15 +360,17 @@ private:
     const float scale = DpiScale();
     width_ = std::max(1, static_cast<int>(std::lround(options.initial_size.width * scale)));
     height_ = std::max(1, static_cast<int>(std::lround(options.initial_size.height * scale)));
+    custom_chrome_ = options.chrome_mode == WindowChromeMode::Custom;
+    custom_title_bar_height_ = options.title_bar_height;
 
-    const int screen = DefaultScreen(display_);
+    screen_ = DefaultScreen(display_);
     const Window root = DefaultRootWindow(display_);
 
     // EGL window surfaces require a window whose visual matches the EGLConfig.
     // Create the window with the renderer's native visual and colormap when EGL
     // is available, and fall back to the default visual otherwise.
     XVisualInfo* presentation_visual = nullptr;
-    int depth = DefaultDepth(display_, screen);
+    int depth = DefaultDepth(display_, screen_);
     if (renderer_.HasPresentation() && renderer_.NativeVisualId() != 0) {
       XVisualInfo visual_info_template{};
       visual_info_template.visualid = static_cast<VisualID>(renderer_.NativeVisualId());
@@ -349,12 +384,12 @@ private:
     }
 
     XSetWindowAttributes attributes{};
-    attributes.background_pixel = BlackPixel(display_, screen);
-    attributes.border_pixel = WhitePixel(display_, screen);
+    attributes.background_pixel = BlackPixel(display_, screen_);
+    attributes.border_pixel = WhitePixel(display_, screen_);
     attributes.colormap = colormap_;
     attributes.event_mask =
         StructureNotifyMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
-            ExposureMask | FocusChangeMask | EnterWindowMask | LeaveWindowMask;
+            ExposureMask | FocusChangeMask | EnterWindowMask | LeaveWindowMask | PropertyChangeMask;
     unsigned long value_mask = CWBackPixel | CWBorderPixel | CWEventMask;
     if (colormap_ != 0) {
       value_mask |= CWColormap;
@@ -369,7 +404,7 @@ private:
         0,
         depth,
         InputOutput,
-        presentation_visual != nullptr ? presentation_visual->visual : DefaultVisual(display_, screen),
+        presentation_visual != nullptr ? presentation_visual->visual : DefaultVisual(display_, screen_),
         value_mask,
         &attributes
     );
@@ -392,11 +427,34 @@ private:
     wm_delete_window_ = XInternAtom(display_, "WM_DELETE_WINDOW", 0);
     XSetWMProtocols(display_, window_, &wm_delete_window_, 1);
 
+    motif_wm_hints_ = XInternAtom(display_, "_MOTIF_WM_HINTS", 0);
+    net_wm_state_ = XInternAtom(display_, "_NET_WM_STATE", 0);
+    net_wm_state_max_h_ = XInternAtom(display_, "_NET_WM_STATE_MAXIMIZED_HORZ", 0);
+    net_wm_state_max_v_ = XInternAtom(display_, "_NET_WM_STATE_MAXIMIZED_VERT", 0);
+    net_wm_moveresize_ = XInternAtom(display_, "_NET_WM_MOVERESIZE", 0);
+    net_frame_extents_ = XInternAtom(display_, "_NET_FRAME_EXTENTS", 0);
+
+    if (custom_chrome_) {
+      MotifWmHints hints{};
+      hints.flags = kMwmHintsDecorations;
+      hints.decorations = 0;
+      XChangeProperty(
+          display_,
+          window_,
+          motif_wm_hints_,
+          motif_wm_hints_,
+          32,
+          PropModeReplace,
+          reinterpret_cast<const unsigned char*>(&hints),
+          5
+      );
+    }
+
     XSelectInput(
         display_,
         window_,
         StructureNotifyMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
-            ExposureMask | FocusChangeMask | EnterWindowMask | LeaveWindowMask
+            ExposureMask | FocusChangeMask | EnterWindowMask | LeaveWindowMask | PropertyChangeMask
     );
 
     clipboard_atom_ = XInternAtom(display_, "CLIPBOARD", 0);
@@ -619,6 +677,9 @@ private:
     case SelectionClear:
       clipboard_text_.clear();
       break;
+    case PropertyNotify:
+      HandlePropertyNotify(event.xproperty);
+      break;
     default:
       if (randr_event_base_ != 0 && event.type - randr_event_base_ == RRScreenChangeNotify) {
         XRRUpdateConfiguration(&event);
@@ -637,6 +698,52 @@ private:
     }
   }
 
+  void SetWindowMaximized(bool add) {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    XClientMessageEvent event{};
+    event.type = ClientMessage;
+    event.window = window_;
+    event.message_type = net_wm_state_;
+    event.format = 32;
+    event.data.l[0] = add ? 1 : 0;
+    event.data.l[1] = static_cast<long>(net_wm_state_max_h_);
+    event.data.l[2] = static_cast<long>(net_wm_state_max_v_);
+    event.data.l[3] = 0;
+    event.data.l[4] = 0;
+    XEvent send_event{};
+    send_event.xclient = event;
+    XSendEvent(
+        display_,
+        DefaultRootWindow(display_),
+        0,
+        SubstructureRedirectMask | SubstructureNotifyMask,
+        &send_event
+    );
+    XFlush(display_);
+  }
+
+  void RequestClose() {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    XClientMessageEvent event{};
+    event.type = ClientMessage;
+    event.window = window_;
+    event.message_type = wm_protocols_;
+    event.format = 32;
+    event.data.l[0] = static_cast<long>(wm_delete_window_);
+    event.data.l[1] = CurrentTime;
+    event.data.l[2] = 0;
+    event.data.l[3] = 0;
+    event.data.l[4] = 0;
+    XEvent send_event{};
+    send_event.xclient = event;
+    XSendEvent(display_, window_, 0, NoEventMask, &send_event);
+    XFlush(display_);
+  }
+
   void HandleConfigureNotify(const XConfigureEvent& event) {
     if (event.width == width_ && event.height == height_) {
       return;
@@ -647,6 +754,95 @@ private:
     renderer_.Resize(display_, window_, width_, height_, dpi_);
     UpdateRuntimeViewport();
     RequestFrameAt(Now());
+  }
+
+  void HandlePropertyNotify(const XPropertyEvent& event) {
+    if (event.window != window_ || event.state != PropertyNewValue) {
+      return;
+    }
+    if (event.atom == net_wm_state_) {
+      const bool was_maximized = maximized_;
+      ReadMaximizedState();
+      if (maximized_ != was_maximized) {
+        UpdateRuntimeViewport();
+      }
+    } else if (event.atom == net_frame_extents_) {
+      ReadFrameExtents();
+    }
+  }
+
+  void ReadMaximizedState() {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    Atom actual_type = 0;
+    int actual_format = 0;
+    unsigned long item_count = 0;
+    unsigned long bytes_after = 0;
+    unsigned char* data = nullptr;
+    const int status = XGetWindowProperty(
+        display_,
+        window_,
+        net_wm_state_,
+        0,
+        64,
+        0,
+        XA_ATOM,
+        &actual_type,
+        &actual_format,
+        &item_count,
+        &bytes_after,
+        &data
+    );
+    if (status == 0 && data != nullptr && actual_type == XA_ATOM && actual_format == 32) {
+      const auto* atoms = reinterpret_cast<const Atom*>(data);
+      maximized_ = LinuxMaximizedFromAtoms(
+          std::vector<Atom>(atoms, atoms + item_count), net_wm_state_max_h_, net_wm_state_max_v_
+      );
+    }
+    if (data != nullptr) {
+      XFree(data);
+    }
+  }
+
+  void ReadFrameExtents() {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    Atom actual_type = 0;
+    int actual_format = 0;
+    unsigned long item_count = 0;
+    unsigned long bytes_after = 0;
+    unsigned char* data = nullptr;
+    const int status = XGetWindowProperty(
+        display_,
+        window_,
+        net_frame_extents_,
+        0,
+        4,
+        0,
+        XA_CARDINAL,
+        &actual_type,
+        &actual_format,
+        &item_count,
+        &bytes_after,
+        &data
+    );
+    if (status == 0 && data != nullptr && actual_format == 32 && item_count >= 4) {
+      frame_extents_ =
+          LinuxReadFrameExtents(static_cast<const long*>(static_cast<const void*>(data)), static_cast<int>(item_count));
+    }
+    if (data != nullptr) {
+      XFree(data);
+    }
+  }
+
+  void RefreshWindowState() {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    ReadMaximizedState();
+    ReadFrameExtents();
   }
 
   void HandleExpose(const XExposeEvent& event) {
@@ -664,17 +860,77 @@ private:
     if (event.button != Button1) {
       return;
     }
+    suppress_pointer_ = false;
+    if (TryBeginNativeWindowOperation(event)) {
+      suppress_pointer_ = true;
+      return;
+    }
     pointer_down_ = true;
     const Point position = ClientPoint(event.x, event.y);
     SendPointer(PointerEventType::Down, position, ComputeClickCount(event.button, position, event.time));
   }
 
   void HandleButtonRelease(const XButtonEvent& event) {
+    // The press began a native window operation, so the matching release belongs
+    // to the window manager and must not be forwarded to the runtime.
+    if (suppress_pointer_) {
+      suppress_pointer_ = false;
+      return;
+    }
     if (event.button != Button1) {
       return;
     }
     pointer_down_ = false;
     SendPointer(PointerEventType::Up, ClientPoint(event.x, event.y));
+  }
+
+  bool TryBeginNativeWindowOperation(const XButtonEvent& event) {
+    if (!custom_chrome_) {
+      return false;
+    }
+    const Point position = ClientPoint(event.x, event.y);
+    const float scale = DpiScale();
+    const Size viewport{static_cast<float>(width_) / scale, static_cast<float>(height_) / scale};
+    const WindowTitleBarMetrics title = ResolveLinuxTitleBarMetrics(custom_title_bar_height_, viewport, maximized_);
+    const float border = LinuxResizeBorderDips(frame_extents_, scale, kLinuxResizeBorderDips);
+    const Rect caption_bounds{viewport.width - title.right_inset, 0.0F, title.right_inset, title.height};
+    const LinuxResizeDirection direction =
+        ResolveLinuxResizeDirection(position, border, viewport, maximized_, caption_bounds);
+    if (direction != LinuxResizeDirection::None) {
+      InitiateWindowMoveResize(event, static_cast<long>(direction));
+      return true;
+    }
+    if (runtime_ != nullptr && runtime_->IsWindowDragRegion(position)) {
+      InitiateWindowMoveResize(event, static_cast<long>(LinuxResizeDirection::Move));
+      return true;
+    }
+    return false;
+  }
+
+  void InitiateWindowMoveResize(const XButtonEvent& event, long direction) {
+    if (display_ == nullptr || window_ == 0) {
+      return;
+    }
+    XClientMessageEvent message{};
+    message.type = ClientMessage;
+    message.window = window_;
+    message.message_type = net_wm_moveresize_;
+    message.format = 32;
+    message.data.l[0] = event.x_root;
+    message.data.l[1] = event.y_root;
+    message.data.l[2] = direction;
+    message.data.l[3] = event.button;
+    message.data.l[4] = event.time;
+    XEvent send_event{};
+    send_event.xclient = message;
+    XSendEvent(
+        display_,
+        DefaultRootWindow(display_),
+        0,
+        SubstructureRedirectMask | SubstructureNotifyMask,
+        &send_event
+    );
+    XFlush(display_);
   }
 
   void HandleScrollButton(const XButtonEvent& event) {
@@ -836,9 +1092,15 @@ private:
       return;
     }
     const float scale = DpiScale();
-    runtime_->SetWindowMetrics({
+    WindowMetrics metrics{
         .viewport = {static_cast<float>(width_) / scale, static_cast<float>(height_) / scale},
-    });
+        .safe_area = {},
+        .title_bar = std::nullopt,
+    };
+    if (custom_chrome_) {
+      metrics.title_bar = ResolveLinuxTitleBarMetrics(custom_title_bar_height_, metrics.viewport, maximized_);
+    }
+    runtime_->SetWindowMetrics(metrics);
   }
 
   void HandleDisplayChange() {
@@ -1015,12 +1277,24 @@ private:
   Atom utf8_string_atom_ = 0;
   Atom targets_atom_ = 0;
   Atom clipboard_property_ = 0;
+  bool custom_chrome_ = false;
+  float custom_title_bar_height_ = 0.0F;
+  bool maximized_ = false;
+  int screen_ = 0;
+  LinuxFrameExtents frame_extents_;
+  Atom motif_wm_hints_ = 0;
+  Atom net_wm_state_ = 0;
+  Atom net_wm_state_max_h_ = 0;
+  Atom net_wm_state_max_v_ = 0;
+  Atom net_wm_moveresize_ = 0;
+  Atom net_frame_extents_ = 0;
   LinuxRenderer renderer_;
   LinuxTextInput text_input_;
   PlatformFrameState frame_state_;
   std::optional<double> scheduled_frame_deadline_;
   bool running_ = false;
   bool pointer_down_ = false;
+  bool suppress_pointer_ = false;
   Point last_pointer_position_;
   std::uint32_t last_click_count_ = 0;
   unsigned int last_click_button_ = 0;

--- a/platform/linux/linux_internal.h
+++ b/platform/linux/linux_internal.h
@@ -13,16 +13,147 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <vector>
 
 #include <huxerui/render_scene.h>
+#include <huxerui/window.h>
 
 namespace huxerui::detail {
+
+// Framework-rendered caption buttons match the modern 46-DIP interaction width used on Windows.
+inline constexpr float kLinuxCaptionButtonWidth = 46.0F;
+// Resize hit-test border when the window manager reports no frame extents.
+inline constexpr float kLinuxResizeBorderDips = 6.0F;
+// Minimum logical title-bar height so framework caption controls remain usable.
+inline constexpr float kLinuxMinTitleBarHeight = 32.0F;
+
+// Mirrors the EWMH _NET_WM_MOVERESIZE direction constants; Move requests window movement.
+enum class LinuxResizeDirection : long {
+  None = -1,
+  TopLeft = 0,
+  Top = 1,
+  TopRight = 2,
+  Right = 3,
+  BottomRight = 4,
+  Bottom = 5,
+  BottomLeft = 6,
+  Left = 7,
+  Move = 8,
+};
+
+struct LinuxFrameExtents {
+  long left = 0;
+  long right = 0;
+  long top = 0;
+  long bottom = 0;
+};
 
 struct LinuxDamageRegion {
   bool full = false;
   std::vector<XRectangle> rects;
 };
+
+inline WindowTitleBarMetrics ResolveLinuxTitleBarMetrics(
+    float preferred_height, Size viewport, bool maximized
+) noexcept {
+  const float width = std::isfinite(viewport.width) ? std::max(0.0F, viewport.width) : 0.0F;
+  const float viewport_height = std::isfinite(viewport.height) ? std::max(0.0F, viewport.height) : 0.0F;
+  const float preferred = std::isfinite(preferred_height) ? std::max(0.0F, preferred_height) : 0.0F;
+  return {
+      .height = std::min(viewport_height, std::max(preferred, kLinuxMinTitleBarHeight)),
+      .left_inset = 0.0F,
+      .right_inset = std::min(width, 3.0F * kLinuxCaptionButtonWidth),
+      .maximized = maximized,
+  };
+}
+
+inline LinuxResizeDirection ResolveLinuxResizeDirection(
+    Point point, float border, Size viewport, bool maximized, std::optional<Rect> caption_bounds = std::nullopt
+) noexcept {
+  if (maximized || !std::isfinite(border) || border <= 0.0F) {
+    return LinuxResizeDirection::None;
+  }
+  const float width = std::isfinite(viewport.width) ? std::max(0.0F, viewport.width) : 0.0F;
+  const float height = std::isfinite(viewport.height) ? std::max(0.0F, viewport.height) : 0.0F;
+  if (width <= 0.0F || height <= 0.0F) {
+    return LinuxResizeDirection::None;
+  }
+  const float x = std::clamp(point.x, 0.0F, width);
+  const float y = std::clamp(point.y, 0.0F, height);
+  if (caption_bounds.has_value() &&
+      x >= caption_bounds->x && x <= caption_bounds->x + caption_bounds->width &&
+      y >= caption_bounds->y && y <= caption_bounds->y + caption_bounds->height) {
+    return LinuxResizeDirection::None;
+  }
+  const bool left = x <= border;
+  const bool right = x >= width - border;
+  const bool top = y <= border;
+  const bool bottom = y >= height - border;
+  if (top && left) {
+    return LinuxResizeDirection::TopLeft;
+  }
+  if (top && right) {
+    return LinuxResizeDirection::TopRight;
+  }
+  if (bottom && left) {
+    return LinuxResizeDirection::BottomLeft;
+  }
+  if (bottom && right) {
+    return LinuxResizeDirection::BottomRight;
+  }
+  if (left) {
+    return LinuxResizeDirection::Left;
+  }
+  if (right) {
+    return LinuxResizeDirection::Right;
+  }
+  if (top) {
+    return LinuxResizeDirection::Top;
+  }
+  if (bottom) {
+    return LinuxResizeDirection::Bottom;
+  }
+  return LinuxResizeDirection::None;
+}
+
+inline bool LinuxMaximizedFromAtoms(const std::vector<Atom>& states, Atom max_h, Atom max_v) noexcept {
+  bool has_horizontal = false;
+  bool has_vertical = false;
+  for (const Atom atom : states) {
+    has_horizontal = has_horizontal || atom == max_h;
+    has_vertical = has_vertical || atom == max_v;
+    if (has_horizontal && has_vertical) {
+      return true;
+    }
+  }
+  return has_horizontal && has_vertical;
+}
+
+inline LinuxFrameExtents LinuxReadFrameExtents(const long* values, int count) noexcept {
+  LinuxFrameExtents extents{};
+  if (values != nullptr && count > 0) {
+    extents.left = values[0];
+    if (count > 1) {
+      extents.right = values[1];
+    }
+    if (count > 2) {
+      extents.top = values[2];
+    }
+    if (count > 3) {
+      extents.bottom = values[3];
+    }
+  }
+  return extents;
+}
+
+inline float LinuxResizeBorderDips(const LinuxFrameExtents& extents, float scale, float fallback) noexcept {
+  const long max_extent = std::max(extents.left, extents.right);
+  if (max_extent <= 0 || !std::isfinite(scale) || scale <= 0.0F) {
+    return fallback;
+  }
+  return static_cast<float>(max_extent) / scale;
+}
 
 inline LinuxDamageRegion ResolveLinuxDamage(const DamageRegion& damage, float scale, int width, int height) noexcept {
   LinuxDamageRegion result;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ if (UNIX AND NOT APPLE)
             platform/linux_damage.cpp
             platform/linux_renderer.cpp
             platform/linux_text_input.cpp
+            platform/linux_window_chrome.cpp
     )
 endif ()
 

--- a/tests/platform/linux_window_chrome.cpp
+++ b/tests/platform/linux_window_chrome.cpp
@@ -1,0 +1,106 @@
+#include "runtime_test_support.h"
+#include "linux_internal.h"
+
+#include <limits>
+
+namespace huxerui::test {
+
+TEST_CASE("LinuxTitleBarMetricsResolvePreferredHeightAndReserveControls") {
+  const WindowTitleBarMetrics preferred = detail::ResolveLinuxTitleBarMetrics(40.0F, {320.0F, 200.0F}, false);
+  REQUIRE(preferred.height == 40.0F);
+  REQUIRE(preferred.left_inset == 0.0F);
+  REQUIRE(preferred.right_inset == 3.0F * detail::kLinuxCaptionButtonWidth);
+  REQUIRE_FALSE(preferred.maximized);
+
+  const WindowTitleBarMetrics floored = detail::ResolveLinuxTitleBarMetrics(12.0F, {320.0F, 200.0F}, false);
+  REQUIRE(floored.height == detail::kLinuxMinTitleBarHeight);
+
+  const WindowTitleBarMetrics constrained = detail::ResolveLinuxTitleBarMetrics(40.0F, {100.0F, 20.0F}, false);
+  REQUIRE(constrained.height == 20.0F);
+  REQUIRE(constrained.right_inset == 100.0F);
+
+  const WindowTitleBarMetrics maximized = detail::ResolveLinuxTitleBarMetrics(40.0F, {320.0F, 200.0F}, true);
+  REQUIRE(maximized.maximized);
+
+  const WindowTitleBarMetrics non_finite =
+      detail::ResolveLinuxTitleBarMetrics(std::numeric_limits<float>::quiet_NaN(), {320.0F, 200.0F}, false);
+  REQUIRE(non_finite.height == detail::kLinuxMinTitleBarHeight);
+}
+
+TEST_CASE("LinuxResizeDirectionMatchesEdgeSemantics") {
+  const Size viewport{300.0F, 200.0F};
+  const float border = 6.0F;
+
+  REQUIRE(detail::ResolveLinuxResizeDirection({0.0F, 0.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::TopLeft);
+  REQUIRE(detail::ResolveLinuxResizeDirection({150.0F, 0.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::Top);
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 0.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::TopRight);
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 100.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::Right);
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 199.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::BottomRight);
+  REQUIRE(detail::ResolveLinuxResizeDirection({150.0F, 199.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::Bottom);
+  REQUIRE(detail::ResolveLinuxResizeDirection({0.0F, 199.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::BottomLeft);
+  REQUIRE(detail::ResolveLinuxResizeDirection({0.0F, 100.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::Left);
+  REQUIRE(detail::ResolveLinuxResizeDirection({150.0F, 100.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::None);
+
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 199.0F}, border, viewport, true) ==
+          detail::LinuxResizeDirection::None);
+
+  REQUIRE(detail::ResolveLinuxResizeDirection({0.0F, 100.0F}, 0.0F, viewport, false) ==
+          detail::LinuxResizeDirection::None);
+
+  const Rect caption_bounds{162.0F, 0.0F, 138.0F, 40.0F};
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 5.0F}, border, viewport, false, caption_bounds) ==
+          detail::LinuxResizeDirection::None);
+  REQUIRE(detail::ResolveLinuxResizeDirection({299.0F, 100.0F}, border, viewport, false, caption_bounds) ==
+          detail::LinuxResizeDirection::Right);
+  REQUIRE(detail::ResolveLinuxResizeDirection({150.0F, 0.0F}, border, viewport, false, caption_bounds) ==
+          detail::LinuxResizeDirection::Top);
+
+  REQUIRE(detail::ResolveLinuxResizeDirection({-10.0F, -10.0F}, border, viewport, false) ==
+          detail::LinuxResizeDirection::TopLeft);
+}
+
+TEST_CASE("LinuxMaximizedStateRequiresBothAxes") {
+  const Atom max_h = static_cast<Atom>(1);
+  const Atom max_v = static_cast<Atom>(2);
+  const Atom other = static_cast<Atom>(3);
+  REQUIRE(detail::LinuxMaximizedFromAtoms({max_h, max_v}, max_h, max_v));
+  REQUIRE_FALSE(detail::LinuxMaximizedFromAtoms({max_h}, max_h, max_v));
+  REQUIRE_FALSE(detail::LinuxMaximizedFromAtoms({}, max_h, max_v));
+  REQUIRE(detail::LinuxMaximizedFromAtoms({max_h, max_v, other}, max_h, max_v));
+}
+
+TEST_CASE("LinuxResizeBorderFallsBackWithoutFrameExtents") {
+  REQUIRE(detail::LinuxResizeBorderDips({}, 1.0F, 6.0F) == 6.0F);
+  REQUIRE(detail::LinuxResizeBorderDips({8, 8, 8, 8}, 2.0F, 6.0F) == 4.0F);
+  REQUIRE(detail::LinuxResizeBorderDips({10, 6, 0, 0}, 1.0F, 6.0F) == 10.0F);
+
+  const detail::LinuxFrameExtents empty = detail::LinuxReadFrameExtents(nullptr, 0);
+  REQUIRE(empty.left == 0);
+  REQUIRE(empty.right == 0);
+  REQUIRE(empty.top == 0);
+  REQUIRE(empty.bottom == 0);
+
+  const long values[] = {1, 2, 3, 4};
+  const detail::LinuxFrameExtents full = detail::LinuxReadFrameExtents(values, 4);
+  REQUIRE(full.left == 1);
+  REQUIRE(full.right == 2);
+  REQUIRE(full.top == 3);
+  REQUIRE(full.bottom == 4);
+
+  const detail::LinuxFrameExtents partial = detail::LinuxReadFrameExtents(values, 2);
+  REQUIRE(partial.left == 1);
+  REQUIRE(partial.right == 2);
+  REQUIRE(partial.top == 0);
+  REQUIRE(partial.bottom == 0);
+}
+
+} // namespace huxerui::test


### PR DESCRIPTION
## What changed

Implements `WindowChromeMode::Custom` on the Linux (X11) backend, bringing it to parity with the Windows and macOS implementations under the same two-mode contract.

- **`_MOTIF_WM_HINTS` decoration removal**: server decorations are dropped in Custom mode (`MWM_HINTS_DECORATIONS`, zero decorations) while the window stays window-manager managed, preserving taskbar presence, snap, and WM keybindings.
- **Framework-rendered caption controls**: the shared `WindowControlsLayout` supplies minimize / maximize-restore / close controls; their geometry is submitted as `WindowTitleBarMetrics.right_inset` (3 × 46 DIP) with a 32-DIP minimum height and viewport clamping.
- **Native drag and edge/corner resize**: `_NET_WM_MOVERESIZE` client messages sent to the root window from the pointer button event (root-relative coordinates, button, time). Hit-testing mirrors the Windows `HTCAPTION` approach: caption bounds → resize edges → `Runtime::IsWindowDragRegion()` → normal client handling.
- **Resize border**: prefers the WM-reported `_NET_FRAME_EXTENTS` (subscribed via `PropertyNotify`) with a 6-DIP fallback; resize edges are skipped while maximized.
- **Window commands**: minimize via `XIconifyWindow`, maximize/restore/toggle via EWMH `_NET_WM_STATE`, close via the existing `WM_DELETE_WINDOW` path. Maximized state is tracked through `PropertyNotify` and drives the caption glyph swap through the shared `maximize_state_changed` path.
- **PropertyNotify plumbing**: `PropertyChangeMask` on both event masks plus a new dispatch case to observe `_NET_WM_STATE` and `_NET_FRAME_EXTENTS`.

System mode is byte-for-byte unchanged (no title-bar metrics submitted).

## Tests

New `tests/platform/linux_window_chrome.cpp` covers:
- title-bar metric resolution (preferred height, minimum, viewport clamping, right-inset reservation)
- resize-direction edge semantics (maximized skip, caption-bounds exclusion, zero border, out-of-bounds clamping)
- maximized-state detection from `_NET_WM_STATE` atoms
- frame-extents parsing and resize-border fallback

All 6 ctest suites pass (507 test cases / 5335 assertions). Manual validation on KWin covers decoration removal, drag, edge resize, caption interaction, and the maximized glyph swap.

## Notes

- Linux metric resolution uses a 32-DIP minimum and a 46-DIP caption-button width (X11 has no native caption system metric).
- Per-WM decoration behavior varies; `_MOTIF_WM_HINTS` is honored by KWin and Mutter. Wayland (`xdg-decoration`) remains future work, unchanged by this PR.
- `docs/design/window-chrome.md` status and Linux mapping updated from "deferred" to implemented.