### PR TITLE
perf(web): cache text layouts across redraws

### DIFF
--- a/cmake/HuxerUITargets.cmake
+++ b/cmake/HuxerUITargets.cmake
@@ -213,6 +213,10 @@ function(huxerui_resolve_host_tool tool_name output_variable)
     string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" HUXERUI_HOST_SYSTEM)
     if (HUXERUI_HOST_SYSTEM STREQUAL "darwin")
         set(HUXERUI_HOST_SYSTEM "macos")
+    elseif (HUXERUI_HOST_SYSTEM STREQUAL "android")
+        # Termux local builds treat the Android host like a Linux host for
+        # the locally built hcg/hapt tools (local build compatibility only).
+        set(HUXERUI_HOST_SYSTEM "linux")
     elseif (NOT HUXERUI_HOST_SYSTEM STREQUAL "windows"
             AND NOT HUXERUI_HOST_SYSTEM STREQUAL "linux")
         message(FATAL_ERROR

--- a/platform/web/web_renderer.cpp
+++ b/platform/web/web_renderer.cpp
@@ -797,11 +797,36 @@ void WebRenderer::RenderCommand(const DrawRectCommand& command) {
   context_.call<void>("fill");
 }
 
+const TextLayout* WebRenderer::FindOrCreateTextLayout(const TextLayoutCacheKey& key) {
+  const auto existing = text_layout_cache_.find(key);
+  if (existing != text_layout_cache_.end()) {
+    return existing->second.get();
+  }
+  // Rebuilding layouts dominates draw cost: every cluster boundary is
+  // measured through the JS bridge. Cap the cache and evict wholesale when
+  // it grows beyond the working set of one screen.
+  if (text_layout_cache_.size() >= 512) {
+    text_layout_cache_.clear();
+  }
+  auto layout = std::make_shared<WebTextLayout>(
+      context_, key.text, TextStyle{key.font, Color::Rgb(0, 0, 0), TextDecoration::None}, key.max_width, key.options
+  );
+  const TextLayout* pointer = layout.get();
+  text_layout_cache_.emplace(key, std::move(layout));
+  return pointer;
+}
+
 void WebRenderer::RenderCommand(const DrawTextCommand& command) {
   if (command.rect.IsEmpty() || command.style.foreground.alpha <= 0.0F) {
     return;
   }
-  WebTextLayout layout(context_, command.text, command.style, command.rect.width, command.options);
+  const TextLayoutCacheKey key{
+      command.text,
+      command.style.font,
+      command.rect.width,
+      command.options,
+  };
+  const auto& layout = static_cast<const WebTextLayout&>(*FindOrCreateTextLayout(key));
   const float vertical_offset =
       command.options.wrap == TextWrap::NoWrap ? (command.rect.height - layout.Metrics().size.height) * 0.5F : 0.0F;
   context_.call<void>("save");

--- a/platform/web/web_renderer.h
+++ b/platform/web/web_renderer.h
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include <emscripten/val.h>
 
@@ -32,6 +34,40 @@ public:
   void Draw(const RenderFrame& frame);
 
 private:
+  // Layout results depend only on text, font, the maximum width, and the
+  // layout options. Caching them avoids rebuilding grapheme boundaries and
+  // re-measuring every cluster through the JS bridge on every frame.
+  struct TextLayoutCacheKey {
+    std::string text;
+    Font font;
+    float max_width = 0.0F;
+    TextLayoutOptions options;
+
+    bool operator==(const TextLayoutCacheKey&) const = default;
+  };
+
+  struct TextLayoutCacheKeyHash {
+    [[nodiscard]] std::size_t operator()(const TextLayoutCacheKey& key) const noexcept {
+      std::size_t seed = std::hash<std::string>{}(key.text);
+      const auto mix = [&seed](std::size_t value) {
+        seed ^= value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
+      };
+      mix(std::hash<std::string_view>{}(key.font.FamilyName()));
+      mix(std::hash<int>{}(static_cast<int>(key.font.FamilyKind())));
+      mix(std::hash<float>{}(key.font.Size()));
+      mix(std::hash<int>{}(static_cast<int>(key.font.Weight())));
+      mix(std::hash<int>{}(static_cast<int>(key.font.Slant())));
+      mix(std::hash<float>{}(key.max_width));
+      mix(std::hash<int>{}(static_cast<int>(key.options.align)));
+      mix(std::hash<int>{}(static_cast<int>(key.options.wrap)));
+      mix(std::hash<int>{}(static_cast<int>(key.options.shaping.direction)));
+      mix(std::hash<std::string>{}(key.options.shaping.locale));
+      return seed;
+    }
+  };
+
+  [[nodiscard]] const TextLayout* FindOrCreateTextLayout(const TextLayoutCacheKey& key);
+
   void RenderSceneNode(const RenderNode& node);
   void RenderSequence(const PaintSequence& sequence);
   void RenderCommand(const DrawRectCommand& command);
@@ -58,6 +94,8 @@ private:
   float display_scale_ = 1.0F;
   std::uintptr_t session_id_ = 0;
   bool force_redraw_ = true;
+  std::unordered_map<TextLayoutCacheKey, std::shared_ptr<TextLayout>, TextLayoutCacheKeyHash>
+      text_layout_cache_;
 };
 
 } // namespace huxerui::detail


### PR DESCRIPTION
Every DrawTextCommand rebuilds a WebTextLayout on each repaint: line breaking and caret-stop construction measure every grapheme cluster through the JS bridge. Scrolling or dragging the scroll bar repaints the full content region, so this cost dominated frame time. Cache layouts by text, font, maximum width, and layout options; reuse line data and font metrics without re-measuring. The cache caps at 512 entries and evicts wholesale beyond one screen's working set. Also map the Android host to the linux host-tool layout so Termux can resolve locally built hcg/hapt.