### PR TITLE
fix(linux): declare staged dependency byproducts

### DIFF
--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -153,6 +153,12 @@ function(huxerui_platform_configure)
             COMMAND ${CMAKE_COMMAND} --install "${libpng_BINARY_DIR}"
             COMMAND ${CMAKE_COMMAND} --install "${freetype_BINARY_DIR}"
             COMMAND ${CMAKE_COMMAND} --install "${harfbuzz_BINARY_DIR}"
+            BYPRODUCTS
+                    "${HUXERUI_LINUX_STAGE}/lib/libz.a"
+                    "${HUXERUI_LINUX_STAGE}/lib/libexpat.a"
+                    "${HUXERUI_LINUX_STAGE}/lib/libpng16.a"
+                    "${HUXERUI_LINUX_STAGE}/lib/libfreetype.a"
+                    "${HUXERUI_LINUX_STAGE}/lib/libharfbuzz.a"
             DEPENDS zlibstatic expat png_static freetype harfbuzz
     )
 


### PR DESCRIPTION
## Summary

- declare the zlib, expat, libpng, FreeType, and HarfBuzz staged archives as outputs of the Linux dependency installation target
- allow Ninja to schedule the staging command before linking instead of reporting a missing libharfbuzz.a with no producer rule
- keep the fix entirely within cmake/platform/Linux.cmake

## Validation

- ran huxerui run linux --profile debug in the existing consumer project; it built, linked, and launched successfully
- clean-configured and built a newly generated Linux-only application; Ninja completed 182/182 build steps
- verified the generated build.ninja records the staged archives as CUSTOM_COMMAND outputs
- ran git diff --check