### PR TITLE
fix(linux): stabilize IME, text rendering, and backend performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See [Getting Started](docs/getting-started.md) for application setup, platform b
 | Platform | Status | Native integration |
 |---|---|---|
 | Android | Supported | View, Canvas, StaticLayout, InputConnection |
-| Linux | Supported | X11, Cairo, EGL/OpenGL ES, FreeType, HarfBuzz, XIM |
+| Linux | Supported | X11, Cairo, EGL/OpenGL ES, FreeType, HarfBuzz, XIM, optional Fcitx5 DBus preedit |
 | iOS | Technical preview | UIKit, CoreGraphics, CoreText, UITextInput |
 | macOS | Supported | AppKit, CoreGraphics, CoreText, NSTextInputClient |
 | Windows | Supported | Win32, D3D11, Direct2D, DirectWrite |

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -11,6 +11,11 @@ function(huxerui_platform_configure)
     pkg_check_modules(HUXERUI_XRANDR REQUIRED IMPORTED_TARGET xrandr)
     pkg_check_modules(HUXERUI_EGL REQUIRED IMPORTED_TARGET egl)
     pkg_check_modules(HUXERUI_GLES2 REQUIRED IMPORTED_TARGET glesv2)
+    pkg_check_modules(HUXERUI_FCITX5_GCLIENT QUIET IMPORTED_TARGET Fcitx5GClient)
+
+    if(TARGET PkgConfig::HUXERUI_FCITX5_GCLIENT)
+        list(APPEND HUXERUI_PLATFORM_COMPILE_DEFINITIONS HUXERUI_HAS_FCITX5_GCLIENT=1)
+    endif()
 
     include(FetchContent)
     include(ExternalProject)
@@ -272,8 +277,14 @@ function(huxerui_platform_configure)
             ${HUXERUI_XRANDR_INCLUDE_DIRS}
             ${HUXERUI_EGL_INCLUDE_DIRS}
             ${HUXERUI_GLES2_INCLUDE_DIRS}
+            ${HUXERUI_FCITX5_GCLIENT_INCLUDE_DIRS}
             "${HUXERUI_LINUX_STAGE}/include"
             "${HUXERUI_LINUX_STAGE}/include/freetype2"
+            PARENT_SCOPE
+    )
+
+    set(HUXERUI_PLATFORM_COMPILE_DEFINITIONS
+            ${HUXERUI_PLATFORM_COMPILE_DEFINITIONS}
             PARENT_SCOPE
     )
 
@@ -287,6 +298,9 @@ function(huxerui_platform_configure)
         )
     endforeach()
     list(APPEND HUXERUI_PLATFORM_LINK_LIBRARIES m pthread dl)
+    if(TARGET PkgConfig::HUXERUI_FCITX5_GCLIENT)
+        list(APPEND HUXERUI_PLATFORM_LINK_LIBRARIES PkgConfig::HUXERUI_FCITX5_GCLIENT)
+    endif()
 
     set(HUXERUI_PLATFORM_LINK_LIBRARIES
             ${HUXERUI_PLATFORM_LINK_LIBRARIES}

--- a/docs/design/text-input.md
+++ b/docs/design/text-input.md
@@ -1,6 +1,6 @@
 # Text Input and TextField Design
 
-Status: implemented foundation with Android, iOS, macOS, and Windows platform adapters
+Status: implemented foundation with Android, iOS, Linux, macOS, and Windows platform adapters
 
 This document defines the target text editing model, input session lifecycle, platform IME boundary, and built-in `TextField` behavior for HuxerUI. The design builds on the existing controlled control model, `Runtime` focus ownership, `PlatformAdapter`, retained `NodeExtension` state, typed events, and retained-scene rendering.
 
@@ -983,6 +983,25 @@ The first Windows implementation uses IMM32:
 - Selection, deletion, and control keys continue through the key path where IMM32 does not provide a direct operation.
 
 TSF can replace or augment the adapter later without changing Runtime, TextInputClient, TextField, or SweetEditor integration.
+
+## Linux adapter
+
+The X11 host keeps XIM as the generic input-method fallback.
+When the process selects Fcitx and the optional `Fcitx5GClient` development package is available at build time, the adapter creates a Fcitx DBus input context because the default Fcitx XIM styles expose candidate placement without exposing application-rendered preedit callbacks.
+
+The Fcitx path:
+
+- Sends each key through a bounded-time asynchronous Fcitx request and returns declined or forwarded events to the shared direct-key path in event-loop order.
+- Keeps the XIM context unfocused while the non-secure Fcitx context owns focus so the two frontends cannot reset each other's composition.
+- Maps formatted preedit updates to `UpdateComposition`, converting the Fcitx UTF-8 byte cursor to the common UTF-16 offset space.
+- Maps committed strings to `CommitText` and clears local composition bookkeeping only after Runtime accepts the command.
+- Publishes bounded non-secure surrounding text in UTF-8 byte coordinates and maps adjacent Fcitx deletion requests to Unicode-code-point `DeleteSurrounding` commands.
+- Publishes the transformed caret rectangle in X11 root coordinates while leaving candidate rendering with Fcitx.
+- Integrates the GLib DBus sources into the X11 `poll()` wait set so input-method callbacks wake the event loop without periodic polling.
+- Bypasses both Fcitx and XIM for secure sessions, leaving direct key text and editing keys on the shared path and never publishing secure surrounding text.
+
+If the Fcitx client library is unavailable, the build remains supported and uses XIM.
+XIM callback composition is rendered inline when the active input method advertises `XIMPreeditCallbacks`; position and root styles retain their native candidate-window behavior.
 
 ## PlatformView focus
 

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -133,11 +133,6 @@ void ConfigureDetectableAutoRepeat(Display* display) noexcept {
   static_cast<void>(XkbSetDetectableAutoRepeat(display, 0, nullptr));
 }
 
-bool FilterInputEvent(const XEvent& event, Window window) noexcept {
-  XEvent filtered = event;
-  return XFilterEvent(&filtered, window) != 0;
-}
-
 std::string StripControlCharacters(std::string_view text) {
   std::string result;
   result.reserve(text.size());
@@ -611,11 +606,12 @@ private:
         );
       }
 
-      std::array<pollfd, 2> descriptors{{
-          {.fd = connection, .events = POLLIN, .revents = 0},
-          {.fd = ui_dispatcher_->FileDescriptor(), .events = POLLIN, .revents = 0},
-      }};
-      const int poll_result = poll(descriptors.data(), descriptors.size(), timeout_ms);
+      poll_descriptors_.clear();
+      poll_descriptors_.push_back({.fd = connection, .events = POLLIN, .revents = 0});
+      poll_descriptors_.push_back({.fd = ui_dispatcher_->FileDescriptor(), .events = POLLIN, .revents = 0});
+      timeout_ms = text_input_.PreparePoll(poll_descriptors_, timeout_ms);
+      const int poll_result = poll(poll_descriptors_.data(), poll_descriptors_.size(), timeout_ms);
+      text_input_.DispatchPoll(poll_descriptors_, poll_result >= 0);
       if (poll_result < 0) {
         if (errno == EINTR) {
           continue;
@@ -626,7 +622,12 @@ private:
         break;
       }
 
-      if ((descriptors[1].revents & (POLLIN | POLLERR | POLLHUP)) != 0) {
+      text_input_.TakeDeferredKeyEvents(deferred_key_events_);
+      for (LinuxDeferredKeyEvent& event : deferred_key_events_) {
+        DispatchDeferredKeyEvent(event);
+      }
+
+      if ((poll_descriptors_[1].revents & (POLLIN | POLLERR | POLLHUP)) != 0) {
         try {
           ui_dispatcher_->RunPending();
         } catch (...) {
@@ -662,6 +663,9 @@ private:
   }
 
   void DispatchEvent(XEvent& event) {
+    if (text_input_.FilterEvent(event)) {
+      return;
+    }
     switch (event.type) {
     case ClientMessage:
       HandleClientMessage(event.xclient);
@@ -679,34 +683,22 @@ private:
       }
       break;
     case ButtonPress:
-      if (FilterInputEvent(event, window_)) {
-        return;
-      }
       HandleButtonPress(event.xbutton);
       break;
     case ButtonRelease:
-      if (FilterInputEvent(event, window_)) {
-        return;
-      }
       HandleButtonRelease(event.xbutton);
       break;
     case MotionNotify:
-      if (FilterInputEvent(event, window_)) {
-        return;
-      }
       HandleMotionNotify(event.xmotion);
       break;
     case LeaveNotify:
-      if (FilterInputEvent(event, window_)) {
-        return;
-      }
       HandleLeaveNotify(event.xcrossing);
       break;
     case KeyPress:
-      HandleKeyPress(event.xkey);
+      HandleKeyPress(event);
       break;
     case KeyRelease:
-      HandleKeyRelease(event.xkey);
+      HandleKeyRelease(event);
       break;
     case FocusIn:
       text_input_.SetFocus(true);
@@ -1038,23 +1030,44 @@ private:
     return count;
   }
 
-  void HandleKeyPress(const XKeyEvent& event) {
-    if (text_input_.HandleXKeyEvent(event)) {
+  void HandleKeyPress(XEvent& xevent) {
+    const XimKeyEventResult input_result = text_input_.HandleXKeyEvent(xevent);
+    if (input_result == XimKeyEventResult::Consumed) {
       return;
     }
+    DispatchKeyPress(xevent.xkey, input_result);
+  }
+
+  void DispatchKeyPress(XKeyEvent& event, XimKeyEventResult input_result) {
     const KeySym keysym = XLookupKeysym(const_cast<XKeyEvent*>(&event), 0);
     const bool repeat = key_pressed_[event.keycode] != 0;
     key_pressed_[event.keycode] = 1;
-    SendKey(KeyEventType::Down, keysym, event.state, TranslateKeyText(event), repeat);
+    const std::string text =
+        input_result == XimKeyEventResult::DispatchWithoutText ? std::string{} : TranslateKeyText(event);
+    SendKey(KeyEventType::Down, keysym, event.state, text, repeat);
   }
 
-  void HandleKeyRelease(const XKeyEvent& event) {
-    if (text_input_.HandleXKeyEvent(event)) {
+  void HandleKeyRelease(XEvent& xevent) {
+    XKeyEvent& event = xevent.xkey;
+    key_pressed_[event.keycode] = 0;
+    if (text_input_.HandleXKeyEvent(xevent) == XimKeyEventResult::Consumed) {
       return;
     }
-    key_pressed_[event.keycode] = 0;
+    DispatchKeyRelease(event);
+  }
+
+  void DispatchKeyRelease(XKeyEvent& event) {
     const KeySym keysym = XLookupKeysym(const_cast<XKeyEvent*>(&event), 0);
     SendKey(KeyEventType::Up, keysym, event.state, {}, false);
+  }
+
+  void DispatchDeferredKeyEvent(LinuxDeferredKeyEvent& deferred) {
+    if (deferred.event.type == KeyPress) {
+      DispatchKeyPress(deferred.event.xkey, deferred.result);
+    } else if (deferred.event.type == KeyRelease) {
+      key_pressed_[deferred.event.xkey.keycode] = 0;
+      DispatchKeyRelease(deferred.event.xkey);
+    }
   }
 
   std::string TranslateKeyText(const XKeyEvent& event) const {
@@ -1342,6 +1355,8 @@ private:
   std::shared_ptr<LinuxUIThreadDispatcher> ui_dispatcher_;
   LinuxRenderer renderer_;
   LinuxTextInput text_input_;
+  std::vector<pollfd> poll_descriptors_;
+  std::vector<LinuxDeferredKeyEvent> deferred_key_events_;
   PlatformFrameState frame_state_;
   std::optional<double> scheduled_frame_deadline_;
   bool running_ = false;

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -5,6 +5,7 @@
 #include <X11/keysym.h>
 
 #include <poll.h>
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -275,6 +276,37 @@ public:
 
   PlatformResources* Resources() noexcept override {
     return this;
+  }
+
+  std::optional<ProcessMetrics> QueryProcessMetrics() noexcept override {
+    rusage usage{};
+    if (getrusage(RUSAGE_SELF, &usage) != 0) {
+      return std::nullopt;
+    }
+    std::uint64_t resident_pages = 0;
+    try {
+      std::ifstream statm("/proc/self/statm");
+      std::uint64_t total_pages = 0;
+      if (!(statm >> total_pages >> resident_pages)) {
+        return std::nullopt;
+      }
+      static_cast<void>(total_pages);
+    } catch (...) {
+      return std::nullopt;
+    }
+    const long page_size = sysconf(_SC_PAGESIZE);
+    const long processor_count = sysconf(_SC_NPROCESSORS_ONLN);
+    if (page_size <= 0) {
+      return std::nullopt;
+    }
+    const auto timeval_seconds = [](const timeval& value) {
+      return static_cast<double>(value.tv_sec) + static_cast<double>(value.tv_usec) / 1'000'000.0;
+    };
+    return ProcessMetrics{
+        .cpu_time_seconds = timeval_seconds(usage.ru_utime) + timeval_seconds(usage.ru_stime),
+        .memory_usage_bytes = resident_pages * static_cast<std::uint64_t>(page_size),
+        .processor_count = static_cast<std::uint32_t>(std::max(1L, processor_count)),
+    };
   }
 
   ResourceConfiguration Configuration() const override {

--- a/platform/linux/linux_internal.h
+++ b/platform/linux/linux_internal.h
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <vector>
@@ -55,6 +56,12 @@ struct LinuxFrameExtents {
 struct LinuxDamageRegion {
   bool full = false;
   std::vector<XRectangle> rects;
+};
+
+struct LinuxTextureUploadPlan {
+  bool full = false;
+  std::vector<XRectangle> rects;
+  std::uint64_t pixel_count = 0;
 };
 
 inline WindowTitleBarMetrics ResolveLinuxTitleBarMetrics(
@@ -192,6 +199,53 @@ inline LinuxDamageRegion ResolveLinuxDamage(const DamageRegion& damage, float sc
           }
       );
     }
+  }
+  return result;
+}
+
+inline LinuxTextureUploadPlan ResolveLinuxTextureUpload(
+    bool full_damage, const std::vector<XRectangle>& damage_rects, int width, int height, bool texture_initialized
+) {
+  LinuxTextureUploadPlan result;
+  if (width <= 0 || height <= 0) {
+    result.full = true;
+    return result;
+  }
+  const std::uint64_t full_pixels = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height);
+  if (full_damage || !texture_initialized || damage_rects.empty()) {
+    result.full = true;
+    result.pixel_count = full_pixels;
+    return result;
+  }
+
+  constexpr std::size_t maximum_partial_rects = 32;
+  for (const XRectangle& rect : damage_rects) {
+    const int raw_left = static_cast<int>(rect.x);
+    const int raw_top = static_cast<int>(rect.y);
+    const int left = std::clamp(raw_left, 0, width);
+    const int top = std::clamp(raw_top, 0, height);
+    const int right = std::clamp(raw_left + static_cast<int>(rect.width), 0, width);
+    const int bottom = std::clamp(raw_top + static_cast<int>(rect.height), 0, height);
+    const int rect_width = right - left;
+    const int rect_height = bottom - top;
+    if (rect_width <= 0 || rect_height <= 0) {
+      continue;
+    }
+    result.rects.push_back(
+        XRectangle{
+            static_cast<short>(left),
+            static_cast<short>(top),
+            static_cast<unsigned short>(rect_width),
+            static_cast<unsigned short>(rect_height),
+        }
+    );
+    result.pixel_count += static_cast<std::uint64_t>(rect_width) * static_cast<std::uint64_t>(rect_height);
+  }
+
+  if (result.rects.empty() || result.rects.size() > maximum_partial_rects || result.pixel_count * 2U >= full_pixels) {
+    result.full = true;
+    result.rects.clear();
+    result.pixel_count = full_pixels;
   }
   return result;
 }

--- a/platform/linux/linux_renderer.cpp
+++ b/platform/linux/linux_renderer.cpp
@@ -61,10 +61,17 @@ void CombineHash(std::size_t& seed, std::size_t value) noexcept {
 }
 
 std::size_t HashFont(const Font& font) noexcept {
-  std::size_t result = std::hash<std::string_view>{}(font.FamilyName());
+  std::size_t result = std::hash<FontFamilyKind>{}(font.FamilyKind());
+  CombineHash(result, std::hash<std::string_view>{}(font.FamilyName()));
   CombineHash(result, std::hash<float>{}(font.Size()));
   CombineHash(result, std::hash<FontWeight>{}(font.Weight()));
   CombineHash(result, std::hash<FontSlant>{}(font.Slant()));
+  return result;
+}
+
+std::size_t HashShaping(const TextShapingOptions& shaping) noexcept {
+  std::size_t result = std::hash<TextDirection>{}(shaping.direction);
+  CombineHash(result, std::hash<std::string_view>{}(shaping.locale));
   return result;
 }
 
@@ -74,12 +81,10 @@ struct FontHash {
   }
 };
 
-// Shaping output depends only on the run text plus the font; decoration, shaping
-// locale, and direction are applied after shaping, so the cache key omits them.
-// This diverges from win32, where DirectWrite embeds those values in the layout.
 struct TextRunKey {
   std::string text;
   Font font;
+  TextShapingOptions shaping;
 
   bool operator==(const TextRunKey&) const = default;
 };
@@ -87,23 +92,25 @@ struct TextRunKey {
 struct TextRunKeyView {
   std::string_view text;
   const Font& font;
+  const TextShapingOptions& shaping;
 };
 
 struct TextRunKeyHash {
   using is_transparent = void;
 
   std::size_t operator()(const TextRunKey& key) const noexcept {
-    return Hash(key.text, key.font);
+    return Hash(key.text, key.font, key.shaping);
   }
 
   std::size_t operator()(const TextRunKeyView& key) const noexcept {
-    return Hash(key.text, key.font);
+    return Hash(key.text, key.font, key.shaping);
   }
 
 private:
-  static std::size_t Hash(std::string_view text, const Font& font) noexcept {
+  static std::size_t Hash(std::string_view text, const Font& font, const TextShapingOptions& shaping) noexcept {
     std::size_t result = std::hash<std::string_view>{}(text);
     CombineHash(result, HashFont(font));
+    CombineHash(result, HashShaping(shaping));
     return result;
   }
 };
@@ -116,7 +123,7 @@ struct TextRunKeyEqual {
   }
 
   bool operator()(const TextRunKey& left, const TextRunKeyView& right) const noexcept {
-    return std::string_view(left.text) == right.text && left.font == right.font;
+    return std::string_view(left.text) == right.text && left.font == right.font && left.shaping == right.shaping;
   }
 
   bool operator()(const TextRunKeyView& left, const TextRunKey& right) const noexcept {
@@ -124,15 +131,11 @@ struct TextRunKeyEqual {
   }
 };
 
-// Line breaking depends only on the paragraph text, font, wrap width, and wrap
-// mode; alignment is applied at draw time and shaping locale/direction never
-// influence wrapping, so the cache key omits them. This diverges from win32,
-// where DirectWrite embeds those values in the layout.
 struct ParagraphKey {
   std::string text;
   Font font;
   float wrap_width = 0.0F;
-  TextWrap wrap = TextWrap::NoWrap;
+  TextLayoutOptions options;
 
   bool operator==(const ParagraphKey&) const = default;
 };
@@ -141,26 +144,29 @@ struct ParagraphKeyView {
   std::string_view text;
   const Font& font;
   float wrap_width;
-  TextWrap wrap;
+  const TextLayoutOptions& options;
 };
 
 struct ParagraphKeyHash {
   using is_transparent = void;
 
   std::size_t operator()(const ParagraphKey& key) const noexcept {
-    return Hash(key.text, key.font, key.wrap_width, key.wrap);
+    return Hash(key.text, key.font, key.wrap_width, key.options);
   }
 
   std::size_t operator()(const ParagraphKeyView& key) const noexcept {
-    return Hash(key.text, key.font, key.wrap_width, key.wrap);
+    return Hash(key.text, key.font, key.wrap_width, key.options);
   }
 
 private:
-  static std::size_t Hash(std::string_view text, const Font& font, float wrap_width, TextWrap wrap) noexcept {
+  static std::size_t
+  Hash(std::string_view text, const Font& font, float wrap_width, const TextLayoutOptions& options) noexcept {
     std::size_t result = std::hash<std::string_view>{}(text);
     CombineHash(result, HashFont(font));
     CombineHash(result, std::hash<float>{}(wrap_width));
-    CombineHash(result, std::hash<TextWrap>{}(wrap));
+    CombineHash(result, HashShaping(options.shaping));
+    CombineHash(result, std::hash<TextAlign>{}(options.align));
+    CombineHash(result, std::hash<TextWrap>{}(options.wrap));
     return result;
   }
 };
@@ -174,7 +180,7 @@ struct ParagraphKeyEqual {
 
   bool operator()(const ParagraphKey& left, const ParagraphKeyView& right) const noexcept {
     return std::string_view(left.text) == right.text && left.font == right.font &&
-           left.wrap_width == right.wrap_width && left.wrap == right.wrap;
+           left.wrap_width == right.wrap_width && left.options == right.options;
   }
 
   bool operator()(const ParagraphKeyView& left, const ParagraphKey& right) const noexcept {
@@ -194,7 +200,21 @@ struct ShapedGlyph {
 struct ShapedRun {
   std::vector<ShapedGlyph> glyphs;
   float advance = 0.0F;
+  TextDirection direction = TextDirection::LeftToRight;
 };
+
+// Repeated round glyphs expose fractional raster phases as apparent size changes. Keep their device phase stable while
+// retaining the shaped advances used for layout.
+[[nodiscard]] bool ShouldSnapRepeatedGlyphOrigins(const std::vector<ShapedGlyph>& glyphs) noexcept {
+  if (glyphs.size() < 2) {
+    return false;
+  }
+  const ShapedGlyph& first = glyphs.front();
+  return std::all_of(glyphs.begin() + 1, glyphs.end(), [&](const ShapedGlyph& glyph) {
+    return glyph.index == first.index && glyph.x_advance == first.x_advance && glyph.x_offset == first.x_offset &&
+           glyph.y_offset == first.y_offset && glyph.fallback == first.fallback;
+  });
+}
 
 struct LayoutLine {
   std::string text;
@@ -205,6 +225,7 @@ struct LayoutLine {
   float leading = 0.0F;
   float baseline = 0.0F;
   std::size_t byte_start = 0;
+  TextDirection direction = TextDirection::LeftToRight;
 };
 
 [[nodiscard]] std::uint32_t DecodeCodePoint(std::string_view text, std::size_t offset, std::size_t width) {
@@ -314,26 +335,27 @@ public:
         break;
       }
       float x = 0.0F;
-      for (const ShapedGlyph& glyph : line.glyphs) {
+      for (std::size_t glyph_index = 0; glyph_index < line.glyphs.size(); ++glyph_index) {
+        const ShapedGlyph& glyph = line.glyphs[glyph_index];
         const float glyph_end = x + glyph.x_advance;
         const float distance = ClampTo(x, glyph_end, point.x);
-        const std::size_t glyph_utf16 = Utf16At(line.byte_start + glyph.cluster);
-        if (distance < best_distance || (distance == best_distance && glyph_utf16 > 0)) {
-          const bool trailing = point.x > (x + glyph_end) * 0.5F;
-          const std::size_t resolved_utf16 =
-              trailing ? Utf16At(
-                             line.byte_start + glyph.cluster +
-                                 Utf8Width(static_cast<unsigned char>(text_[line.byte_start + glyph.cluster]))
-                         )
-                       : glyph_utf16;
+        const std::size_t glyph_start = Utf16At(line.byte_start + glyph.cluster);
+        const std::size_t glyph_finish = Utf16At(line.byte_start + GlyphLogicalEnd(line, glyph_index));
+        if (distance < best_distance || (distance == best_distance && glyph_start > 0)) {
+          const bool right_half = point.x > (x + glyph_end) * 0.5F;
+          const std::size_t resolved_utf16 = line.direction == TextDirection::RightToLeft
+                                                 ? (right_half ? glyph_start : glyph_finish)
+                                                 : (right_half ? glyph_finish : glyph_start);
           best_offset = static_cast<TextOffset>(resolved_utf16);
-          best_affinity = trailing ? TextAffinity::Upstream : TextAffinity::Downstream;
+          best_affinity = right_half ? TextAffinity::Upstream : TextAffinity::Downstream;
           best_distance = distance;
         }
         x = glyph_end;
       }
       if (point.x >= x && x - point.x <= best_distance) {
-        best_offset = static_cast<TextOffset>(Utf16At(line.byte_start + line.text.size()));
+        best_offset = line.direction == TextDirection::RightToLeft
+                          ? static_cast<TextOffset>(Utf16At(line.byte_start))
+                          : static_cast<TextOffset>(Utf16At(line.byte_start + line.text.size()));
         best_affinity = TextAffinity::Downstream;
         best_distance = x - point.x;
       }
@@ -349,14 +371,7 @@ public:
       if (clamped < static_cast<TextOffset>(line_start_utf16) || clamped > static_cast<TextOffset>(line_end_utf16)) {
         continue;
       }
-      float x = 0.0F;
-      for (const ShapedGlyph& glyph : line.glyphs) {
-        const std::size_t glyph_utf16 = Utf16At(line.byte_start + glyph.cluster);
-        if (glyph_utf16 >= static_cast<std::size_t>(clamped)) {
-          break;
-        }
-        x += glyph.x_advance;
-      }
+      const float x = XForUtf16(line, clamped - static_cast<TextOffset>(line_start_utf16));
       static_cast<void>(affinity);
       const float height = line.ascent + line.descent + line.leading;
       return {
@@ -384,8 +399,10 @@ public:
       if (visible_start >= visible_end) {
         continue;
       }
-      const float left = XForUtf16(line, visible_start - static_cast<TextOffset>(line_start_utf16));
-      const float right = XForUtf16(line, visible_end - static_cast<TextOffset>(line_start_utf16));
+      const float first = XForUtf16(line, visible_start - static_cast<TextOffset>(line_start_utf16));
+      const float last = XForUtf16(line, visible_end - static_cast<TextOffset>(line_start_utf16));
+      const float left = std::min(first, last);
+      const float right = std::max(first, last);
       const float height = line.ascent + line.descent + line.leading;
       rects.push_back({
           left,
@@ -477,14 +494,33 @@ private:
   [[nodiscard]] float XForUtf16(const LayoutLine& line, TextOffset utf16_within_line) const {
     const std::size_t line_start_utf16 = Utf16At(line.byte_start);
     float x = 0.0F;
-    for (const ShapedGlyph& glyph : line.glyphs) {
-      const std::size_t glyph_utf16 = Utf16At(line.byte_start + glyph.cluster);
-      if (static_cast<TextOffset>(glyph_utf16 - line_start_utf16) >= utf16_within_line) {
-        break;
+    for (std::size_t glyph_index = 0; glyph_index < line.glyphs.size(); ++glyph_index) {
+      const ShapedGlyph& glyph = line.glyphs[glyph_index];
+      const TextOffset glyph_start =
+          static_cast<TextOffset>(Utf16At(line.byte_start + glyph.cluster) - line_start_utf16);
+      const TextOffset glyph_end =
+          static_cast<TextOffset>(Utf16At(line.byte_start + GlyphLogicalEnd(line, glyph_index)) - line_start_utf16);
+      if (utf16_within_line >= glyph_start && utf16_within_line <= glyph_end) {
+        const float fraction = glyph_end == glyph_start ? 0.0F
+                                                        : static_cast<float>(utf16_within_line - glyph_start) /
+                                                              static_cast<float>(glyph_end - glyph_start);
+        return line.direction == TextDirection::RightToLeft ? x + glyph.x_advance * (1.0F - fraction)
+                                                            : x + glyph.x_advance * fraction;
       }
       x += glyph.x_advance;
     }
     return x;
+  }
+
+  [[nodiscard]] std::size_t GlyphLogicalEnd(const LayoutLine& line, std::size_t glyph_index) const noexcept {
+    const std::size_t cluster = line.glyphs[glyph_index].cluster;
+    std::size_t end = line.text.size();
+    for (const ShapedGlyph& candidate : line.glyphs) {
+      if (candidate.cluster > cluster) {
+        end = std::min(end, static_cast<std::size_t>(candidate.cluster));
+      }
+    }
+    return end;
   }
 
   std::string text_;
@@ -607,23 +643,21 @@ struct CairoSurfaceHandle {
 };
 
 [[nodiscard]] GLuint CompileProgram() {
-  const char* vertex_source =
-      "attribute vec2 a_pos;\n"
-      "attribute vec2 a_uv;\n"
-      "varying vec2 v_uv;\n"
-      "void main() {\n"
-      "  gl_Position = vec4(a_pos, 0.0, 1.0);\n"
-      "  v_uv = a_uv;\n"
-      "}\n";
-  const char* fragment_source =
-      "precision mediump float;\n"
-      "varying vec2 v_uv;\n"
-      "uniform sampler2D u_tex;\n"
-      "uniform bool u_bgra;\n"
-      "void main() {\n"
-      "  vec4 c = texture2D(u_tex, v_uv);\n"
-      "  gl_FragColor = u_bgra ? c.bgra : c;\n"
-      "}\n";
+  const char* vertex_source = "attribute vec2 a_pos;\n"
+                              "attribute vec2 a_uv;\n"
+                              "varying vec2 v_uv;\n"
+                              "void main() {\n"
+                              "  gl_Position = vec4(a_pos, 0.0, 1.0);\n"
+                              "  v_uv = a_uv;\n"
+                              "}\n";
+  const char* fragment_source = "precision mediump float;\n"
+                                "varying vec2 v_uv;\n"
+                                "uniform sampler2D u_tex;\n"
+                                "uniform bool u_bgra;\n"
+                                "void main() {\n"
+                                "  vec4 c = texture2D(u_tex, v_uv);\n"
+                                "  gl_FragColor = u_bgra ? c.bgra : c;\n"
+                                "}\n";
 
   const GLuint vertex = glCreateShader(GL_VERTEX_SHADER);
   glShaderSource(vertex, 1, &vertex_source, nullptr);
@@ -1094,15 +1128,8 @@ struct LinuxRenderer::State {
     return face;
   }
 
-  [[nodiscard]] ShapedRun ShapeRun(std::string_view text, const TextStyle& style) {
-    // A cache hit skips FaceFor and the char-size reset below. That is safe
-    // because the next cache miss re-establishes the shared face's 96-dpi char
-    // size, MetricsFor uses font-wide metrics independent of char size, and
-    // Cairo re-scales faces during rendering.
-    const auto cached = shaped_run_cache.find(TextRunKeyView{text, style.font});
-    if (cached != shaped_run_cache.end()) {
-      return cached->second;
-    }
+  [[nodiscard]] ShapedRun
+  ShapeRunValue(std::string_view text, const TextStyle& style, const TextShapingOptions& options) {
     FT_Face face = FaceFor(style.font);
     // Cairo's FT load face rewrites the shared face's character size while
     // rendering; reset it to the 96-dpi reference so shaping stays in DIPs.
@@ -1119,10 +1146,15 @@ struct LinuxRenderer::State {
         false,
     };
     hb_buffer_add_utf8(shaping.buffer, text.data(), static_cast<int>(text.size()), 0, static_cast<int>(text.size()));
+    const TextDirection direction =
+        options.direction == TextDirection::Auto ? ResolveDirection(text) : options.direction;
     hb_buffer_set_direction(
         shaping.buffer,
-        ResolveDirection(text) == TextDirection::RightToLeft ? HB_DIRECTION_RTL : HB_DIRECTION_LTR
+        direction == TextDirection::RightToLeft ? HB_DIRECTION_RTL : HB_DIRECTION_LTR
     );
+    if (!options.locale.empty()) {
+      hb_buffer_set_language(shaping.buffer, hb_language_from_string(options.locale.data(), options.locale.size()));
+    }
     hb_buffer_guess_segment_properties(shaping.buffer);
     hb_shape(shaping.font, shaping.buffer, nullptr, 0);
 
@@ -1131,6 +1163,7 @@ struct LinuxRenderer::State {
     const hb_glyph_position_t* glyph_position = hb_buffer_get_glyph_positions(shaping.buffer, nullptr);
 
     ShapedRun run;
+    run.direction = direction;
     run.glyphs.reserve(glyph_count);
     for (unsigned int index = 0; index < glyph_count; ++index) {
       run.glyphs.push_back({
@@ -1144,24 +1177,56 @@ struct LinuxRenderer::State {
     }
 
     if (std::any_of(run.glyphs.begin(), run.glyphs.end(), [](const ShapedGlyph& glyph) { return glyph.index == 0; })) {
-      run = ApplyFallbackShaping(text, style, std::move(run));
+      run = ApplyFallbackShaping(text, style, options, std::move(run));
     }
-    if (shaped_run_cache.size() >= kMaxShapedRuns) {
-      shaped_run_cache.erase(shaped_run_cache.begin());
-    }
-    shaped_run_cache.emplace(TextRunKey{std::string(text), style.font}, run);
     return run;
   }
 
-  [[nodiscard]] float ProbeAdvance(std::string_view text, const TextStyle& style) {
-    const auto cached = shaped_run_cache.find(TextRunKeyView{text, style.font});
+  [[nodiscard]] static std::uint64_t ShapedRunBytes(const TextRunKey& key, const ShapedRun& run) noexcept {
+    return static_cast<std::uint64_t>(sizeof(TextRunKey) + key.text.size() + key.shaping.locale.size()) +
+           static_cast<std::uint64_t>(sizeof(ShapedRun) + run.glyphs.size() * sizeof(ShapedGlyph));
+  }
+
+  [[nodiscard]] const ShapedRun&
+  ShapeRun(std::string_view text, const TextStyle& style, const TextShapingOptions& options) {
+    // A cache hit skips FaceFor and the char-size reset below. That is safe
+    // because the next cache miss re-establishes the shared face's 96-dpi char
+    // size, MetricsFor uses font-wide metrics independent of char size, and
+    // Cairo re-scales faces during rendering.
+    const auto cached = shaped_run_cache.find(TextRunKeyView{text, style.font, options});
+    if (cached != shaped_run_cache.end()) {
+      return cached->second;
+    }
+    ShapedRun run = ShapeRunValue(text, style, options);
+    TextRunKey key{std::string(text), style.font, options};
+    const std::uint64_t entry_bytes = ShapedRunBytes(key, run);
+    if (entry_bytes > kShapedRunCacheBudget) {
+      transient_shaped_run = std::move(run);
+      return transient_shaped_run;
+    }
+    while (!shaped_run_cache.empty() && (shaped_run_cache.size() >= kMaxShapedRuns ||
+                                         shaped_run_cache_bytes > kShapedRunCacheBudget - entry_bytes)) {
+      const auto victim = shaped_run_cache.begin();
+      shaped_run_cache_bytes -= ShapedRunBytes(victim->first, victim->second);
+      shaped_run_cache.erase(victim);
+    }
+    auto [inserted, was_inserted] = shaped_run_cache.emplace(std::move(key), std::move(run));
+    static_cast<void>(was_inserted);
+    shaped_run_cache_bytes += entry_bytes;
+    return inserted->second;
+  }
+
+  [[nodiscard]] float ProbeAdvance(std::string_view text, const TextStyle& style, const TextShapingOptions& options) {
+    const auto cached = shaped_run_cache.find(TextRunKeyView{text, style.font, options});
     if (cached != shaped_run_cache.end()) {
       return cached->second.advance;
     }
-    return ShapeRun(text, style).advance;
+    return ShapeRunValue(text, style, options).advance;
   }
 
-  [[nodiscard]] ShapedRun ApplyFallbackShaping(std::string_view text, const TextStyle& style, ShapedRun run) {
+  [[nodiscard]] ShapedRun ApplyFallbackShaping(
+      std::string_view text, const TextStyle& style, const TextShapingOptions& options, ShapedRun run
+  ) {
     std::size_t offset = 0;
     while (offset < run.glyphs.size()) {
       ShapedGlyph& glyph = run.glyphs[offset];
@@ -1194,6 +1259,16 @@ struct LinuxRenderer::State {
           0,
           static_cast<int>(width)
       );
+      hb_buffer_set_direction(
+          fallback_shaping.buffer,
+          run.direction == TextDirection::RightToLeft ? HB_DIRECTION_RTL : HB_DIRECTION_LTR
+      );
+      if (!options.locale.empty()) {
+        hb_buffer_set_language(
+            fallback_shaping.buffer,
+            hb_language_from_string(options.locale.data(), options.locale.size())
+        );
+      }
       hb_buffer_guess_segment_properties(fallback_shaping.buffer);
       hb_shape(fallback_shaping.font, fallback_shaping.buffer, nullptr, 0);
       const unsigned int count = hb_buffer_get_length(fallback_shaping.buffer);
@@ -1215,19 +1290,25 @@ struct LinuxRenderer::State {
     return run;
   }
 
-  void
-  ShapeLine(std::string_view text, const TextStyle& style, std::size_t byte_start, std::vector<LayoutLine>& lines) {
-    ShapedRun run = ShapeRun(text, style);
+  void ShapeLine(
+      std::string_view text,
+      const TextStyle& style,
+      const TextShapingOptions& options,
+      std::size_t byte_start,
+      std::vector<LayoutLine>& lines
+  ) {
+    const ShapedRun& run = ShapeRun(text, style, options);
     const FontMetrics metrics = MetricsFor(style.font);
     lines.push_back({
         std::string(text),
-        std::move(run.glyphs),
+        run.glyphs,
         run.advance,
         metrics.ascent,
         metrics.descent,
         metrics.leading,
         0.0F,
         byte_start,
+        run.direction,
     });
   }
 
@@ -1369,9 +1450,8 @@ struct LinuxRenderer::State {
   }
 
   [[nodiscard]] EGLDisplay GetPlatformDisplay(Display* display) const {
-    const auto get_platform_display = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
-        eglGetProcAddress("eglGetPlatformDisplay")
-    );
+    const auto get_platform_display =
+        reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplay"));
     if (get_platform_display != nullptr) {
       return get_platform_display(EGL_PLATFORM_X11_KHR, display, nullptr);
     }
@@ -1489,10 +1569,22 @@ struct LinuxRenderer::State {
       attrib_position = glGetAttribLocation(program, "a_pos");
       attrib_uv = glGetAttribLocation(program, "a_uv");
       static constexpr float kQuadVertices[] = {
-          -1.0F, -1.0F, 0.0F, 1.0F,
-           1.0F, -1.0F, 1.0F, 1.0F,
-          -1.0F,  1.0F, 0.0F, 0.0F,
-           1.0F,  1.0F, 1.0F, 0.0F,
+          -1.0F,
+          -1.0F,
+          0.0F,
+          1.0F,
+          1.0F,
+          -1.0F,
+          1.0F,
+          1.0F,
+          -1.0F,
+          1.0F,
+          0.0F,
+          0.0F,
+          1.0F,
+          1.0F,
+          1.0F,
+          0.0F,
       };
       glGenBuffers(1, &quad_vbo);
       glBindBuffer(GL_ARRAY_BUFFER, quad_vbo);
@@ -1507,7 +1599,6 @@ struct LinuxRenderer::State {
     // byte-for-byte and the shader swizzles to RGBA when it is missing.
     const char* extensions = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
     use_bgra_upload = ExtensionSupported(extensions, "GL_EXT_texture_format_BGRA8888");
-
     gl_ready = true;
     return true;
   }
@@ -1547,8 +1638,7 @@ struct LinuxRenderer::State {
       glBindTexture(GL_TEXTURE_2D, texture);
     }
     const GLenum filter =
-        egl_size_valid && static_cast<int>(egl_width) == surface_width &&
-                static_cast<int>(egl_height) == surface_height
+        egl_size_valid && static_cast<int>(egl_width) == surface_width && static_cast<int>(egl_height) == surface_height
             ? GL_NEAREST
             : GL_LINEAR;
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
@@ -1656,83 +1746,158 @@ struct LinuxRenderer::State {
   }
 };
 
-[[nodiscard]] std::vector<LayoutLine>
-WrapLines(std::string_view text, const TextStyle& style, float wrap_width, TextWrap wrap, LinuxRenderer::State& state) {
-  std::vector<LayoutLine> lines;
-  if (text.empty()) {
-    return lines;
+[[nodiscard]] std::uint64_t ParagraphBytes(const ParagraphKey& key, const std::vector<LayoutLine>& lines) noexcept {
+  std::uint64_t result =
+      static_cast<std::uint64_t>(sizeof(ParagraphKey) + key.text.size() + key.options.shaping.locale.size());
+  result += static_cast<std::uint64_t>(sizeof(LayoutLine)) * lines.size();
+  for (const LayoutLine& line : lines) {
+    result += static_cast<std::uint64_t>(line.text.size());
+    result += static_cast<std::uint64_t>(line.glyphs.size()) * sizeof(ShapedGlyph);
   }
-  const auto cached = state.paragraph_cache.find(ParagraphKeyView{text, style.font, wrap_width, wrap});
+  return result;
+}
+
+[[nodiscard]] const std::vector<LayoutLine>& WrapLines(
+    std::string_view text,
+    const TextStyle& style,
+    float wrap_width,
+    const TextLayoutOptions& options,
+    LinuxRenderer::State& state
+) {
+  std::vector<LayoutLine> lines;
+  const auto cached = state.paragraph_cache.find(ParagraphKeyView{text, style.font, wrap_width, options});
   if (cached != state.paragraph_cache.end()) {
     return cached->second;
   }
   const std::size_t length = text.size();
-  std::size_t line_start = 0;
-  std::size_t line_end = 0;
-  std::size_t last_space = std::string_view::npos;
-
-  const auto flush_line = [&]() {
-    if (line_end <= line_start) {
-      return;
-    }
-    const std::string_view span = text.substr(line_start, line_end - line_start);
-    state.ShapeLine(span, style, line_start, lines);
+  const auto flush_span = [&](std::size_t start, std::size_t end) {
+    state.ShapeLine(text.substr(start, end - start), style, options.shaping, start, lines);
   };
 
-  if (wrap == TextWrap::NoWrap) {
+  if (options.wrap == TextWrap::NoWrap) {
+    std::size_t line_start = 0;
     std::size_t offset = 0;
     while (offset < length) {
       if (text[offset] == '\n') {
-        line_end = offset;
-        flush_line();
+        flush_span(line_start, offset);
         line_start = offset + 1;
       }
-      ++offset;
+      const std::size_t width = Utf8Width(static_cast<unsigned char>(text[offset]));
+      offset += std::min(width, length - offset);
     }
-    line_end = length;
-    flush_line();
-    return lines;
-  }
+    flush_span(line_start, length);
+  } else {
+    std::size_t paragraph_start = 0;
+    while (paragraph_start <= length) {
+      const std::size_t newline = text.find('\n', paragraph_start);
+      const std::size_t paragraph_end = newline == std::string_view::npos ? length : newline;
+      std::vector<std::size_t> boundaries;
+      boundaries.push_back(paragraph_start);
+      for (std::size_t offset = paragraph_start; offset < paragraph_end;) {
+        const std::size_t scalar_width =
+            std::min(Utf8Width(static_cast<unsigned char>(text[offset])), paragraph_end - offset);
+        offset += scalar_width;
+        boundaries.push_back(offset);
+      }
 
-  std::size_t offset = 0;
-  while (offset < length) {
-    const char ch = text[offset];
-    if (ch == '\n') {
-      line_end = offset;
-      flush_line();
-      line_start = offset + 1;
-      last_space = std::string_view::npos;
-      ++offset;
-      continue;
+      if (boundaries.size() == 1) {
+        flush_span(paragraph_start, paragraph_end);
+      } else {
+        std::size_t line_start_index = 0;
+        const std::size_t final_index = boundaries.size() - 1;
+        while (line_start_index < final_index) {
+          const auto fits = [&](std::size_t candidate_index) {
+            return state.ProbeAdvance(
+                       text.substr(
+                           boundaries[line_start_index],
+                           boundaries[candidate_index] - boundaries[line_start_index]
+                       ),
+                       style,
+                       options.shaping
+                   ) <= wrap_width;
+          };
+
+          std::size_t fitting_index = line_start_index;
+          std::size_t first_overflow_index = line_start_index + 1;
+          // Exponential probes keep long wrapped paragraphs from reshaping every growing prefix; binary search
+          // then finds the exact scalar boundary within the first overflowing span.
+          std::size_t span = 1;
+          while (true) {
+            const std::size_t remaining = final_index - line_start_index;
+            const std::size_t candidate_index = line_start_index + std::min(span, remaining);
+            if (!fits(candidate_index)) {
+              first_overflow_index = candidate_index;
+              break;
+            }
+            fitting_index = candidate_index;
+            if (candidate_index == final_index) {
+              break;
+            }
+            span = span > remaining / 2 ? remaining : span * 2;
+          }
+
+          if (fitting_index == final_index) {
+            flush_span(boundaries[line_start_index], paragraph_end);
+            break;
+          }
+          if (fitting_index > line_start_index && first_overflow_index > fitting_index + 1) {
+            std::size_t low = fitting_index + 1;
+            std::size_t high = first_overflow_index - 1;
+            while (low <= high) {
+              const std::size_t middle = low + (high - low) / 2;
+              if (fits(middle)) {
+                fitting_index = middle;
+                low = middle + 1;
+              } else {
+                high = middle - 1;
+              }
+            }
+          }
+          if (fitting_index == line_start_index) {
+            fitting_index = line_start_index + 1;
+          }
+
+          std::size_t break_index = fitting_index;
+          for (std::size_t index = fitting_index; index > line_start_index; --index) {
+            const std::size_t scalar_start = boundaries[index - 1];
+            if (scalar_start > boundaries[line_start_index] &&
+                (text[scalar_start] == ' ' || text[scalar_start] == '\t')) {
+              break_index = index - 1;
+              break;
+            }
+          }
+          flush_span(boundaries[line_start_index], boundaries[break_index]);
+          line_start_index = break_index == fitting_index ? fitting_index : break_index + 1;
+        }
+      }
+
+      if (newline == std::string_view::npos) {
+        break;
+      }
+      paragraph_start = newline + 1;
     }
-    if (ch == ' ' || ch == '\t') {
-      last_space = offset;
-    }
-    const std::string_view candidate = text.substr(line_start, offset + 1 - line_start);
-    const float probe_advance = state.ProbeAdvance(candidate, style);
-    if (probe_advance <= wrap_width) {
-      ++offset;
-      continue;
-    }
-    if (last_space != std::string_view::npos && last_space > line_start) {
-      line_end = last_space;
-      flush_line();
-      line_start = last_space + 1;
-      last_space = std::string_view::npos;
-      continue;
-    }
-    line_end = offset > line_start ? offset : line_start + 1;
-    flush_line();
-    line_start = line_end;
-    last_space = std::string_view::npos;
   }
-  line_end = length;
-  flush_line();
-  if (state.paragraph_cache.size() >= state.kMaxParagraphs) {
-    state.paragraph_cache.erase(state.paragraph_cache.begin());
+  float baseline_offset = 0.0F;
+  for (LayoutLine& line : lines) {
+    line.baseline = baseline_offset + line.ascent;
+    baseline_offset += line.ascent + line.descent + line.leading;
   }
-  state.paragraph_cache.emplace(ParagraphKey{std::string(text), style.font, wrap_width, wrap}, lines);
-  return lines;
+  ParagraphKey key{std::string(text), style.font, wrap_width, options};
+  const std::uint64_t entry_bytes = ParagraphBytes(key, lines);
+  if (entry_bytes > state.kParagraphCacheBudget) {
+    state.transient_paragraph = std::move(lines);
+    return state.transient_paragraph;
+  }
+  while (!state.paragraph_cache.empty() && (state.paragraph_cache.size() >= state.kMaxParagraphs ||
+                                            state.paragraph_cache_bytes > state.kParagraphCacheBudget - entry_bytes)) {
+    const auto victim = state.paragraph_cache.begin();
+    state.paragraph_cache_bytes -= ParagraphBytes(victim->first, victim->second);
+    state.paragraph_cache.erase(victim);
+  }
+  auto [inserted, was_inserted] = state.paragraph_cache.emplace(std::move(key), std::move(lines));
+  static_cast<void>(was_inserted);
+  state.paragraph_cache_bytes += entry_bytes;
+  return inserted->second;
 }
 
 LinuxRenderer::LinuxRenderer() : state_(std::make_unique<State>()) {}
@@ -1826,14 +1991,29 @@ LinuxRenderer::MeasureRun(std::string_view text, const TextStyle& style, const T
   if (text.find_first_of("\r\n") != std::string_view::npos) {
     throw std::invalid_argument("HuxerUI text runs must not contain line breaks");
   }
-  static_cast<void>(options);
   if (text.empty()) {
     const FontMetrics empty_metrics = Metrics(style.font);
     return {0.0F, {0.0F, 0.0F, 0.0F, 0.0F}, empty_metrics};
   }
-  ShapedRun run = state_->ShapeRun(text, style);
+  const ShapedRun& run = state_->ShapeRun(text, style, options);
   const FontMetrics metrics = state_->MetricsFor(style.font);
-  const Rect visual_bounds{0.0F, -metrics.ascent, run.advance, metrics.ascent + metrics.descent};
+  Rect visual_bounds{0.0F, -metrics.ascent, run.advance, metrics.ascent + metrics.descent};
+  const auto include_decoration = [&](float center, float thickness) {
+    if (run.advance <= 0.0F || thickness <= 0.0F) {
+      return;
+    }
+    const float top = center - thickness * 0.5F;
+    const float current_top = std::min(visual_bounds.y, top);
+    const float current_bottom = std::max(visual_bounds.y + visual_bounds.height, top + thickness);
+    visual_bounds.y = current_top;
+    visual_bounds.height = current_bottom - current_top;
+  };
+  if (HasTextDecoration(style.decoration, TextDecoration::Underline)) {
+    include_decoration(metrics.underline_position, metrics.underline_thickness);
+  }
+  if (HasTextDecoration(style.decoration, TextDecoration::StrikeThrough)) {
+    include_decoration(-metrics.strike_through_position, metrics.strike_through_thickness);
+  }
   return {run.advance, visual_bounds, metrics};
 }
 
@@ -1845,7 +2025,7 @@ TextLayoutMetrics LinuxRenderer::MeasureText(
   }
   const bool constrained = std::isfinite(max_width) && max_width > 0.0F;
   const float wrap_width = constrained ? max_width : std::numeric_limits<float>::max();
-  std::vector<LayoutLine> lines = WrapLines(text, style, wrap_width, options.wrap, *state_);
+  const std::vector<LayoutLine>& lines = WrapLines(text, style, wrap_width, options, *state_);
 
   if (lines.empty()) {
     return {};
@@ -1853,8 +2033,7 @@ TextLayoutMetrics LinuxRenderer::MeasureText(
 
   float width = 0.0F;
   float total_height = 0.0F;
-  for (LayoutLine& line : lines) {
-    line.baseline = total_height + line.ascent;
+  for (const LayoutLine& line : lines) {
     total_height += line.ascent + line.descent + line.leading;
     width = std::max(width, line.advance);
   }
@@ -1876,7 +2055,7 @@ std::unique_ptr<TextLayout> LinuxRenderer::CreateTextLayout(
 ) {
   const bool constrained = std::isfinite(max_width) && max_width > 0.0F;
   const float wrap_width = constrained ? max_width : std::numeric_limits<float>::max();
-  std::vector<LayoutLine> lines = WrapLines(text, style, wrap_width, options.wrap, *state_);
+  std::vector<LayoutLine> lines = WrapLines(text, style, wrap_width, options, *state_);
 
   if (lines.empty()) {
     const FontMetrics metrics = state_->MetricsFor(style.font);
@@ -1888,16 +2067,6 @@ std::unique_ptr<TextLayout> LinuxRenderer::CreateTextLayout(
     lines.push_back(std::move(empty_line));
   }
 
-  float width = 0.0F;
-  float total_height = 0.0F;
-  for (LayoutLine& line : lines) {
-    line.baseline = total_height + line.ascent;
-    total_height += line.ascent + line.descent + line.leading;
-    width = std::max(width, line.advance);
-  }
-  if (constrained) {
-    width = std::min(width, max_width);
-  }
   return std::make_unique<LinuxTextLayout>(std::string(text), std::move(lines));
 }
 
@@ -1987,6 +2156,19 @@ namespace {
 
 void SetSourceColor(cairo_t* cr, const Color& color) {
   cairo_set_source_rgba(cr, color.red, color.green, color.blue, color.alpha);
+}
+
+void SnapTextOriginToDevicePixels(cairo_t* cr, double& x, double& y) {
+  cairo_matrix_t matrix{};
+  cairo_get_matrix(cr, &matrix);
+  constexpr double epsilon = 1.0e-6;
+  if (std::abs(matrix.xy) > epsilon || std::abs(matrix.yx) > epsilon) {
+    return;
+  }
+  cairo_user_to_device(cr, &x, &y);
+  x = std::round(x);
+  y = std::round(y);
+  cairo_device_to_user(cr, &x, &y);
 }
 
 [[nodiscard]] cairo_line_cap_t CairoLineCap(StrokeCap cap) noexcept {
@@ -2139,6 +2321,23 @@ public:
 
 private:
   void RenderSequence(const PaintSequence& sequence) {
+    if (sequence.Commands().empty()) {
+      return;
+    }
+    double clip_left = 0.0;
+    double clip_top = 0.0;
+    double clip_right = 0.0;
+    double clip_bottom = 0.0;
+    cairo_clip_extents(cr_, &clip_left, &clip_top, &clip_right, &clip_bottom);
+    const Rect clip{
+        static_cast<float>(clip_left),
+        static_cast<float>(clip_top),
+        static_cast<float>(std::max(0.0, clip_right - clip_left)),
+        static_cast<float>(std::max(0.0, clip_bottom - clip_top)),
+    };
+    if (!sequence.Bounds().Intersects(clip)) {
+      return;
+    }
     for (const PaintCommand& command : sequence.Commands()) {
       std::visit([this](const auto& value) { RenderCommand(value); }, command);
     }
@@ -2174,12 +2373,14 @@ private:
 
   void RenderCommand(const DrawTextRunsCommand& command) {
     for (const TextRun& run : command.runs) {
-      ShapedRun shaped = state_.ShapeRun(run.text, run.style);
-      cairo_font_face_t* current_face = state_.CairoFontFor(run.style.font);
-      cairo_set_font_face(cr_, current_face);
+      const ShapedRun& shaped = state_.ShapeRun(run.text, run.style, run.shaping);
+      cairo_font_face_t* primary_face = state_.CairoFontFor(run.style.font);
+      cairo_font_face_t* current_face = primary_face;
+      cairo_set_font_face(cr_, primary_face);
       cairo_set_font_size(cr_, run.style.font.Size());
       SetSourceColor(cr_, run.style.foreground);
-      std::vector<cairo_glyph_t> batch;
+      std::vector<cairo_glyph_t>& batch = state_.glyph_scratch;
+      batch.clear();
       batch.reserve(shaped.glyphs.size());
       const auto flush = [&]() {
         if (!batch.empty()) {
@@ -2188,6 +2389,10 @@ private:
         }
       };
       double x = run.baseline_origin.x;
+      double baseline_y = run.baseline_origin.y;
+      SnapTextOriginToDevicePixels(cr_, x, baseline_y);
+      const double decoration_x = x;
+      const bool snap_repeated_glyph_origins = ShouldSnapRepeatedGlyphOrigins(shaped.glyphs);
       for (const ShapedGlyph& glyph : shaped.glyphs) {
         if (glyph.fallback) {
           cairo_font_face_t* fallback =
@@ -2197,11 +2402,27 @@ private:
             cairo_set_font_face(cr_, fallback);
             current_face = fallback;
           }
+        } else if (current_face != primary_face) {
+          flush();
+          cairo_set_font_face(cr_, primary_face);
+          current_face = primary_face;
         }
-        batch.push_back({glyph.index, x + glyph.x_offset, run.baseline_origin.y + glyph.y_offset});
+        double draw_x = x + glyph.x_offset;
+        double draw_y = baseline_y + glyph.y_offset;
+        if (snap_repeated_glyph_origins) {
+          SnapTextOriginToDevicePixels(cr_, draw_x, draw_y);
+        }
+        batch.push_back({glyph.index, draw_x, draw_y});
         x += glyph.x_advance;
       }
       flush();
+      DrawDecorations(
+          static_cast<float>(decoration_x),
+          static_cast<float>(baseline_y),
+          shaped.advance,
+          run.style,
+          state_.MetricsFor(run.style.font)
+      );
     }
   }
 
@@ -2591,24 +2812,25 @@ private:
     }
     const float wrap_width =
         std::isfinite(rect.width) && rect.width > 0.0F ? rect.width : std::numeric_limits<float>::max();
-    std::vector<LayoutLine> lines = WrapLines(text, style, wrap_width, options.wrap, state_);
+    const std::vector<LayoutLine>& lines = WrapLines(text, style, wrap_width, options, state_);
     if (lines.empty()) {
       return;
     }
     float total_height = 0.0F;
-    for (LayoutLine& line : lines) {
-      line.baseline = total_height + line.ascent;
+    for (const LayoutLine& line : lines) {
       total_height += line.ascent + line.descent + line.leading;
     }
     float y = rect.y;
     if (options.wrap == TextWrap::NoWrap && total_height < rect.height) {
       y += (rect.height - total_height) * 0.5F;
     }
-    cairo_font_face_t* current_face = state_.CairoFontFor(style.font);
-    cairo_set_font_face(cr_, current_face);
+    cairo_font_face_t* primary_face = state_.CairoFontFor(style.font);
+    cairo_font_face_t* current_face = primary_face;
+    cairo_set_font_face(cr_, primary_face);
     cairo_set_font_size(cr_, style.font.Size());
     SetSourceColor(cr_, style.foreground);
-    std::vector<cairo_glyph_t> batch;
+    std::vector<cairo_glyph_t>& batch = state_.glyph_scratch;
+    batch.clear();
     const auto flush = [&]() {
       if (!batch.empty()) {
         cairo_show_glyphs(cr_, batch.data(), static_cast<int>(batch.size()));
@@ -2619,12 +2841,18 @@ private:
       float x = rect.x;
       if (options.align == TextAlign::Center) {
         x += std::max(0.0F, (rect.width - line.advance) * 0.5F);
-      } else if (options.align == TextAlign::Trailing) {
+      } else if (
+          (options.align == TextAlign::Leading && line.direction == TextDirection::RightToLeft) ||
+          (options.align == TextAlign::Trailing && line.direction != TextDirection::RightToLeft)
+      ) {
         x += std::max(0.0F, rect.width - line.advance);
       }
       batch.reserve(line.glyphs.size());
-      const double baseline_y = y + line.baseline;
-      double glyph_x = x;
+      double run_x = x;
+      double baseline_y = y + line.baseline;
+      SnapTextOriginToDevicePixels(cr_, run_x, baseline_y);
+      double glyph_x = run_x;
+      const bool snap_repeated_glyph_origins = ShouldSnapRepeatedGlyphOrigins(line.glyphs);
       for (const ShapedGlyph& glyph : line.glyphs) {
         if (glyph.fallback) {
           cairo_font_face_t* fallback =
@@ -2634,11 +2862,54 @@ private:
             cairo_set_font_face(cr_, fallback);
             current_face = fallback;
           }
+        } else if (current_face != primary_face) {
+          flush();
+          cairo_set_font_face(cr_, primary_face);
+          current_face = primary_face;
         }
-        batch.push_back({glyph.index, glyph_x + glyph.x_offset, baseline_y + glyph.y_offset});
+        double draw_x = glyph_x + glyph.x_offset;
+        double draw_y = baseline_y + glyph.y_offset;
+        if (snap_repeated_glyph_origins) {
+          SnapTextOriginToDevicePixels(cr_, draw_x, draw_y);
+        }
+        batch.push_back({glyph.index, draw_x, draw_y});
         glyph_x += glyph.x_advance;
       }
       flush();
+      DrawDecorations(
+          static_cast<float>(run_x),
+          static_cast<float>(baseline_y),
+          line.advance,
+          style,
+          state_.MetricsFor(style.font)
+      );
+    }
+  }
+
+  void DrawDecorations(float x, float baseline, float advance, const TextStyle& style, const FontMetrics& metrics) {
+    if (advance <= 0.0F || style.decoration == TextDecoration::None) {
+      return;
+    }
+    SetSourceColor(cr_, style.foreground);
+    if (HasTextDecoration(style.decoration, TextDecoration::Underline) && metrics.underline_thickness > 0.0F) {
+      cairo_rectangle(
+          cr_,
+          x,
+          baseline + metrics.underline_position - metrics.underline_thickness * 0.5F,
+          advance,
+          metrics.underline_thickness
+      );
+      cairo_fill(cr_);
+    }
+    if (HasTextDecoration(style.decoration, TextDecoration::StrikeThrough) && metrics.strike_through_thickness > 0.0F) {
+      cairo_rectangle(
+          cr_,
+          x,
+          baseline - metrics.strike_through_position - metrics.strike_through_thickness * 0.5F,
+          advance,
+          metrics.strike_through_thickness
+      );
+      cairo_fill(cr_);
     }
   }
 

--- a/platform/linux/linux_renderer.cpp
+++ b/platform/linux/linux_renderer.cpp
@@ -690,6 +690,31 @@ struct CairoSurfaceHandle {
   return false;
 }
 
+cairo_user_data_key_t free_type_face_key;
+
+void ReleaseFreeTypeFace(void* data) {
+  if (data != nullptr) {
+    FT_Done_Face(static_cast<FT_Face>(data));
+  }
+}
+
+[[nodiscard]] cairo_font_face_t* CreateCairoFace(FT_Face face) {
+  if (face == nullptr || FT_Reference_Face(face) != 0) {
+    throw std::runtime_error("HuxerUI could not retain the FreeType font face");
+  }
+  cairo_font_face_t* cairo_face = cairo_ft_font_face_create_for_ft_face(face, 0);
+  cairo_status_t status = cairo_font_face_status(cairo_face);
+  if (status == CAIRO_STATUS_SUCCESS) {
+    status = cairo_font_face_set_user_data(cairo_face, &free_type_face_key, face, ReleaseFreeTypeFace);
+  }
+  if (status != CAIRO_STATUS_SUCCESS) {
+    cairo_font_face_destroy(cairo_face);
+    FT_Done_Face(face);
+    throw std::runtime_error("HuxerUI could not create the Cairo font face");
+  }
+  return cairo_face;
+}
+
 } // namespace
 
 struct LinuxRenderer::State {
@@ -702,14 +727,22 @@ struct LinuxRenderer::State {
   std::map<std::pair<std::uint32_t, float>, cairo_font_face_t*> cairo_fallback_font_cache;
   std::unordered_map<TextRunKey, ShapedRun, TextRunKeyHash, TextRunKeyEqual> shaped_run_cache;
   std::unordered_map<ParagraphKey, std::vector<LayoutLine>, ParagraphKeyHash, ParagraphKeyEqual> paragraph_cache;
+  ShapedRun transient_shaped_run;
+  std::vector<LayoutLine> transient_paragraph;
+  std::uint64_t shaped_run_cache_bytes = 0;
+  std::uint64_t paragraph_cache_bytes = 0;
+  static constexpr std::size_t kMaxFonts = 64;
   static constexpr std::size_t kMaxShapedRuns = 1024;
   static constexpr std::size_t kMaxParagraphs = 256;
   static constexpr std::size_t kMaxFallbackFonts = 256;
+  static constexpr std::uint64_t kShapedRunCacheBudget = 8 * 1024 * 1024;
+  static constexpr std::uint64_t kParagraphCacheBudget = 8 * 1024 * 1024;
   hb_buffer_t* hb_scratch_buffer = nullptr;
   // Scratch buffer for the BoxBlurMask horizontal pass, reused across
   // sequential per-frame shadow draws. ScenePainter runs once per frame on a
   // single thread, so the buffer is never reentrant.
   std::vector<unsigned char> blur_scratch;
+  std::vector<cairo_glyph_t> glyph_scratch;
 
   cairo_surface_t* retained_surface = nullptr;
   cairo_t* retained_context = nullptr;
@@ -721,6 +754,7 @@ struct LinuxRenderer::State {
   // present so a standalone PresentGl uploads the full surface.
   std::vector<XRectangle> pending_damage_rects;
   bool pending_damage_full = true;
+  std::vector<unsigned char> upload_scratch;
 
   Display* display = nullptr;
   Window window = 0;
@@ -732,7 +766,6 @@ struct LinuxRenderer::State {
   EGLContext egl_context = EGL_NO_CONTEXT;
   bool egl_ready = false;
   bool gl_ready = false;
-  bool diag_printed_ = false;
   unsigned long native_visual_id = 0;
   bool use_bgra_upload = false;
   GLuint texture = 0;
@@ -744,7 +777,6 @@ struct LinuxRenderer::State {
   GLint uniform_bgra = -1;
   GLint attrib_position = -1;
   GLint attrib_uv = -1;
-
   struct ImageCacheEntry {
     cairo_surface_t* surface = nullptr;
     std::uint64_t bytes = 0;
@@ -753,6 +785,47 @@ struct LinuxRenderer::State {
   std::uint64_t image_cache_bytes = 0;
   static constexpr std::uint64_t kImageCacheBudget = 32 * 1024 * 1024;
 
+  struct ShadowMaskKey {
+    float width = 0.0F;
+    float height = 0.0F;
+    float corner_radius = 0.0F;
+    float blur_radius = 0.0F;
+    float scale = 1.0F;
+
+    bool operator==(const ShadowMaskKey&) const = default;
+  };
+
+  struct ShadowMaskEntry {
+    ShadowMaskKey key;
+    cairo_surface_t* surface = nullptr;
+    std::uint64_t bytes = 0;
+  };
+
+  std::vector<ShadowMaskEntry> shadow_masks;
+  std::uint64_t shadow_mask_bytes = 0;
+  static constexpr std::uint64_t kShadowMaskBudget = 32 * 1024 * 1024;
+  static constexpr std::size_t kMaxShadowMasks = 64;
+
+  struct PathShadowMaskKey {
+    Path path;
+    PathFillRule fill_rule = PathFillRule::NonZero;
+    float blur_radius = 0.0F;
+    float scale = 1.0F;
+
+    bool operator==(const PathShadowMaskKey&) const = default;
+  };
+
+  struct PathShadowMaskEntry {
+    PathShadowMaskKey key;
+    cairo_surface_t* surface = nullptr;
+    std::uint64_t bytes = 0;
+  };
+
+  std::vector<PathShadowMaskEntry> path_shadow_masks;
+  std::uint64_t path_shadow_mask_bytes = 0;
+  static constexpr std::uint64_t kPathShadowMaskBudget = 32 * 1024 * 1024;
+  static constexpr std::size_t kMaxPathShadowMasks = 32;
+
   ~State() {
     for (auto& [key, entry] : image_cache) {
       if (entry.surface != nullptr) {
@@ -760,18 +833,19 @@ struct LinuxRenderer::State {
       }
     }
     image_cache.clear();
+    ClearShadowMasks();
     for (auto& [key, face] : cairo_font_cache) {
       cairo_font_face_destroy(face);
     }
     cairo_font_cache.clear();
-    for (auto& [key, face] : fallback_font_cache) {
-      FT_Done_Face(face);
-    }
-    fallback_font_cache.clear();
     for (auto& [key, face] : cairo_fallback_font_cache) {
       cairo_font_face_destroy(face);
     }
     cairo_fallback_font_cache.clear();
+    for (auto& [key, face] : fallback_font_cache) {
+      FT_Done_Face(face);
+    }
+    fallback_font_cache.clear();
     if (retained_context != nullptr) {
       cairo_destroy(retained_context);
     }
@@ -801,6 +875,23 @@ struct LinuxRenderer::State {
     return std::max(dpi, 1.0F) / kDipsPerInch;
   }
 
+  void ClearShadowMasks() noexcept {
+    for (ShadowMaskEntry& entry : shadow_masks) {
+      if (entry.surface != nullptr) {
+        cairo_surface_destroy(entry.surface);
+      }
+    }
+    shadow_masks.clear();
+    shadow_mask_bytes = 0;
+    for (PathShadowMaskEntry& entry : path_shadow_masks) {
+      if (entry.surface != nullptr) {
+        cairo_surface_destroy(entry.surface);
+      }
+    }
+    path_shadow_masks.clear();
+    path_shadow_mask_bytes = 0;
+  }
+
   void EnsureFontconfig() {
     if (fc_ready) {
       return;
@@ -819,6 +910,32 @@ struct LinuxRenderer::State {
       throw std::runtime_error("HuxerUI could not initialize FreeType");
     }
     ft_ready = true;
+  }
+
+  void EvictFont(const Font& font) noexcept {
+    const auto cairo = cairo_font_cache.find(font);
+    if (cairo != cairo_font_cache.end()) {
+      cairo_font_face_destroy(cairo->second);
+      cairo_font_cache.erase(cairo);
+    }
+    const auto face = font_cache.find(font);
+    if (face != font_cache.end()) {
+      FT_Done_Face(face->second);
+      font_cache.erase(face);
+    }
+  }
+
+  void EvictFallbackFont(const std::pair<std::uint32_t, float>& key) noexcept {
+    const auto cairo = cairo_fallback_font_cache.find(key);
+    if (cairo != cairo_fallback_font_cache.end()) {
+      cairo_font_face_destroy(cairo->second);
+      cairo_fallback_font_cache.erase(cairo);
+    }
+    const auto face = fallback_font_cache.find(key);
+    if (face != fallback_font_cache.end()) {
+      FT_Done_Face(face->second);
+      fallback_font_cache.erase(face);
+    }
   }
 
   FT_Face FaceFor(const Font& font) {
@@ -862,7 +979,15 @@ struct LinuxRenderer::State {
       FT_Done_Face(face);
       throw std::runtime_error("HuxerUI could not set the font size");
     }
-    font_cache.emplace(font, face);
+    if (font_cache.size() >= kMaxFonts) {
+      EvictFont(font_cache.begin()->first);
+    }
+    try {
+      font_cache.emplace(font, face);
+    } catch (...) {
+      FT_Done_Face(face);
+      throw;
+    }
     return face;
   }
 
@@ -873,8 +998,13 @@ struct LinuxRenderer::State {
     }
     FT_Face face = FaceFor(font);
     static_cast<void>(FT_Select_Charmap(face, FT_ENCODING_UNICODE));
-    cairo_font_face_t* cairo_face = cairo_ft_font_face_create_for_ft_face(face, 0);
-    cairo_font_cache.emplace(font, cairo_face);
+    cairo_font_face_t* cairo_face = CreateCairoFace(face);
+    try {
+      cairo_font_cache.emplace(font, cairo_face);
+    } catch (...) {
+      cairo_font_face_destroy(cairo_face);
+      throw;
+    }
     return cairo_face;
   }
 
@@ -889,11 +1019,13 @@ struct LinuxRenderer::State {
       return nullptr;
     }
     static_cast<void>(FT_Select_Charmap(face, FT_ENCODING_UNICODE));
-    cairo_font_face_t* cairo_face = cairo_ft_font_face_create_for_ft_face(face, 0);
-    if (cairo_fallback_font_cache.size() >= kMaxFallbackFonts) {
-      cairo_fallback_font_cache.erase(cairo_fallback_font_cache.begin());
+    cairo_font_face_t* cairo_face = CreateCairoFace(face);
+    try {
+      cairo_fallback_font_cache.emplace(key, cairo_face);
+    } catch (...) {
+      cairo_font_face_destroy(cairo_face);
+      throw;
     }
-    cairo_fallback_font_cache.emplace(key, cairo_face);
     return cairo_face;
   }
 
@@ -951,9 +1083,14 @@ struct LinuxRenderer::State {
       return nullptr;
     }
     if (fallback_font_cache.size() >= kMaxFallbackFonts) {
-      fallback_font_cache.erase(fallback_font_cache.begin());
+      EvictFallbackFont(fallback_font_cache.begin()->first);
     }
-    fallback_font_cache.emplace(key, face);
+    try {
+      fallback_font_cache.emplace(key, face);
+    } catch (...) {
+      FT_Done_Face(face);
+      throw;
+    }
     return face;
   }
 
@@ -1386,32 +1523,17 @@ struct LinuxRenderer::State {
     // strokes under nearest sampling.
     EGLint egl_width = 0;
     EGLint egl_height = 0;
-    const bool egl_size_valid =
-        eglQuerySurface(egl_display, egl_surface, EGL_WIDTH, &egl_width) == EGL_TRUE &&
-        eglQuerySurface(egl_display, egl_surface, EGL_HEIGHT, &egl_height) == EGL_TRUE;
+    const bool egl_size_valid = eglQuerySurface(egl_display, egl_surface, EGL_WIDTH, &egl_width) == EGL_TRUE &&
+                                eglQuerySurface(egl_display, egl_surface, EGL_HEIGHT, &egl_height) == EGL_TRUE;
     glViewport(
         0,
         0,
         egl_size_valid ? static_cast<GLsizei>(egl_width) : surface_width,
         egl_size_valid ? static_cast<GLsizei>(egl_height) : surface_height
     );
-    if (!diag_printed_) {
-      std::fprintf(
-          stderr,
-          "[HuxerUI GL] surface=%dx%d egl=%dx%d scale=%.2f bgra=%d renderer=%s\n",
-          surface_width,
-          surface_height,
-          static_cast<int>(egl_width),
-          static_cast<int>(egl_height),
-          Scale(),
-          use_bgra_upload ? 1 : 0,
-          reinterpret_cast<const char*>(glGetString(GL_RENDERER))
-      );
-      diag_printed_ = true;
-    }
-
     const GLenum format = use_bgra_upload ? GL_BGRA_EXT : GL_RGBA;
-    if (texture_width != surface_width || texture_height != surface_height) {
+    const bool texture_initialized = texture != 0 && texture_width == surface_width && texture_height == surface_height;
+    if (!texture_initialized) {
       if (texture == 0) {
         glGenTextures(1, &texture);
       }
@@ -1436,69 +1558,68 @@ struct LinuxRenderer::State {
     const unsigned char* data = cairo_image_surface_get_data(retained_surface);
     const int stride = cairo_image_surface_get_stride(retained_surface);
     cairo_surface_flush(retained_surface);
-    // Cairo drawing is clipped to the damage rects, so only the damaged rows of
-    // the retained surface change between presents. Uploading just those rows
-    // (GLES2 has no GL_UNPACK_ROW_LENGTH, hence per-row) reproduces the texture
-    // exactly; multi-rect or large-rect damage falls back to the full upload.
-    // A freshly reallocated texture has undefined storage outside the upload, so
-    // partial uploads require the texture to already match the surface size.
-    const bool partial =
-        !pending_damage_full && pending_damage_rects.size() == 1 &&
-        pending_damage_rects[0].height > 0 &&
-        pending_damage_rects[0].height <= static_cast<unsigned short>(surface_height / 2) && surface_height > 0 &&
-        texture_width == surface_width && texture_height == surface_height;
-    if (partial) {
-      const XRectangle& rect = pending_damage_rects[0];
-      const int rect_left = std::clamp(static_cast<int>(rect.x), 0, surface_width);
-      const int rect_top = std::clamp(static_cast<int>(rect.y), 0, surface_height);
-      const int rect_width = std::clamp(static_cast<int>(rect.width), 0, surface_width - rect_left);
-      const int rect_height = std::clamp(static_cast<int>(rect.height), 0, surface_height - rect_top);
-      if (rect_width > 0 && rect_height > 0) {
-        for (int row = 0; row < rect_height; ++row) {
-          const int y = rect_top + row;
-          glTexSubImage2D(
-              GL_TEXTURE_2D,
-              0,
-              rect_left,
-              y,
-              rect_width,
-              1,
-              format,
-              GL_UNSIGNED_BYTE,
-              data + static_cast<std::size_t>(y) * static_cast<std::size_t>(stride) +
-                  static_cast<std::size_t>(rect_left) * 4U
-          );
-        }
-      }
-    } else {
+    const LinuxTextureUploadPlan upload = ResolveLinuxTextureUpload(
+        pending_damage_full,
+        pending_damage_rects,
+        surface_width,
+        surface_height,
+        texture_initialized
+    );
+    if (upload.full) {
       if (stride == surface_width * 4) {
         glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, surface_width, surface_height, format, GL_UNSIGNED_BYTE, data);
       } else {
-        // GLES2 has no GL_UNPACK_ROW_LENGTH, so a padded Cairo stride is copied
-        // one row at a time.
+        const std::size_t row_bytes = static_cast<std::size_t>(surface_width) * 4U;
+        upload_scratch.resize(row_bytes * static_cast<std::size_t>(surface_height));
         for (int row = 0; row < surface_height; ++row) {
-          glTexSubImage2D(
-              GL_TEXTURE_2D,
-              0,
-              0,
-              row,
-              surface_width,
-              1,
-              format,
-              GL_UNSIGNED_BYTE,
-              data + static_cast<std::size_t>(row) * static_cast<std::size_t>(stride)
+          std::memcpy(
+              upload_scratch.data() + static_cast<std::size_t>(row) * row_bytes,
+              data + static_cast<std::size_t>(row) * static_cast<std::size_t>(stride),
+              row_bytes
           );
         }
+        glTexSubImage2D(
+            GL_TEXTURE_2D,
+            0,
+            0,
+            0,
+            surface_width,
+            surface_height,
+            format,
+            GL_UNSIGNED_BYTE,
+            upload_scratch.data()
+        );
       }
-    }
-    pending_damage_full = true;
-    pending_damage_rects.clear();
-
-    if (!use_bgra_upload) {
-      glUniform1i(uniform_bgra, 1);
+    } else {
+      for (const XRectangle& rect : upload.rects) {
+        const int rect_width = static_cast<int>(rect.width);
+        const int rect_height = static_cast<int>(rect.height);
+        const std::size_t row_bytes = static_cast<std::size_t>(rect_width) * 4U;
+        upload_scratch.resize(row_bytes * static_cast<std::size_t>(rect_height));
+        for (int row = 0; row < rect_height; ++row) {
+          std::memcpy(
+              upload_scratch.data() + static_cast<std::size_t>(row) * row_bytes,
+              data + static_cast<std::size_t>(static_cast<int>(rect.y) + row) * static_cast<std::size_t>(stride) +
+                  static_cast<std::size_t>(rect.x) * 4U,
+              row_bytes
+          );
+        }
+        glTexSubImage2D(
+            GL_TEXTURE_2D,
+            0,
+            rect.x,
+            rect.y,
+            rect_width,
+            rect_height,
+            format,
+            GL_UNSIGNED_BYTE,
+            upload_scratch.data()
+        );
+      }
     }
 
     glUseProgram(program);
+    glUniform1i(uniform_bgra, use_bgra_upload ? 0 : 1);
     glBindBuffer(GL_ARRAY_BUFFER, quad_vbo);
     glVertexAttribPointer(attrib_position, 2, GL_FLOAT, GL_FALSE, 16, nullptr);
     glEnableVertexAttribArray(attrib_position);
@@ -1510,7 +1631,14 @@ struct LinuxRenderer::State {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    if (eglSwapBuffers(egl_display, egl_surface) != EGL_TRUE) {
+    // The retained Cairo bitmap and GL texture support partial updates, but an
+    // EGL back buffer is not preserved without an explicit buffer-age repair
+    // strategy. Swap the complete rendered quad so unchanged text never comes
+    // from an older or undefined back buffer.
+    const EGLBoolean swap_result = eglSwapBuffers(egl_display, egl_surface);
+    pending_damage_full = true;
+    pending_damage_rects.clear();
+    if (swap_result != EGL_TRUE) {
       const EGLint error = eglGetError();
       if (error == EGL_BAD_SURFACE || error == EGL_BAD_CONTEXT || error == EGL_BAD_NATIVE_WINDOW) {
         // A lost or resized native window invalidates the surface; drop it so
@@ -1629,6 +1757,7 @@ void LinuxRenderer::Discard() noexcept {
   }
   state_->image_cache.clear();
   state_->image_cache_bytes = 0;
+  state_->ClearShadowMasks();
   for (auto& [key, face] : state_->cairo_font_cache) {
     cairo_font_face_destroy(face);
   }
@@ -1641,6 +1770,16 @@ void LinuxRenderer::Discard() noexcept {
     FT_Done_Face(face);
   }
   state_->fallback_font_cache.clear();
+  for (auto& [key, face] : state_->font_cache) {
+    FT_Done_Face(face);
+  }
+  state_->font_cache.clear();
+  state_->shaped_run_cache.clear();
+  state_->paragraph_cache.clear();
+  state_->transient_shaped_run = {};
+  state_->transient_paragraph.clear();
+  state_->shaped_run_cache_bytes = 0;
+  state_->paragraph_cache_bytes = 0;
   if (state_->retained_context != nullptr) {
     cairo_destroy(state_->retained_context);
     state_->retained_context = nullptr;
@@ -1674,6 +1813,7 @@ void LinuxRenderer::DpiChanged(Display* display, Window window, float dpi) {
   state_->display = display;
   state_->window = window;
   state_->dpi = dpi;
+  state_->ClearShadowMasks();
   state_->force_full_repaint = true;
 }
 
@@ -2162,21 +2302,12 @@ private:
       return;
     }
     const float scale = state_.Scale();
-    const float blur_pixels = command.blur_radius * scale;
     const int mask_width = std::max(1, static_cast<int>(std::ceil(resolved.bounds.width * scale)));
     const int mask_height = std::max(1, static_cast<int>(std::ceil(resolved.bounds.height * scale)));
-    CairoSurfaceHandle mask_handle{cairo_image_surface_create(CAIRO_FORMAT_A8, mask_width, mask_height)};
-    cairo_surface_t* mask = mask_handle.surface;
-    cairo_t* mask_cr = cairo_create(mask);
-    cairo_scale(mask_cr, scale, scale);
-    cairo_translate(mask_cr, -resolved.bounds.x, -resolved.bounds.y);
-    cairo_set_source_rgb(mask_cr, 1.0, 1.0, 1.0);
-    AddRoundedRect(mask_cr, resolved.caster, resolved.corner_radius);
-    cairo_fill(mask_cr);
-    cairo_destroy(mask_cr);
-
-    const int radius = std::max(1, static_cast<int>(std::ceil(blur_pixels * 0.57735)));
-    cairo_surface_t* blurred = BoxBlurMask(mask, radius);
+    cairo_surface_t* blurred = BlurredRectMaskFor(resolved, command.blur_radius, scale, mask_width, mask_height);
+    if (blurred == nullptr) {
+      return;
+    }
 
     SetSourceColor(cr_, command.color);
     cairo_save(cr_);
@@ -2192,30 +2323,83 @@ private:
     cairo_mask(cr_, blur_pattern);
     cairo_pattern_destroy(blur_pattern);
     cairo_restore(cr_);
-    cairo_surface_destroy(blurred);
+  }
+
+  [[nodiscard]] cairo_surface_t*
+  BlurredRectMaskFor(const ResolvedShadow& shadow, float blur_radius, float scale, int width, int height) {
+    const LinuxRenderer::State::ShadowMaskKey key{
+        shadow.caster.width,
+        shadow.caster.height,
+        shadow.corner_radius,
+        blur_radius,
+        scale,
+    };
+    const auto cached = std::find_if(
+        state_.shadow_masks.begin(),
+        state_.shadow_masks.end(),
+        [&](const LinuxRenderer::State::ShadowMaskEntry& entry) { return entry.key == key; }
+    );
+    if (cached != state_.shadow_masks.end()) {
+      std::rotate(cached, cached + 1, state_.shadow_masks.end());
+      return state_.shadow_masks.back().surface;
+    }
+
+    CairoSurfaceHandle mask_handle{cairo_image_surface_create(CAIRO_FORMAT_A8, width, height)};
+    if (cairo_surface_status(mask_handle.surface) != CAIRO_STATUS_SUCCESS) {
+      return nullptr;
+    }
+    cairo_t* mask_cr = cairo_create(mask_handle.surface);
+    cairo_scale(mask_cr, scale, scale);
+    cairo_translate(mask_cr, blur_radius - shadow.caster.x, blur_radius - shadow.caster.y);
+    cairo_set_source_rgb(mask_cr, 1.0, 1.0, 1.0);
+    AddRoundedRect(mask_cr, shadow.caster, shadow.corner_radius);
+    cairo_fill(mask_cr);
+    cairo_destroy(mask_cr);
+
+    const int radius = std::max(1, static_cast<int>(std::ceil(blur_radius * scale * 0.57735F)));
+    cairo_surface_t* blurred = BoxBlurMask(mask_handle.surface, radius);
+    if (blurred == nullptr || cairo_surface_status(blurred) != CAIRO_STATUS_SUCCESS) {
+      if (blurred != nullptr) {
+        cairo_surface_destroy(blurred);
+      }
+      return nullptr;
+    }
+    const std::uint64_t bytes =
+        static_cast<std::uint64_t>(cairo_image_surface_get_stride(blurred)) * static_cast<std::uint64_t>(height);
+    while (!state_.shadow_masks.empty() && (state_.shadow_masks.size() >= state_.kMaxShadowMasks ||
+                                            state_.shadow_mask_bytes + bytes > state_.kShadowMaskBudget)) {
+      state_.shadow_mask_bytes -= state_.shadow_masks.front().bytes;
+      cairo_surface_destroy(state_.shadow_masks.front().surface);
+      state_.shadow_masks.erase(state_.shadow_masks.begin());
+    }
+    state_.shadow_masks.push_back({key, blurred, bytes});
+    state_.shadow_mask_bytes += bytes;
+    return blurred;
   }
 
   [[nodiscard]] cairo_surface_t* BoxBlurMask(cairo_surface_t* mask, int radius) {
     const int width = cairo_image_surface_get_width(mask);
     const int height = cairo_image_surface_get_height(mask);
     const unsigned char* source = cairo_image_surface_get_data(mask);
+    const int source_stride = cairo_image_surface_get_stride(mask);
     state_.blur_scratch.resize(static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
     const int window = radius * 2 + 1;
     for (int y = 0; y < height; ++y) {
       int sum = 0;
       for (int x = -radius; x <= radius; ++x) {
         const int clamped_x = std::clamp(x, 0, width - 1);
-        sum += source[y * width + clamped_x];
+        sum += source[y * source_stride + clamped_x];
       }
       for (int x = 0; x < width; ++x) {
         state_.blur_scratch[y * width + x] = static_cast<unsigned char>(sum / window);
         const int remove_x = std::clamp(x - radius, 0, width - 1);
         const int add_x = std::clamp(x + radius + 1, 0, width - 1);
-        sum += source[y * width + add_x] - source[y * width + remove_x];
+        sum += source[y * source_stride + add_x] - source[y * source_stride + remove_x];
       }
     }
     cairo_surface_t* result = cairo_image_surface_create(CAIRO_FORMAT_A8, width, height);
     unsigned char* result_data = cairo_image_surface_get_data(result);
+    const int result_stride = cairo_image_surface_get_stride(result);
     for (int x = 0; x < width; ++x) {
       int sum = 0;
       for (int y = -radius; y <= radius; ++y) {
@@ -2223,7 +2407,7 @@ private:
         sum += state_.blur_scratch[clamped_y * width + x];
       }
       for (int y = 0; y < height; ++y) {
-        result_data[y * width + x] = static_cast<unsigned char>(sum / window);
+        result_data[y * result_stride + x] = static_cast<unsigned char>(sum / window);
         const int remove_y = std::clamp(y - radius, 0, height - 1);
         const int add_y = std::clamp(y + radius + 1, 0, height - 1);
         sum += state_.blur_scratch[add_y * width + x] - state_.blur_scratch[remove_y * width + x];
@@ -2286,22 +2470,10 @@ private:
     }
     const int mask_width = std::max(1, static_cast<int>(std::ceil(shadow_bounds.width * scale)));
     const int mask_height = std::max(1, static_cast<int>(std::ceil(shadow_bounds.height * scale)));
-    CairoSurfaceHandle mask_handle{cairo_image_surface_create(CAIRO_FORMAT_A8, mask_width, mask_height)};
-    cairo_surface_t* mask = mask_handle.surface;
-    cairo_t* mask_cr = cairo_create(mask);
-    cairo_scale(mask_cr, scale, scale);
-    cairo_translate(mask_cr, -shadow_bounds.x, -shadow_bounds.y);
-    cairo_translate(mask_cr, command.offset.x, command.offset.y);
-    cairo_set_source_rgb(mask_cr, 1.0, 1.0, 1.0);
-    AppendPath(mask_cr, command.path);
-    cairo_set_fill_rule(
-        mask_cr,
-        command.fill_rule == PathFillRule::EvenOdd ? CAIRO_FILL_RULE_EVEN_ODD : CAIRO_FILL_RULE_WINDING
-    );
-    cairo_fill(mask_cr);
-    cairo_destroy(mask_cr);
-    cairo_surface_t* blurred =
-        BoxBlurMask(mask, std::max(1, static_cast<int>(std::ceil(command.blur_radius * scale * 0.57735))));
+    cairo_surface_t* blurred = BlurredPathMaskFor(command, bounds, scale, mask_width, mask_height);
+    if (blurred == nullptr) {
+      return;
+    }
 
     SetSourceColor(cr_, command.color);
     cairo_save(cr_);
@@ -2321,7 +2493,62 @@ private:
     cairo_mask(cr_, blur_pattern);
     cairo_pattern_destroy(blur_pattern);
     cairo_restore(cr_);
-    cairo_surface_destroy(blurred);
+  }
+
+  [[nodiscard]] cairo_surface_t*
+  BlurredPathMaskFor(const DrawPathShadowCommand& command, const Rect& bounds, float scale, int width, int height) {
+    const LinuxRenderer::State::PathShadowMaskKey key{
+        command.path,
+        command.fill_rule,
+        command.blur_radius,
+        scale,
+    };
+    const auto cached = std::find_if(
+        state_.path_shadow_masks.begin(),
+        state_.path_shadow_masks.end(),
+        [&](const LinuxRenderer::State::PathShadowMaskEntry& entry) { return entry.key == key; }
+    );
+    if (cached != state_.path_shadow_masks.end()) {
+      std::rotate(cached, cached + 1, state_.path_shadow_masks.end());
+      return state_.path_shadow_masks.back().surface;
+    }
+
+    CairoSurfaceHandle mask_handle{cairo_image_surface_create(CAIRO_FORMAT_A8, width, height)};
+    if (cairo_surface_status(mask_handle.surface) != CAIRO_STATUS_SUCCESS) {
+      return nullptr;
+    }
+    cairo_t* mask_cr = cairo_create(mask_handle.surface);
+    cairo_scale(mask_cr, scale, scale);
+    cairo_translate(mask_cr, command.blur_radius - bounds.x, command.blur_radius - bounds.y);
+    cairo_set_source_rgb(mask_cr, 1.0, 1.0, 1.0);
+    AppendPath(mask_cr, command.path);
+    cairo_set_fill_rule(
+        mask_cr,
+        command.fill_rule == PathFillRule::EvenOdd ? CAIRO_FILL_RULE_EVEN_ODD : CAIRO_FILL_RULE_WINDING
+    );
+    cairo_fill(mask_cr);
+    cairo_destroy(mask_cr);
+
+    const int radius = std::max(1, static_cast<int>(std::ceil(command.blur_radius * scale * 0.57735F)));
+    cairo_surface_t* blurred = BoxBlurMask(mask_handle.surface, radius);
+    if (blurred == nullptr || cairo_surface_status(blurred) != CAIRO_STATUS_SUCCESS) {
+      if (blurred != nullptr) {
+        cairo_surface_destroy(blurred);
+      }
+      return nullptr;
+    }
+    const std::uint64_t bytes =
+        static_cast<std::uint64_t>(cairo_image_surface_get_stride(blurred)) * static_cast<std::uint64_t>(height);
+    while (!state_.path_shadow_masks.empty() &&
+           (state_.path_shadow_masks.size() >= state_.kMaxPathShadowMasks ||
+            state_.path_shadow_mask_bytes + bytes > state_.kPathShadowMaskBudget)) {
+      state_.path_shadow_mask_bytes -= state_.path_shadow_masks.front().bytes;
+      cairo_surface_destroy(state_.path_shadow_masks.front().surface);
+      state_.path_shadow_masks.erase(state_.path_shadow_masks.begin());
+    }
+    state_.path_shadow_masks.push_back({key, blurred, bytes});
+    state_.path_shadow_mask_bytes += bytes;
+    return blurred;
   }
 
   void RenderCommand(const PushClipCommand& command) {

--- a/platform/linux/linux_text_input.cpp
+++ b/platform/linux/linux_text_input.cpp
@@ -2,16 +2,24 @@
 
 #include <X11/keysym.h>
 
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+#include <fcitx-gclient/fcitxgclient.h>
+#include <glib.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <cstdlib>
 #include <iconv.h>
 #include <langinfo.h>
 #include <limits>
 #include <memory>
+#include <new>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -29,6 +37,23 @@ namespace huxerui::detail {
 namespace {
 
 constexpr XIMStyle kXimPreeditMask = 0x000F;
+
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+constexpr std::uint64_t kFcitxCapabilityPreedit = 1ULL << 1;
+constexpr std::uint64_t kFcitxCapabilityFormattedPreedit = 1ULL << 4;
+constexpr std::uint64_t kFcitxCapabilitySurroundingText = 1ULL << 6;
+constexpr std::uint64_t kFcitxCapabilityEmail = 1ULL << 7;
+constexpr std::uint64_t kFcitxCapabilityDigit = 1ULL << 8;
+constexpr std::uint64_t kFcitxCapabilityUrl = 1ULL << 12;
+constexpr std::uint64_t kFcitxCapabilityDialable = 1ULL << 13;
+constexpr std::uint64_t kFcitxCapabilityNumber = 1ULL << 14;
+constexpr std::uint64_t kFcitxCapabilityMultiline = 1ULL << 35;
+constexpr std::uint64_t kFcitxCapabilitySensitive = 1ULL << 36;
+constexpr std::uint64_t kFcitxCapabilityKeyEventOrderFix = 1ULL << 37;
+constexpr int kFcitxKeyTimeoutMs = 250;
+constexpr std::size_t kFcitxMaxPendingKeys = 64;
+constexpr TextOffset kFcitxSurroundingLimit = 4096;
+#endif
 
 std::optional<std::uint32_t> DecodeUtf8CodePoint(std::string_view text, std::size_t& byte_offset) {
   if (byte_offset >= text.size()) {
@@ -81,6 +106,27 @@ std::optional<std::size_t> Utf8ByteOffsetOfCodePoint(std::string_view text, int 
     }
   }
   return byte_offset;
+}
+
+bool ContainsFcitx(std::string_view value) noexcept {
+  constexpr std::string_view needle = "fcitx";
+  if (value.size() < needle.size()) {
+    return false;
+  }
+  for (std::size_t offset = 0; offset <= value.size() - needle.size(); ++offset) {
+    bool matches = true;
+    for (std::size_t index = 0; index < needle.size(); ++index) {
+      const unsigned char character = static_cast<unsigned char>(value[offset + index]);
+      if (static_cast<char>(std::tolower(character)) != needle[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool AppendUtf8(std::string& output, std::uint32_t code_point) {
@@ -180,55 +226,8 @@ std::string LocaleBytesToUtf8(const char* input) {
 
 } // namespace
 
-bool IsTextProducingKey(Key key) noexcept {
-  switch (key) {
-  case Key::Unknown:
-  case Key::Tab:
-  case Key::Enter:
-  case Key::Space:
-  case Key::Escape:
-  case Key::Backspace:
-  case Key::Delete:
-  case Key::ArrowLeft:
-  case Key::ArrowRight:
-  case Key::ArrowUp:
-  case Key::ArrowDown:
-  case Key::Home:
-  case Key::End:
-  case Key::PageUp:
-  case Key::PageDown:
-  case Key::A:
-  case Key::C:
-  case Key::V:
-  case Key::X:
-  case Key::Y:
-  case Key::Z:
-  case Key::Shift:
-  case Key::Control:
-  case Key::Alt:
-  case Key::Meta:
-    return false;
-  }
-  return true;
-}
-
-bool IsEditingKeySym(KeySym keysym) noexcept {
+bool ShouldBypassXimLookup(KeySym keysym, unsigned int state) noexcept {
   switch (keysym) {
-  case XK_Tab:
-  case XK_Return:
-  case XK_KP_Enter:
-  case XK_space:
-  case XK_Escape:
-  case XK_BackSpace:
-  case XK_Delete:
-  case XK_Left:
-  case XK_Right:
-  case XK_Up:
-  case XK_Down:
-  case XK_Home:
-  case XK_End:
-  case XK_Page_Up:
-  case XK_Page_Down:
   case XK_a:
   case XK_A:
   case XK_c:
@@ -241,6 +240,9 @@ bool IsEditingKeySym(KeySym keysym) noexcept {
   case XK_Y:
   case XK_z:
   case XK_Z:
+    return (state & (ControlMask | Mod4Mask)) != 0;
+  case XK_space:
+    return (state & (ControlMask | Mod1Mask | Mod4Mask)) != 0;
   case XK_Shift_L:
   case XK_Shift_R:
   case XK_Control_L:
@@ -249,9 +251,21 @@ bool IsEditingKeySym(KeySym keysym) noexcept {
   case XK_Alt_R:
   case XK_Meta_L:
   case XK_Meta_R:
+  case XK_Super_L:
+  case XK_Super_R:
+  case XK_Hyper_L:
+  case XK_Hyper_R:
     return true;
   }
   return false;
+}
+
+bool ShouldFilterXimEvent(int event_type, bool input_context_available, bool active, bool secure) noexcept {
+  if (!input_context_available) {
+    return false;
+  }
+  const bool key_event = event_type == KeyPress || event_type == KeyRelease;
+  return !key_event || (active && !secure);
 }
 
 std::optional<int> Utf8CodePointCount(std::string_view text) noexcept {
@@ -286,9 +300,69 @@ std::optional<TextOffset> Utf8PrefixUtf16Length(std::string_view text, int code_
   return utf16_length;
 }
 
+std::optional<TextOffset> Utf8BytePrefixUtf16Length(std::string_view text, int byte_count) noexcept {
+  if (byte_count < 0 || static_cast<std::size_t>(byte_count) > text.size()) {
+    return std::nullopt;
+  }
+  TextOffset utf16_length = 0;
+  std::size_t byte_offset = 0;
+  const std::size_t requested_bytes = static_cast<std::size_t>(byte_count);
+  while (byte_offset < requested_bytes) {
+    const std::optional<std::uint32_t> code_point = DecodeUtf8CodePoint(text, byte_offset);
+    if (!code_point.has_value() || byte_offset > requested_bytes) {
+      return std::nullopt;
+    }
+    const TextOffset width = *code_point > 0xFFFFU ? 2 : 1;
+    if (utf16_length > std::numeric_limits<TextOffset>::max() - width) {
+      return std::nullopt;
+    }
+    utf16_length += width;
+  }
+  return utf16_length;
+}
+
+std::optional<std::size_t> Utf16OffsetToUtf8Byte(std::string_view text, TextOffset offset) noexcept {
+  if (offset < 0) {
+    return std::nullopt;
+  }
+  TextOffset utf16_offset = 0;
+  std::size_t byte_offset = 0;
+  while (byte_offset < text.size()) {
+    if (utf16_offset == offset) {
+      return byte_offset;
+    }
+    const std::optional<std::uint32_t> code_point = DecodeUtf8CodePoint(text, byte_offset);
+    if (!code_point.has_value()) {
+      return std::nullopt;
+    }
+    const TextOffset width = *code_point > 0xFFFFU ? 2 : 1;
+    if (utf16_offset > std::numeric_limits<TextOffset>::max() - width) {
+      return std::nullopt;
+    }
+    utf16_offset += width;
+    if (utf16_offset > offset) {
+      return std::nullopt;
+    }
+  }
+  return utf16_offset == offset ? std::optional<std::size_t>(byte_offset) : std::nullopt;
+}
+
+bool ShouldUseFcitxFrontend(const char* xmodifiers, const char* gtk_im_module, const char* qt_im_module) noexcept {
+  return (xmodifiers != nullptr && ContainsFcitx(xmodifiers)) ||
+         (gtk_im_module != nullptr && ContainsFcitx(gtk_im_module)) ||
+         (qt_im_module != nullptr && ContainsFcitx(qt_im_module));
+}
+
+bool ShouldFocusXim(bool focused, bool fcitx_available, bool active, bool secure) noexcept {
+  return focused && active && !secure && !fcitx_available;
+}
+
 std::optional<std::string>
 ApplyXimPreeditEdit(std::string_view current, int chg_first, int chg_length, std::string_view replacement) {
   if (chg_first < 0 || chg_length < 0) {
+    return std::nullopt;
+  }
+  if (chg_first > std::numeric_limits<int>::max() - chg_length) {
     return std::nullopt;
   }
   const std::optional<std::size_t> range_start = Utf8ByteOffsetOfCodePoint(current, chg_first);
@@ -309,11 +383,47 @@ ApplyXimPreeditEdit(std::string_view current, int chg_first, int chg_length, std
 }
 
 struct LinuxTextInput::State {
-  static int XimStartCallback(XIM im, XPointer client_data, XPointer call_data);
-  static void XimDrawCallback(XIM im, XPointer client_data, XPointer call_data);
-  static void XimCaretCallback(XIM im, XPointer client_data, XPointer call_data);
-  static void XimDoneCallback(XIM im, XPointer client_data, XPointer call_data);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+  struct AsyncLifetime {
+    State* state = nullptr;
+  };
+
+  struct AsyncKeyCallbackData {
+    std::weak_ptr<AsyncLifetime> lifetime;
+    std::uint64_t generation = 0;
+    XEvent event{};
+    GCancellable* cancellable = nullptr;
+  };
+#endif
+
+  State() {
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    fcitx_async_lifetime = std::make_shared<AsyncLifetime>();
+    fcitx_async_lifetime->state = this;
+#endif
+  }
+
+  ~State() {
+    Reset();
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    fcitx_async_lifetime->state = nullptr;
+#endif
+  }
+
+  static int XimStartCallback(XIC ic, XPointer client_data, XPointer call_data);
+  static void XimDrawCallback(XIC ic, XPointer client_data, XPointer call_data);
+  static void XimCaretCallback(XIC ic, XPointer client_data, XPointer call_data);
+  static void XimDoneCallback(XIC ic, XPointer client_data, XPointer call_data);
   static void XimInstantiateCallback(Display* display, XPointer client_data, XPointer call_data);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+  static void FcitxConnectedCallback(FcitxGClient* client, gpointer user_data);
+  static void FcitxForwardCallback(FcitxGClient* client, guint keyval, gint state, gint is_release, gpointer user_data);
+  static void FcitxCommitCallback(FcitxGClient* client, gchar* text, gpointer user_data);
+  static void FcitxPreeditCallback(FcitxGClient* client, GPtrArray* items, gint cursor, gpointer user_data);
+  static void FcitxDeleteSurroundingCallback(FcitxGClient* client, gint offset, guint count, gpointer user_data);
+  static void FcitxNotifyFocusOutCallback(FcitxGClient* client, gpointer user_data);
+  static void FcitxKeyCallback(GObject* source, GAsyncResult* result, gpointer user_data);
+#endif
 
   void SetRuntime(Runtime* value) noexcept {
     runtime = value;
@@ -325,6 +435,9 @@ struct LinuxTextInput::State {
     }
     CloseInputContext();
     CloseInputMethod();
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    CloseFcitx();
+#endif
     display = value_display;
     window = value_window;
     composing = false;
@@ -345,6 +458,9 @@ struct LinuxTextInput::State {
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    InitializeFcitx();
+#endif
   }
 
   void SetDpiScale(float scale) noexcept {
@@ -354,6 +470,9 @@ struct LinuxTextInput::State {
   void Reset() noexcept {
     CloseInputContext();
     CloseInputMethod();
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    CloseFcitx();
+#endif
     runtime = nullptr;
     display = nullptr;
     window = 0;
@@ -375,58 +494,72 @@ struct LinuxTextInput::State {
   }
 
   [[nodiscard]] XIC InputContext() const noexcept {
+    if (!Active() || secure) {
+      return nullptr;
+    }
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    if (FcitxAvailable()) {
+      return nullptr;
+    }
+#endif
     return xic;
+  }
+
+  [[nodiscard]] bool FilterEvent(XEvent& event) noexcept {
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    if ((event.type == KeyPress || event.type == KeyRelease) && FcitxAvailable() && Active() && !secure) {
+      return false;
+    }
+#endif
+    if (!ShouldFilterXimEvent(event.type, xic != nullptr, Active(), secure)) {
+      return false;
+    }
+    return XFilterEvent(&event, 0) != 0;
   }
 
   void SetFocus(bool value) {
     focused = value;
-    if (xic != nullptr) {
-      if (focused) {
-        XSetICFocus(xic);
-      } else {
-        XUnsetICFocus(xic);
-        composing = false;
-        composition_text.clear();
-        composition_caret_code_points = 0;
-      }
+    UpdateInputContextFocus();
+    if (!focused) {
+      composing = false;
+      composition_text.clear();
+      composition_caret_code_points = 0;
     }
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    UpdateFcitxFocus();
+#endif
   }
 
-  [[nodiscard]] bool HandleXKeyEvent(const XKeyEvent& event) {
-    if (display == nullptr || window == 0 || xic == nullptr) {
-      return false;
+  [[nodiscard]] XimKeyEventResult HandleXKeyEvent(XEvent& xevent) {
+    XKeyEvent& event = xevent.xkey;
+    if (display == nullptr || window == 0) {
+      return XimKeyEventResult::Unhandled;
     }
     const bool is_release = event.type != KeyPress;
     const KeySym keysym = XLookupKeysym(const_cast<XKeyEvent*>(&event), 0);
-    const bool editing_key = IsEditingKeySym(keysym);
-    // Editing, navigation, shortcut, and modifier keys never produce composed
-    // text; route them straight to the focused view so Backspace and friends
-    // are not swallowed or committed as mask characters by the input method.
-    if (is_release || editing_key) {
-      return false;
-    }
-    if (secure) {
-      return CommitCommittedText(event);
-    }
     try {
-      XEvent filtered{};
-      filtered.xkey = event;
-      const bool consumed = XFilterEvent(&filtered, window) != 0;
-      if (consumed) {
-        // While composing, the input method consumes the key to edit the
-        // composition. Otherwise it committed text through the callbacks, or it
-        // only adjusted internal state and the key must reach the focused view.
-        if (composing) {
-          return true;
-        }
-        return CommitCommittedText(event);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+      UpdateInputContextFocus();
+      UpdateFcitxFocus();
+      if (!secure && Active() && FcitxAvailable()) {
+        return ProcessFcitxKey(xevent) ? XimKeyEventResult::Consumed : XimKeyEventResult::Unhandled;
       }
-      if (!Active()) {
-        return false;
+#endif
+      if (secure || !Active()) {
+        return XimKeyEventResult::Unhandled;
       }
-      return CommitCommittedText(event);
+      if (xic == nullptr) {
+        return XimKeyEventResult::Unhandled;
+      }
+      if (is_release) {
+        return XimKeyEventResult::Unhandled;
+      }
+      if (ShouldBypassXimLookup(keysym, event.state)) {
+        return XimKeyEventResult::DispatchWithoutText;
+      }
+      return CommitCommittedText(event) ? XimKeyEventResult::Consumed : XimKeyEventResult::DispatchWithoutText;
     } catch (...) {
-      return false;
+      return XimKeyEventResult::Unhandled;
     }
   }
 
@@ -445,6 +578,12 @@ struct LinuxTextInput::State {
     composition_caret_code_points = 0;
     EnsureInputMethod();
     UpdateSpot(geometry);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    ConfigureFcitx();
+    UpdateInputContextFocus();
+    UpdateFcitxFocus();
+    UpdateFcitxSurroundingText();
+#endif
   }
 
   void Update(TextInputSessionId requested_session, const TextInputState& state, const TextInputGeometry& geometry) {
@@ -453,6 +592,10 @@ struct LinuxTextInput::State {
     }
     text_input_state = state;
     UpdateSpot(geometry);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    ConfigureFcitx();
+    UpdateFcitxSurroundingText();
+#endif
   }
 
   void Restart(
@@ -464,11 +607,17 @@ struct LinuxTextInput::State {
     if (requested_session != session_id) {
       return;
     }
+    ResetNativeComposition();
     configuration = config;
     secure = config.secure;
     text_input_state = state;
-    ResetNativeComposition();
     UpdateSpot(geometry);
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    ConfigureFcitx();
+    UpdateInputContextFocus();
+    UpdateFcitxFocus();
+    UpdateFcitxSurroundingText();
+#endif
   }
 
   void Stop(TextInputSessionId requested_session) {
@@ -483,6 +632,453 @@ struct LinuxTextInput::State {
     composing = false;
     composition_text.clear();
     composition_caret_code_points = 0;
+    UpdateInputContextFocus();
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    UpdateFcitxFocus();
+#endif
+  }
+
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+  [[nodiscard]] bool FcitxAvailable() const noexcept {
+    return fcitx_client != nullptr && fcitx_g_client_is_valid(fcitx_client) != FALSE;
+  }
+
+  [[nodiscard]] bool ProcessFcitxKey(const XEvent& event) noexcept {
+    if (fcitx_pending_key_count >= kFcitxMaxPendingKeys) {
+      return false;
+    }
+    GCancellable* cancellable = g_cancellable_new();
+    if (cancellable == nullptr) {
+      return false;
+    }
+    auto* callback_data =
+        new (std::nothrow) AsyncKeyCallbackData{fcitx_async_lifetime, fcitx_key_generation, event, cancellable};
+    if (callback_data == nullptr) {
+      g_object_unref(cancellable);
+      return false;
+    }
+    const XKeyEvent& key_event = event.xkey;
+    const KeySym keysym = XLookupKeysym(const_cast<XKeyEvent*>(&key_event), 0);
+    ++fcitx_pending_key_count;
+    fcitx_g_client_process_key(
+        fcitx_client,
+        static_cast<guint32>(keysym),
+        static_cast<guint32>(key_event.keycode),
+        static_cast<guint32>(key_event.state),
+        key_event.type == KeyRelease ? TRUE : FALSE,
+        static_cast<guint32>(key_event.time),
+        kFcitxKeyTimeoutMs,
+        cancellable,
+        FcitxKeyCallback,
+        callback_data
+    );
+    return true;
+  }
+
+  void CompleteFcitxKey(const XEvent& event, bool handled, std::uint64_t generation) {
+    if (fcitx_pending_key_count > 0) {
+      --fcitx_pending_key_count;
+    }
+    if (generation != fcitx_key_generation || handled) {
+      return;
+    }
+    deferred_key_events.push_back({event, XimKeyEventResult::Unhandled});
+  }
+
+  void OnFcitxForward(guint keyval, guint state, bool release) {
+    if (display == nullptr || window == 0) {
+      return;
+    }
+    const KeyCode keycode = XKeysymToKeycode(display, keyval);
+    if (keycode == 0) {
+      return;
+    }
+    XEvent event{};
+    event.type = release ? KeyRelease : KeyPress;
+    event.xkey.type = event.type;
+    event.xkey.display = display;
+    event.xkey.window = window;
+    event.xkey.root = DefaultRootWindow(display);
+    event.xkey.subwindow = 0;
+    event.xkey.time = CurrentTime;
+    event.xkey.x = 0;
+    event.xkey.y = 0;
+    event.xkey.x_root = 0;
+    event.xkey.y_root = 0;
+    event.xkey.state = state;
+    event.xkey.keycode = keycode;
+    event.xkey.same_screen = 1;
+    deferred_key_events.push_back({event, XimKeyEventResult::Unhandled});
+  }
+
+  void InitializeFcitx() {
+    if (display == nullptr || window == 0 ||
+        !ShouldUseFcitxFrontend(std::getenv("XMODIFIERS"), std::getenv("GTK_IM_MODULE"), std::getenv("QT_IM_MODULE"))) {
+      return;
+    }
+    fcitx_context = g_main_context_ref(g_main_context_default());
+    fcitx_client = fcitx_g_client_new();
+    if (fcitx_client == nullptr) {
+      g_main_context_unref(fcitx_context);
+      fcitx_context = nullptr;
+      return;
+    }
+    fcitx_g_client_set_use_batch_process_key_event(fcitx_client, FALSE);
+    fcitx_g_client_set_display(fcitx_client, "x11:");
+    if (const char* program = g_get_prgname(); program != nullptr) {
+      fcitx_g_client_set_program(fcitx_client, program);
+    }
+    g_signal_connect(fcitx_client, "connected", G_CALLBACK(FcitxConnectedCallback), this);
+    g_signal_connect(fcitx_client, "forward-key", G_CALLBACK(FcitxForwardCallback), this);
+    g_signal_connect(fcitx_client, "commit-string", G_CALLBACK(FcitxCommitCallback), this);
+    g_signal_connect(fcitx_client, "update-formatted-preedit", G_CALLBACK(FcitxPreeditCallback), this);
+    g_signal_connect(fcitx_client, "delete-surrounding-text", G_CALLBACK(FcitxDeleteSurroundingCallback), this);
+    g_signal_connect(fcitx_client, "notify-focus-out", G_CALLBACK(FcitxNotifyFocusOutCallback), this);
+  }
+
+  void CloseFcitx() noexcept {
+    ++fcitx_key_generation;
+    deferred_key_events.clear();
+    if (fcitx_poll_prepared && fcitx_context != nullptr) {
+      g_main_context_release(fcitx_context);
+    }
+    fcitx_poll_prepared = false;
+    fcitx_poll_fds.clear();
+    if (fcitx_client != nullptr) {
+      if (fcitx_focused && FcitxAvailable()) {
+        fcitx_g_client_focus_out(fcitx_client);
+      }
+      g_signal_handlers_disconnect_by_data(fcitx_client, this);
+      g_object_unref(fcitx_client);
+      fcitx_client = nullptr;
+    }
+    if (fcitx_context != nullptr) {
+      g_main_context_unref(fcitx_context);
+      fcitx_context = nullptr;
+    }
+    fcitx_focused = false;
+  }
+
+  void OnFcitxConnected() {
+    if (!FcitxAvailable()) {
+      return;
+    }
+    fcitx_capabilities = std::numeric_limits<std::uint64_t>::max();
+    fcitx_focused = false;
+    ConfigureFcitx();
+    SendFcitxUuidToX11();
+    UpdateInputContextFocus();
+    UpdateFcitxFocus();
+    UpdateFcitxCursor();
+    UpdateFcitxSurroundingText();
+  }
+
+  void ConfigureFcitx() {
+    if (!FcitxAvailable()) {
+      return;
+    }
+    std::uint64_t capabilities = kFcitxCapabilityKeyEventOrderFix;
+    if (!secure && Active()) {
+      capabilities |= kFcitxCapabilityPreedit | kFcitxCapabilityFormattedPreedit | kFcitxCapabilitySurroundingText;
+      if (configuration.multiline) {
+        capabilities |= kFcitxCapabilityMultiline;
+      }
+      switch (configuration.type) {
+      case TextInputType::Email:
+        capabilities |= kFcitxCapabilityEmail;
+        break;
+      case TextInputType::Number:
+      case TextInputType::Decimal:
+        capabilities |= kFcitxCapabilityNumber | kFcitxCapabilityDigit;
+        break;
+      case TextInputType::Phone:
+        capabilities |= kFcitxCapabilityDialable;
+        break;
+      case TextInputType::Url:
+        capabilities |= kFcitxCapabilityUrl;
+        break;
+      case TextInputType::Text:
+        break;
+      }
+    } else {
+      capabilities |= kFcitxCapabilitySensitive;
+    }
+    if (capabilities != fcitx_capabilities) {
+      fcitx_capabilities = capabilities;
+      fcitx_g_client_set_capability(fcitx_client, capabilities);
+    }
+  }
+
+  void UpdateFcitxFocus() {
+    const bool should_focus = focused && Active() && !secure && FcitxAvailable();
+    if (should_focus == fcitx_focused) {
+      return;
+    }
+    if (FcitxAvailable()) {
+      if (should_focus) {
+        fcitx_g_client_focus_in(fcitx_client);
+      } else {
+        fcitx_g_client_focus_out(fcitx_client);
+      }
+    }
+    fcitx_focused = should_focus;
+  }
+
+  void UpdateFcitxSurroundingText() {
+    if (!FcitxAvailable() || runtime == nullptr || !Active() || secure) {
+      return;
+    }
+    const TextOffset requested_cursor = std::max<TextOffset>(text_input_state.selection.active, 0);
+    const TextOffset requested_start =
+        requested_cursor > kFcitxSurroundingLimit / 2 ? requested_cursor - kFcitxSurroundingLimit / 2 : 0;
+    const TextInputContext context =
+        runtime->QueryTextInputContext(session_id, requested_start, kFcitxSurroundingLimit);
+    const std::optional<TextOffset> context_length = Utf16Length(context.text);
+    if (context.result_code != TextInputResultCode::Ok || !context_length.has_value() || context.slice_start < 0 ||
+        *context_length > std::numeric_limits<TextOffset>::max() - context.slice_start) {
+      return;
+    }
+    const TextOffset context_end = context.slice_start + *context_length;
+    const TextOffset cursor_offset = context.selection.active;
+    if (cursor_offset < context.slice_start || cursor_offset > context_end) {
+      return;
+    }
+
+    TextOffset surrounding_end =
+        std::min(context_end, cursor_offset + std::min(kFcitxSurroundingLimit / 2, context_end - cursor_offset));
+    TextOffset surrounding_start =
+        surrounding_end > kFcitxSurroundingLimit ? surrounding_end - kFcitxSurroundingLimit : 0;
+    surrounding_start = std::max(surrounding_start, context.slice_start);
+    surrounding_end = surrounding_start + std::min(kFcitxSurroundingLimit, context_end - surrounding_start);
+    const TextOffset anchor_offset = std::clamp(context.selection.anchor, surrounding_start, surrounding_end);
+
+    const std::optional<std::size_t> start_byte =
+        Utf16OffsetToUtf8Byte(context.text, surrounding_start - context.slice_start);
+    const std::optional<std::size_t> end_byte =
+        Utf16OffsetToUtf8Byte(context.text, surrounding_end - context.slice_start);
+    const std::optional<std::size_t> cursor_byte =
+        Utf16OffsetToUtf8Byte(context.text, cursor_offset - context.slice_start);
+    const std::optional<std::size_t> anchor_byte =
+        Utf16OffsetToUtf8Byte(context.text, anchor_offset - context.slice_start);
+    if (!start_byte.has_value() || !end_byte.has_value() || !cursor_byte.has_value() || !anchor_byte.has_value() ||
+        *end_byte < *start_byte || *cursor_byte < *start_byte || *anchor_byte < *start_byte) {
+      return;
+    }
+    std::string surrounding = context.text.substr(*start_byte, *end_byte - *start_byte);
+    const std::size_t cursor = *cursor_byte - *start_byte;
+    const std::size_t anchor = *anchor_byte - *start_byte;
+    if (cursor > std::numeric_limits<guint>::max() || anchor > std::numeric_limits<guint>::max()) {
+      return;
+    }
+    fcitx_g_client_set_surrounding_text(
+        fcitx_client,
+        surrounding.data(),
+        static_cast<guint>(cursor),
+        static_cast<guint>(anchor)
+    );
+  }
+
+  void UpdateFcitxCursor() {
+    const TextInputGeometry& geometry = latest_geometry;
+    if (!FcitxAvailable() || geometry.result_code != TextInputResultCode::Ok || geometry.session_id != session_id ||
+        display == nullptr || window == 0) {
+      return;
+    }
+    Window child = 0;
+    int root_x = 0;
+    int root_y = 0;
+    if (XTranslateCoordinates(display, window, DefaultRootWindow(display), 0, 0, &root_x, &root_y, &child) == 0) {
+      return;
+    }
+    const double scale = std::isfinite(dpi_scale) && dpi_scale > 0.0F ? static_cast<double>(dpi_scale) : 1.0;
+    const int x = root_x + static_cast<int>(std::lround(static_cast<double>(geometry.caret.x) * scale));
+    const int y = root_y + static_cast<int>(std::lround(static_cast<double>(geometry.caret.y) * scale));
+    const int width = std::max(1, static_cast<int>(std::lround(static_cast<double>(geometry.caret.width) * scale)));
+    const int height = std::max(1, static_cast<int>(std::lround(static_cast<double>(geometry.caret.height) * scale)));
+    fcitx_g_client_set_cursor_rect(fcitx_client, x, y, width, height);
+  }
+
+  void SendFcitxUuidToX11() {
+    if (!FcitxAvailable() || display == nullptr) {
+      return;
+    }
+    const Atom server_atom = XInternAtom(display, "_FCITX_SERVER", 0);
+    const Window server_window = XGetSelectionOwner(display, server_atom);
+    const guint8* uuid = fcitx_g_client_get_uuid(fcitx_client);
+    if (server_atom == 0 || server_window == 0 || uuid == nullptr) {
+      return;
+    }
+    XEvent event{};
+    event.xclient.type = ClientMessage;
+    event.xclient.window = server_window;
+    event.xclient.message_type = server_atom;
+    event.xclient.format = 8;
+    std::memcpy(event.xclient.data.b, uuid, 16);
+    XSendEvent(display, server_window, 0, NoEventMask, &event);
+    XFlush(display);
+  }
+
+  void OnFcitxPreedit(GPtrArray* items, int cursor_bytes) {
+    if (!Active() || secure) {
+      return;
+    }
+    std::string next;
+    if (items != nullptr) {
+      for (guint index = 0; index < items->len; ++index) {
+        const auto* item = static_cast<const FcitxGPreeditItem*>(g_ptr_array_index(items, index));
+        if (item != nullptr && item->string != nullptr) {
+          next.append(item->string);
+        }
+      }
+    }
+    if (next.empty()) {
+      const bool had_composition = composing || text_input_state.composition.has_value();
+      composing = false;
+      composition_text.clear();
+      composition_caret_code_points = 0;
+      if (had_composition) {
+        TextInputCommand cancel;
+        cancel.kind = TextInputCommandKind::CancelComposition;
+        ApplyCommands({std::move(cancel)});
+      }
+      return;
+    }
+    const std::optional<TextOffset> caret = Utf8BytePrefixUtf16Length(next, cursor_bytes);
+    if (!caret.has_value()) {
+      return;
+    }
+    if (SendCompositionUpdate(next, *caret)) {
+      composition_text = std::move(next);
+      composition_caret_code_points = Utf8CodePointCount(composition_text).value_or(0);
+    }
+  }
+
+  void OnFcitxCommit(std::string_view text) {
+    if (!Active() || secure || text.empty()) {
+      return;
+    }
+    if (CommitText(text)) {
+      composing = false;
+      composition_text.clear();
+      composition_caret_code_points = 0;
+      UpdateFcitxSurroundingText();
+    }
+  }
+
+  void OnFcitxDeleteSurrounding(int offset, unsigned int count) {
+    if (!Active() || secure || count == 0) {
+      return;
+    }
+    const std::int64_t start = static_cast<std::int64_t>(offset);
+    const std::int64_t end = start + static_cast<std::int64_t>(count);
+    if (start > 0 || end < 0) {
+      return;
+    }
+    TextInputCommand command;
+    command.kind = TextInputCommandKind::DeleteSurrounding;
+    command.delete_unit = TextInputUnit::UnicodeCodePoint;
+    command.delete_before =
+        static_cast<TextOffset>(std::clamp<std::int64_t>(-start, 0, std::numeric_limits<TextOffset>::max()));
+    command.delete_after =
+        static_cast<TextOffset>(std::clamp<std::int64_t>(end, 0, std::numeric_limits<TextOffset>::max()));
+    const TextInputApplyResult result = ApplyCommands({std::move(command)});
+    if (result.result_code == TextInputResultCode::Ok) {
+      UpdateFcitxSurroundingText();
+    }
+  }
+
+  void OnFcitxNotifyFocusOut() {
+    fcitx_focused = false;
+    const bool had_composition = composing || text_input_state.composition.has_value();
+    composing = false;
+    composition_text.clear();
+    composition_caret_code_points = 0;
+    if (had_composition) {
+      TextInputCommand cancel;
+      cancel.kind = TextInputCommandKind::CancelComposition;
+      ApplyCommands({std::move(cancel)});
+    }
+  }
+
+  int PreparePoll(std::vector<pollfd>& descriptors, int timeout_ms) {
+    if (fcitx_context == nullptr || fcitx_client == nullptr || fcitx_poll_prepared) {
+      return timeout_ms;
+    }
+    for (int iteration = 0; iteration < 16 && g_main_context_iteration(fcitx_context, FALSE) != FALSE; ++iteration) {
+    }
+    if (!g_main_context_acquire(fcitx_context)) {
+      return timeout_ms;
+    }
+    try {
+      fcitx_poll_prepared = true;
+      fcitx_poll_offset = descriptors.size();
+      fcitx_poll_ready = g_main_context_prepare(fcitx_context, &fcitx_poll_priority) != FALSE;
+      gint glib_timeout = -1;
+      gint count = g_main_context_query(fcitx_context, fcitx_poll_priority, &glib_timeout, nullptr, 0);
+      if (count < 0) {
+        count = 0;
+      }
+      while (count > 0) {
+        fcitx_poll_fds.resize(static_cast<std::size_t>(count));
+        const gint actual =
+            g_main_context_query(fcitx_context, fcitx_poll_priority, &glib_timeout, fcitx_poll_fds.data(), count);
+        if (actual <= count) {
+          count = std::max(actual, 0);
+          break;
+        }
+        count = actual;
+      }
+      fcitx_poll_fds.resize(static_cast<std::size_t>(count));
+      for (const GPollFD& descriptor : fcitx_poll_fds) {
+        descriptors.push_back({descriptor.fd, static_cast<short>(descriptor.events), 0});
+      }
+      if (fcitx_poll_ready) {
+        return 0;
+      }
+      if (glib_timeout < 0) {
+        return timeout_ms;
+      }
+      return timeout_ms < 0 ? glib_timeout : std::min(timeout_ms, glib_timeout);
+    } catch (...) {
+      g_main_context_release(fcitx_context);
+      fcitx_poll_prepared = false;
+      fcitx_poll_fds.clear();
+      throw;
+    }
+  }
+
+  void DispatchPoll(const std::vector<pollfd>& descriptors, bool poll_succeeded) noexcept {
+    if (!fcitx_poll_prepared || fcitx_context == nullptr) {
+      return;
+    }
+    if (poll_succeeded && descriptors.size() >= fcitx_poll_offset + fcitx_poll_fds.size()) {
+      for (std::size_t index = 0; index < fcitx_poll_fds.size(); ++index) {
+        fcitx_poll_fds[index].revents = static_cast<gushort>(descriptors[fcitx_poll_offset + index].revents);
+      }
+      if (fcitx_poll_ready || g_main_context_check(
+                                  fcitx_context,
+                                  fcitx_poll_priority,
+                                  fcitx_poll_fds.empty() ? nullptr : fcitx_poll_fds.data(),
+                                  static_cast<gint>(fcitx_poll_fds.size())
+                              )) {
+        g_main_context_dispatch(fcitx_context);
+      }
+    }
+    g_main_context_release(fcitx_context);
+    fcitx_poll_prepared = false;
+    fcitx_poll_fds.clear();
+  }
+#else
+  int PreparePoll(std::vector<pollfd>&, int timeout_ms) {
+    return timeout_ms;
+  }
+
+  void DispatchPoll(const std::vector<pollfd>&, bool) noexcept {}
+#endif
+
+  void TakeDeferredKeyEvents(std::vector<LinuxDeferredKeyEvent>& events) {
+    events.clear();
+    events.swap(deferred_key_events);
   }
 
   bool EnsureInputMethod() {
@@ -576,9 +1172,7 @@ struct LinuxTextInput::State {
     if (xic == nullptr) {
       return false;
     }
-    if (focused) {
-      XSetICFocus(xic);
-    }
+    UpdateInputContextFocus();
     return true;
   }
 
@@ -588,9 +1182,27 @@ struct LinuxTextInput::State {
     }
     CloseInputContext();
     CloseInputMethod();
-    if (EnsureInputMethod() && focused && xic != nullptr) {
-      XSetICFocus(xic);
+    static_cast<void>(EnsureInputMethod());
+  }
+
+  void UpdateInputContextFocus() noexcept {
+    if (xic == nullptr) {
+      xic_focused = false;
+      return;
     }
+    bool should_focus = focused && Active() && !secure;
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    should_focus = ShouldFocusXim(focused, FcitxAvailable(), Active(), secure);
+#endif
+    if (should_focus == xic_focused) {
+      return;
+    }
+    if (should_focus) {
+      XSetICFocus(xic);
+    } else {
+      XUnsetICFocus(xic);
+    }
+    xic_focused = should_focus;
   }
 
   void CloseInputContext() noexcept {
@@ -598,6 +1210,7 @@ struct LinuxTextInput::State {
       XDestroyIC(xic);
       xic = nullptr;
     }
+    xic_focused = false;
     pending_spot_valid = false;
   }
 
@@ -625,7 +1238,9 @@ struct LinuxTextInput::State {
     composing = true;
     composition_text.clear();
     composition_caret_code_points = 0;
-    return 1;
+    // XIM interprets a positive return as a byte limit, while -1 allows the
+    // input method to maintain an unrestricted preedit string.
+    return -1;
   }
 
   void OnPreeditDraw(const XIMPreeditDrawCallbackStruct* call_data) {
@@ -635,8 +1250,7 @@ struct LinuxTextInput::State {
     const int chg_first = std::max(call_data->chg_first, 0);
     const int chg_length = std::max(call_data->chg_length, 0);
     const std::string replacement = XimTextToUtf8(call_data->text);
-    std::optional<std::string> updated =
-        ApplyXimPreeditEdit(composition_text, chg_first, chg_length, replacement);
+    std::optional<std::string> updated = ApplyXimPreeditEdit(composition_text, chg_first, chg_length, replacement);
     if (!updated.has_value()) {
       return;
     }
@@ -749,6 +1363,21 @@ struct LinuxTextInput::State {
     if (xic == nullptr) {
       return false;
     }
+    const auto commit_lookup_text = [this](const char* data, int length) {
+      if (data == nullptr || length <= 0) {
+        return false;
+      }
+      std::string text(data, static_cast<std::size_t>(length));
+      std::erase_if(text, [](char character) {
+        const unsigned char byte = static_cast<unsigned char>(character);
+        return byte < 0x20 || byte == 0x7F;
+      });
+      if (text.empty()) {
+        return false;
+      }
+      return CommitText(text);
+    };
+
     char buffer[kXimCommitBufferBytes];
     KeySym keysym = NoSymbol;
     int status = XLookupNone;
@@ -758,16 +1387,10 @@ struct LinuxTextInput::State {
       const std::size_t needed = static_cast<std::size_t>(std::abs(length)) + 1;
       if (needed > sizeof(buffer)) {
         std::vector<char> grown(needed);
-        length = Xutf8LookupString(
-            xic,
-            const_cast<XKeyPressedEvent*>(&event),
-            grown.data(),
-            grown.size(),
-            &keysym,
-            &status
-        );
+        length =
+            Xutf8LookupString(xic, const_cast<XKeyPressedEvent*>(&event), grown.data(), grown.size(), &keysym, &status);
         if ((status == XLookupChars || status == XLookupBoth) && length > 0) {
-          return CommitText(std::string_view(grown.data(), static_cast<std::size_t>(length)));
+          return commit_lookup_text(grown.data(), length);
         }
         return false;
       }
@@ -775,19 +1398,25 @@ struct LinuxTextInput::State {
     if ((status != XLookupChars && status != XLookupBoth) || length <= 0) {
       return false;
     }
-    return CommitText(std::string_view(buffer, static_cast<std::size_t>(length)));
+    return commit_lookup_text(buffer, length);
   }
 
   void UpdateSpot(const TextInputGeometry& geometry) {
+    latest_geometry = geometry;
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    UpdateFcitxCursor();
+#endif
     if (geometry.result_code != TextInputResultCode::Ok || geometry.session_id != session_id || xic == nullptr) {
       return;
     }
-    if (!std::isfinite(geometry.caret.x) || !std::isfinite(geometry.caret.y)) {
+    if (!std::isfinite(geometry.caret.x) || !std::isfinite(geometry.caret.y) || !std::isfinite(geometry.caret.height)) {
       return;
     }
     const double scale = std::isfinite(dpi_scale) && dpi_scale > 0.0F ? static_cast<double>(dpi_scale) : 1.0;
     const long x = std::lround(static_cast<double>(geometry.caret.x) * scale);
-    const long y = std::lround(static_cast<double>(geometry.caret.y) * scale);
+    // TextInputGeometry describes the caret rectangle from its top edge; XIM
+    // expects a baseline-like spot, so use the bottom edge available here.
+    const long y = std::lround(static_cast<double>(geometry.caret.y + std::max(geometry.caret.height, 0.0F)) * scale);
     pending_spot = XPoint{ClampToShort(x), ClampToShort(y)};
     pending_spot_valid = true;
     ApplyPendingSpot();
@@ -797,11 +1426,21 @@ struct LinuxTextInput::State {
     if (!pending_spot_valid || xic == nullptr || in_callback) {
       return;
     }
-    XSetICValues(xic, XNSpotLocation, &pending_spot, nullptr);
-    pending_spot_valid = false;
+    XVaNestedList preedit_attributes = XVaCreateNestedList(0, XNSpotLocation, &pending_spot, nullptr);
+    if (preedit_attributes == nullptr) {
+      return;
+    }
+    const char* failed_attribute = XSetICValues(xic, XNPreeditAttributes, preedit_attributes, nullptr);
+    XFree(preedit_attributes);
+    pending_spot_valid = failed_attribute != nullptr;
   }
 
   void ResetNativeComposition() {
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+    if (FcitxAvailable() && Active() && !secure) {
+      fcitx_g_client_reset(fcitx_client);
+    }
+#endif
     if (xic == nullptr || !composing) {
       return;
     }
@@ -844,19 +1483,37 @@ struct LinuxTextInput::State {
 
   XIM xim = nullptr;
   XIC xic = nullptr;
+  bool xic_focused = false;
 
   TextInputSessionId session_id = 0;
   TextInputConfiguration configuration;
   TextInputState text_input_state;
+  TextInputGeometry latest_geometry;
 
   std::string composition_text;
   int composition_caret_code_points = 0;
 
   XPoint pending_spot{0, 0};
   bool pending_spot_valid = false;
+  std::vector<LinuxDeferredKeyEvent> deferred_key_events;
+
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+  std::shared_ptr<AsyncLifetime> fcitx_async_lifetime;
+  FcitxGClient* fcitx_client = nullptr;
+  GMainContext* fcitx_context = nullptr;
+  std::uint64_t fcitx_capabilities = std::numeric_limits<std::uint64_t>::max();
+  std::uint64_t fcitx_key_generation = 1;
+  std::size_t fcitx_pending_key_count = 0;
+  bool fcitx_focused = false;
+  bool fcitx_poll_prepared = false;
+  bool fcitx_poll_ready = false;
+  gint fcitx_poll_priority = G_PRIORITY_DEFAULT;
+  std::size_t fcitx_poll_offset = 0;
+  std::vector<GPollFD> fcitx_poll_fds;
+#endif
 };
 
-int LinuxTextInput::State::XimStartCallback(XIM, XPointer client_data, XPointer) {
+int LinuxTextInput::State::XimStartCallback(XIC, XPointer client_data, XPointer) {
   State* state = reinterpret_cast<State*>(client_data);
   if (state == nullptr) {
     return 0;
@@ -868,7 +1525,7 @@ int LinuxTextInput::State::XimStartCallback(XIM, XPointer client_data, XPointer)
   }
 }
 
-void LinuxTextInput::State::XimDrawCallback(XIM, XPointer client_data, XPointer call_data) {
+void LinuxTextInput::State::XimDrawCallback(XIC, XPointer client_data, XPointer call_data) {
   State* state = reinterpret_cast<State*>(client_data);
   if (state == nullptr) {
     return;
@@ -882,7 +1539,7 @@ void LinuxTextInput::State::XimDrawCallback(XIM, XPointer client_data, XPointer 
   state->ApplyPendingSpot();
 }
 
-void LinuxTextInput::State::XimCaretCallback(XIM, XPointer client_data, XPointer call_data) {
+void LinuxTextInput::State::XimCaretCallback(XIC, XPointer client_data, XPointer call_data) {
   State* state = reinterpret_cast<State*>(client_data);
   if (state == nullptr) {
     return;
@@ -896,7 +1553,7 @@ void LinuxTextInput::State::XimCaretCallback(XIM, XPointer client_data, XPointer
   state->ApplyPendingSpot();
 }
 
-void LinuxTextInput::State::XimDoneCallback(XIM, XPointer client_data, XPointer) {
+void LinuxTextInput::State::XimDoneCallback(XIC, XPointer client_data, XPointer) {
   State* state = reinterpret_cast<State*>(client_data);
   if (state == nullptr) {
     return;
@@ -921,12 +1578,94 @@ void LinuxTextInput::State::XimInstantiateCallback(Display*, XPointer client_dat
   }
 }
 
+#if defined(HUXERUI_HAS_FCITX5_GCLIENT)
+void LinuxTextInput::State::FcitxConnectedCallback(FcitxGClient*, gpointer user_data) {
+  State* state = static_cast<State*>(user_data);
+  if (state == nullptr) {
+    return;
+  }
+  try {
+    state->OnFcitxConnected();
+  } catch (...) {
+  }
+}
+
+void LinuxTextInput::State::FcitxForwardCallback(
+    FcitxGClient*, guint keyval, gint modifiers, gint is_release, gpointer user_data
+) {
+  State* owner = static_cast<State*>(user_data);
+  if (owner != nullptr) {
+    try {
+      owner->OnFcitxForward(keyval, static_cast<guint>(modifiers), is_release != 0);
+    } catch (...) {
+    }
+  }
+}
+
+void LinuxTextInput::State::FcitxCommitCallback(FcitxGClient*, gchar* text, gpointer user_data) {
+  State* state = static_cast<State*>(user_data);
+  if (state == nullptr || text == nullptr) {
+    return;
+  }
+  try {
+    state->OnFcitxCommit(text);
+  } catch (...) {
+  }
+}
+
+void LinuxTextInput::State::FcitxPreeditCallback(FcitxGClient*, GPtrArray* items, gint cursor, gpointer user_data) {
+  State* state = static_cast<State*>(user_data);
+  if (state == nullptr) {
+    return;
+  }
+  try {
+    state->OnFcitxPreedit(items, cursor);
+  } catch (...) {
+  }
+}
+
+void LinuxTextInput::State::FcitxDeleteSurroundingCallback(
+    FcitxGClient*, gint offset, guint count, gpointer user_data
+) {
+  State* state = static_cast<State*>(user_data);
+  if (state == nullptr) {
+    return;
+  }
+  try {
+    state->OnFcitxDeleteSurrounding(offset, count);
+  } catch (...) {
+  }
+}
+
+void LinuxTextInput::State::FcitxNotifyFocusOutCallback(FcitxGClient*, gpointer user_data) {
+  State* state = static_cast<State*>(user_data);
+  if (state != nullptr) {
+    try {
+      state->OnFcitxNotifyFocusOut();
+    } catch (...) {
+    }
+  }
+}
+
+void LinuxTextInput::State::FcitxKeyCallback(GObject* source, GAsyncResult* result, gpointer user_data) {
+  std::unique_ptr<AsyncKeyCallbackData> callback_data(static_cast<AsyncKeyCallbackData*>(user_data));
+  const bool handled = fcitx_g_client_process_key_finish(FCITX_G_CLIENT(source), result) != FALSE;
+  g_object_unref(callback_data->cancellable);
+  callback_data->cancellable = nullptr;
+  const std::shared_ptr<AsyncLifetime> lifetime = callback_data->lifetime.lock();
+  if (lifetime == nullptr || lifetime->state == nullptr) {
+    return;
+  }
+  try {
+    lifetime->state->CompleteFcitxKey(callback_data->event, handled, callback_data->generation);
+  } catch (...) {
+  }
+}
+#endif
+
 LinuxTextInput::LinuxTextInput() : state_(std::make_unique<State>()) {}
 
-LinuxTextInput::~LinuxTextInput() {
-  state_->CloseInputContext();
-  state_->CloseInputMethod();
-}
+LinuxTextInput::~LinuxTextInput() = default;
 
 void LinuxTextInput::SetRuntime(Runtime* runtime) noexcept {
   state_->SetRuntime(runtime);
@@ -956,12 +1695,28 @@ XIC LinuxTextInput::InputContext() const noexcept {
   return state_->InputContext();
 }
 
+bool LinuxTextInput::FilterEvent(XEvent& event) noexcept {
+  return state_->FilterEvent(event);
+}
+
 void LinuxTextInput::SetFocus(bool focused) {
   state_->SetFocus(focused);
 }
 
-bool LinuxTextInput::HandleXKeyEvent(const XKeyEvent& event) {
+XimKeyEventResult LinuxTextInput::HandleXKeyEvent(XEvent& event) {
   return state_->HandleXKeyEvent(event);
+}
+
+int LinuxTextInput::PreparePoll(std::vector<pollfd>& descriptors, int timeout_ms) {
+  return state_->PreparePoll(descriptors, timeout_ms);
+}
+
+void LinuxTextInput::DispatchPoll(const std::vector<pollfd>& descriptors, bool poll_succeeded) noexcept {
+  state_->DispatchPoll(descriptors, poll_succeeded);
+}
+
+void LinuxTextInput::TakeDeferredKeyEvents(std::vector<LinuxDeferredKeyEvent>& events) {
+  state_->TakeDeferredKeyEvents(events);
 }
 
 void LinuxTextInput::Start(

--- a/platform/linux/linux_text_input.h
+++ b/platform/linux/linux_text_input.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <poll.h>
+
 #include <memory>
+#include <vector>
 
 #include "linux_internal.h"
 
@@ -12,10 +15,20 @@ class Runtime;
 
 namespace huxerui::detail {
 
-// True for keys that must bypass the XIM composition path: editing,
-// navigation, shortcut, modifier, and unknown keys never produce composed
-// text and are routed to the focused view instead.
-[[nodiscard]] bool IsEditingKeySym(KeySym keysym) noexcept;
+enum class XimKeyEventResult {
+  Unhandled,
+  Consumed,
+  DispatchWithoutText,
+};
+
+struct LinuxDeferredKeyEvent {
+  XEvent event{};
+  XimKeyEventResult result = XimKeyEventResult::Unhandled;
+};
+
+// XIM sees every key first. Only explicit application shortcuts and bare
+// modifier events bypass lookup after the input method declines the event.
+[[nodiscard]] bool ShouldBypassXimLookup(KeySym keysym, unsigned int state) noexcept;
 
 class LinuxTextInput final : public PlatformTextInput {
 public:
@@ -34,7 +47,11 @@ public:
   [[nodiscard]] bool Composing() const noexcept;
   void SetFocus(bool focused);
   [[nodiscard]] XIC InputContext() const noexcept;
-  [[nodiscard]] bool HandleXKeyEvent(const XKeyEvent& event);
+  [[nodiscard]] bool FilterEvent(XEvent& event) noexcept;
+  [[nodiscard]] XimKeyEventResult HandleXKeyEvent(XEvent& event);
+  [[nodiscard]] int PreparePoll(std::vector<pollfd>& descriptors, int timeout_ms);
+  void DispatchPoll(const std::vector<pollfd>& descriptors, bool poll_succeeded) noexcept;
+  void TakeDeferredKeyEvents(std::vector<LinuxDeferredKeyEvent>& events);
 
   void Start(
       TextInputSessionId session_id,

--- a/platform/linux/linux_text_input_internal.h
+++ b/platform/linux/linux_text_input_internal.h
@@ -4,22 +4,27 @@
 #include <string>
 #include <string_view>
 
-#include <huxerui/event.h>
 #include <huxerui/text_input.h>
 
 namespace huxerui::detail {
+
+[[nodiscard]] bool
+ShouldFilterXimEvent(int event_type, bool input_context_available, bool active, bool secure) noexcept;
 
 [[nodiscard]] std::optional<int> Utf8CodePointCount(std::string_view text) noexcept;
 
 [[nodiscard]] std::optional<TextOffset> Utf8PrefixUtf16Length(std::string_view text, int code_point_count) noexcept;
 
+[[nodiscard]] std::optional<TextOffset> Utf8BytePrefixUtf16Length(std::string_view text, int byte_count) noexcept;
+
+[[nodiscard]] std::optional<std::size_t> Utf16OffsetToUtf8Byte(std::string_view text, TextOffset offset) noexcept;
+
+[[nodiscard]] bool
+ShouldUseFcitxFrontend(const char* xmodifiers, const char* gtk_im_module, const char* qt_im_module) noexcept;
+
+[[nodiscard]] bool ShouldFocusXim(bool focused, bool fcitx_available, bool active, bool secure) noexcept;
+
 [[nodiscard]] std::optional<std::string>
 ApplyXimPreeditEdit(std::string_view current, int chg_first, int chg_length, std::string_view replacement);
-
-// True only for keys that may insert text through an input method. Editing,
-// navigation, shortcut, and modifier keys are dispatched to the focused view
-// instead of the XIM composition path so Backspace and friends are never
-// swallowed or committed as mask characters by the input method.
-[[nodiscard]] bool IsTextProducingKey(Key key) noexcept;
 
 } // namespace huxerui::detail

--- a/tests/platform/linux_damage.cpp
+++ b/tests/platform/linux_damage.cpp
@@ -77,5 +77,48 @@ TEST_CASE("LinuxDamageClampsNegativeRectanglesToZero") {
   REQUIRE(rect.height == 20);
 }
 
+TEST_CASE("LinuxTextureUploadKeepsMultipleSmallDamageRectanglesPartial") {
+  const std::vector<XRectangle> damage{{10, 20, 30, 40}, {200, 100, 20, 10}};
+  const detail::LinuxTextureUploadPlan plan = detail::ResolveLinuxTextureUpload(false, damage, 800, 600, true);
+  REQUIRE_FALSE(plan.full);
+  REQUIRE(plan.rects.size() == 2);
+  REQUIRE(plan.rects[0].x == 10);
+  REQUIRE(plan.rects[0].y == 20);
+  REQUIRE(plan.rects[0].width == 30);
+  REQUIRE(plan.rects[0].height == 40);
+  REQUIRE(plan.rects[1].x == 200);
+  REQUIRE(plan.rects[1].y == 100);
+  REQUIRE(plan.rects[1].width == 20);
+  REQUIRE(plan.rects[1].height == 10);
+  REQUIRE(plan.pixel_count == 1400);
+}
+
+TEST_CASE("LinuxTextureUploadUsesFullSurfaceForLargeDamage") {
+  const std::vector<XRectangle> damage{{0, 0, 800, 400}};
+  const detail::LinuxTextureUploadPlan plan = detail::ResolveLinuxTextureUpload(false, damage, 800, 600, true);
+  REQUIRE(plan.full);
+  REQUIRE(plan.rects.empty());
+  REQUIRE(plan.pixel_count == 480000);
+}
+
+TEST_CASE("LinuxTextureUploadInitializesNewTextureCompletely") {
+  const std::vector<XRectangle> damage{{10, 20, 30, 40}};
+  const detail::LinuxTextureUploadPlan plan = detail::ResolveLinuxTextureUpload(false, damage, 800, 600, false);
+  REQUIRE(plan.full);
+  REQUIRE(plan.pixel_count == 480000);
+}
+
+TEST_CASE("LinuxTextureUploadClampsDamageToTheSurface") {
+  const std::vector<XRectangle> damage{{-10, -5, 30, 20}};
+  const detail::LinuxTextureUploadPlan plan = detail::ResolveLinuxTextureUpload(false, damage, 100, 100, true);
+  REQUIRE_FALSE(plan.full);
+  REQUIRE(plan.rects.size() == 1);
+  REQUIRE(plan.rects[0].x == 0);
+  REQUIRE(plan.rects[0].y == 0);
+  REQUIRE(plan.rects[0].width == 20);
+  REQUIRE(plan.rects[0].height == 15);
+  REQUIRE(plan.pixel_count == 300);
+}
+
 } // namespace
 } // namespace huxerui::test

--- a/tests/platform/linux_renderer.cpp
+++ b/tests/platform/linux_renderer.cpp
@@ -55,6 +55,75 @@ TEST_CASE("LinuxMeasureRunProducesPositiveAdvance") {
   renderer.Discard();
 }
 
+TEST_CASE("LinuxTextLayoutHonorsExplicitDirection") {
+  detail::LinuxRenderer renderer;
+  renderer.Initialize();
+
+  const TextStyle style{Font::System(14.0F), Color::Black()};
+  const std::unique_ptr<detail::TextLayout> left_to_right = renderer.CreateTextLayout(
+      "abc",
+      style,
+      200.0F,
+      {.shaping = {.direction = TextDirection::LeftToRight}, .wrap = TextWrap::NoWrap}
+  );
+  const std::unique_ptr<detail::TextLayout> right_to_left = renderer.CreateTextLayout(
+      "abc",
+      style,
+      200.0F,
+      {.shaping = {.direction = TextDirection::RightToLeft}, .wrap = TextWrap::NoWrap}
+  );
+  REQUIRE(left_to_right->CaretRect(0, TextAffinity::Downstream).x == 0.0F);
+  REQUIRE(left_to_right->CaretRect(3, TextAffinity::Downstream).x > 0.0F);
+  REQUIRE(right_to_left->CaretRect(0, TextAffinity::Downstream).x > 0.0F);
+  REQUIRE(right_to_left->CaretRect(3, TextAffinity::Downstream).x == 0.0F);
+  renderer.Discard();
+}
+
+TEST_CASE("LinuxWordWrappingPreservesUtf8ScalarBoundaries") {
+  detail::LinuxRenderer renderer;
+  renderer.Initialize();
+
+  const TextStyle style{Font::System(14.0F), Color::Black()};
+  const float character_width = renderer.MeasureRun("\u4E16", style, {}).advance;
+  const TextLayoutMetrics metrics =
+      renderer.MeasureText("\u4E16\u754C", style, character_width + 0.1F, {.wrap = TextWrap::Word});
+  REQUIRE(metrics.line_count == 2);
+  const std::unique_ptr<detail::TextLayout> layout =
+      renderer.CreateTextLayout("\u4E16\u754C", style, character_width + 0.1F, {.wrap = TextWrap::Word});
+  REQUIRE(layout->NextCaretOffset(0) == 1);
+  REQUIRE(layout->NextCaretOffset(1) == 2);
+  renderer.Discard();
+}
+
+TEST_CASE("LinuxTextMeasurementPreservesTrailingEmptyLine") {
+  detail::LinuxRenderer renderer;
+  renderer.Initialize();
+
+  const TextStyle style{Font::System(14.0F), Color::Black()};
+  const TextLayoutMetrics metrics = renderer.MeasureText("one\n", style, 200.0F, {.wrap = TextWrap::NoWrap});
+  REQUIRE(metrics.line_count == 2);
+  REQUIRE(metrics.last_baseline > metrics.first_baseline);
+  renderer.Discard();
+}
+
+TEST_CASE("LinuxTextDecorationContributesToRunBounds") {
+  detail::LinuxRenderer renderer;
+  renderer.Initialize();
+
+  const TextStyle plain{Font::System(14.0F), Color::Black()};
+  const TextStyle decorated{
+      Font::System(14.0F),
+      Color::Black(),
+      TextDecoration::Underline | TextDecoration::StrikeThrough,
+  };
+  const TextRunMetrics plain_metrics = renderer.MeasureRun("Decorated", plain, {});
+  const TextRunMetrics decorated_metrics = renderer.MeasureRun("Decorated", decorated, {});
+  REQUIRE(decorated_metrics.advance == plain_metrics.advance);
+  REQUIRE(decorated_metrics.visual_bounds.y <= plain_metrics.visual_bounds.y);
+  REQUIRE(decorated_metrics.visual_bounds.height >= plain_metrics.visual_bounds.height);
+  renderer.Discard();
+}
+
 TEST_CASE("LinuxMeasureTextReportsLineCountForNewlines") {
   detail::LinuxRenderer renderer;
   renderer.Initialize();

--- a/tests/platform/linux_text_input.cpp
+++ b/tests/platform/linux_text_input.cpp
@@ -1,43 +1,58 @@
 #include <catch2/catch_amalgamated.hpp>
 
+#include <X11/keysym.h>
+
+#include <limits>
 #include <string>
 
-#include <huxerui/event.h>
-
+#include "linux_text_input.h"
 #include "linux_text_input_internal.h"
 
 namespace huxerui::test {
 namespace {
 
-TEST_CASE("IsTextProducingKey classifies editing keys") {
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Backspace));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Delete));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::ArrowLeft));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::ArrowRight));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::ArrowUp));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::ArrowDown));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Home));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::End));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::PageUp));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::PageDown));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Enter));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Tab));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Escape));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Space));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Unknown));
+TEST_CASE("XIM filters active non-secure key events and all protocol events") {
+  REQUIRE(detail::ShouldFilterXimEvent(KeyPress, true, true, false));
+  REQUIRE(detail::ShouldFilterXimEvent(KeyRelease, true, true, false));
+  REQUIRE(detail::ShouldFilterXimEvent(ClientMessage, true, true, false));
+  REQUIRE(detail::ShouldFilterXimEvent(ClientMessage, true, true, true));
+  REQUIRE(detail::ShouldFilterXimEvent(ClientMessage, true, false, false));
 }
 
-TEST_CASE("IsTextProducingKey classifies shortcut and modifier keys") {
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::A));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::C));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::V));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::X));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Y));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Z));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Shift));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Control));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Alt));
-  REQUIRE_FALSE(detail::IsTextProducingKey(Key::Meta));
+TEST_CASE("XIM leaves secure and inactive key events on the shared path") {
+  REQUIRE_FALSE(detail::ShouldFilterXimEvent(KeyPress, true, true, true));
+  REQUIRE_FALSE(detail::ShouldFilterXimEvent(KeyRelease, true, true, true));
+  REQUIRE_FALSE(detail::ShouldFilterXimEvent(KeyPress, true, false, false));
+  REQUIRE_FALSE(detail::ShouldFilterXimEvent(KeyPress, false, true, false));
+  REQUIRE_FALSE(detail::ShouldFilterXimEvent(ClientMessage, false, true, false));
+}
+
+TEST_CASE("XIM lookup accepts unmodified shortcut letters as text") {
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_a, 0));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_C, ShiftMask));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_v, Mod1Mask));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_X, ShiftMask | Mod1Mask));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_y, 0));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_Z, ShiftMask));
+}
+
+TEST_CASE("XIM lookup bypasses explicit application shortcuts after filtering") {
+  REQUIRE(detail::ShouldBypassXimLookup(XK_a, ControlMask));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_C, Mod4Mask));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_v, ControlMask | ShiftMask));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_X, ControlMask | Mod4Mask));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_y, Mod4Mask | ShiftMask));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_Z, ControlMask));
+}
+
+TEST_CASE("XIM lookup leaves switching and composition keys to the input method") {
+  REQUIRE(detail::ShouldBypassXimLookup(XK_Shift_L, 0));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_Super_L, 0));
+  REQUIRE(detail::ShouldBypassXimLookup(XK_space, Mod4Mask));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_space, 0));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_BackSpace, 0));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_Return, 0));
+  REQUIRE_FALSE(detail::ShouldBypassXimLookup(XK_Left, 0));
 }
 
 TEST_CASE("ApplyXimPreeditEdit replaces the reported code-point range") {
@@ -78,6 +93,7 @@ TEST_CASE("ApplyXimPreeditEdit rejects out-of-range changes") {
   REQUIRE_FALSE(detail::ApplyXimPreeditEdit("abc", 2, 2, "x").has_value());
   REQUIRE_FALSE(detail::ApplyXimPreeditEdit("abc", -1, 1, "x").has_value());
   REQUIRE_FALSE(detail::ApplyXimPreeditEdit("abc", 1, -1, "x").has_value());
+  REQUIRE_FALSE(detail::ApplyXimPreeditEdit("abc", std::numeric_limits<int>::max(), 1, "x").has_value());
 }
 
 TEST_CASE("ApplyXimPreeditEdit rejects invalid UTF-8") {
@@ -95,6 +111,49 @@ TEST_CASE("Utf8PrefixUtf16Length maps code points onto the UTF-16 space") {
   REQUIRE_FALSE(detail::Utf8PrefixUtf16Length(text, 4).has_value());
   REQUIRE_FALSE(detail::Utf8PrefixUtf16Length(text, -1).has_value());
   REQUIRE_FALSE(detail::Utf8PrefixUtf16Length("\xFF", 1).has_value());
+}
+
+TEST_CASE("Utf8BytePrefixUtf16Length maps Fcitx byte cursors onto the UTF-16 space") {
+  const std::string text = "a\xE4\xBD\xA0\xF0\x9F\x98\x80";
+  REQUIRE(detail::Utf8BytePrefixUtf16Length(text, 0) == TextOffset{0});
+  REQUIRE(detail::Utf8BytePrefixUtf16Length(text, 1) == TextOffset{1});
+  REQUIRE(detail::Utf8BytePrefixUtf16Length(text, 4) == TextOffset{2});
+  REQUIRE(detail::Utf8BytePrefixUtf16Length(text, 8) == TextOffset{4});
+  REQUIRE_FALSE(detail::Utf8BytePrefixUtf16Length(text, 2).has_value());
+  REQUIRE_FALSE(detail::Utf8BytePrefixUtf16Length(text, 9).has_value());
+  REQUIRE_FALSE(detail::Utf8BytePrefixUtf16Length(text, -1).has_value());
+  REQUIRE_FALSE(detail::Utf8BytePrefixUtf16Length("\xFF", 1).has_value());
+}
+
+TEST_CASE("Utf16OffsetToUtf8Byte maps surrounding-text offsets onto UTF-8 bytes") {
+  const std::string text = "a\xE4\xBD\xA0\xF0\x9F\x98\x80";
+  REQUIRE(detail::Utf16OffsetToUtf8Byte(text, 0) == 0);
+  REQUIRE(detail::Utf16OffsetToUtf8Byte(text, 1) == 1);
+  REQUIRE(detail::Utf16OffsetToUtf8Byte(text, 2) == 4);
+  REQUIRE(detail::Utf16OffsetToUtf8Byte(text, 4) == 8);
+  REQUIRE_FALSE(detail::Utf16OffsetToUtf8Byte(text, 3).has_value());
+  REQUIRE_FALSE(detail::Utf16OffsetToUtf8Byte(text, 5).has_value());
+  REQUIRE_FALSE(detail::Utf16OffsetToUtf8Byte(text, -1).has_value());
+  REQUIRE_FALSE(detail::Utf16OffsetToUtf8Byte("\xFF", 1).has_value());
+}
+
+TEST_CASE("Fcitx frontend selection recognizes common Linux input module variables") {
+  REQUIRE(detail::ShouldUseFcitxFrontend("@im=fcitx", nullptr, nullptr));
+  REQUIRE(detail::ShouldUseFcitxFrontend("@im=Fcitx5", nullptr, nullptr));
+  REQUIRE(detail::ShouldUseFcitxFrontend(nullptr, "fcitx", nullptr));
+  REQUIRE(detail::ShouldUseFcitxFrontend(nullptr, nullptr, "fcitx5"));
+  REQUIRE_FALSE(detail::ShouldUseFcitxFrontend("@im=ibus", "ibus", "ibus"));
+  REQUIRE_FALSE(detail::ShouldUseFcitxFrontend(nullptr, nullptr, nullptr));
+}
+
+TEST_CASE("XIM focus is limited to active non-secure sessions without Fcitx") {
+  REQUIRE_FALSE(detail::ShouldFocusXim(true, true, true, false));
+  REQUIRE(detail::ShouldFocusXim(true, false, true, false));
+  REQUIRE_FALSE(detail::ShouldFocusXim(true, true, false, false));
+  REQUIRE_FALSE(detail::ShouldFocusXim(true, true, true, true));
+  REQUIRE_FALSE(detail::ShouldFocusXim(true, false, false, false));
+  REQUIRE_FALSE(detail::ShouldFocusXim(true, false, true, true));
+  REQUIRE_FALSE(detail::ShouldFocusXim(false, false, true, false));
 }
 
 TEST_CASE("Utf8CodePointCount counts valid UTF-8") {


### PR DESCRIPTION
## Summary

This PR brings the Linux backend text-input and rendering behavior in line with the native macOS and Windows backends while reducing avoidable renderer work and memory growth.

It is organized as three focused commits:

- `perf(linux): bound renderer work and resource caches`
- `fix(linux): align text layout and rasterization`
- `fix(linux): restore IME composition and key routing`

## Motivation

The Linux backend had several related user-visible problems:

- Fcitx5 could accept keystrokes without exposing stable preedit text, so composition briefly appeared and then disappeared, direct English input could stop working, and Backspace could be swallowed.
- Password mask glyphs could rasterize at different pixel phases, making identical bullets appear wider, thinner, or different in height while focus changed.
- Text shaping and paragraph caches omitted direction and locale state, UTF-8 wrapping could split at invalid boundaries, trailing empty lines were lost, and text decoration or fallback-font transitions were incomplete.
- Renderer caches and temporary buffers could grow or be recreated unnecessarily, and EGL texture uploads handled only a narrow single-damage-rectangle case.

## Linux IME and keyboard routing

- Adds optional `Fcitx5GClient` discovery and linking without making it a required Linux dependency.
- Keeps XIM as the generic fallback when the Fcitx client library is unavailable or Fcitx is not selected by the process environment.
- Integrates Fcitx GLib DBus sources into the existing X11 `poll()` loop so callbacks wake the event loop without periodic polling or a blocking nested loop.
- Sends key events through bounded asynchronous Fcitx requests and preserves event order when declined or forwarded keys return to the shared key path.
- Routes XIM filtering before normal X11 dispatch while allowing secure and inactive text sessions to keep direct editing behavior.
- Separates consumed events from keys that must be dispatched without text, preventing duplicate insertion while preserving Backspace, navigation, shortcuts, and key-up state.
- Converts Fcitx UTF-8 byte cursors to the shared UTF-16 offset model for preedit updates.
- Converts controlled surrounding-text selection to UTF-8 byte coordinates and maps adjacent deletion requests back to Unicode code-point operations.
- Publishes the transformed caret rectangle in X11 root coordinates for native candidate placement.
- Keeps Fcitx and XIM focus ownership mutually exclusive so one frontend cannot reset composition owned by the other.
- Bypasses Fcitx and XIM for secure sessions and never publishes secure surrounding text.

The shared controlled `TextEditingValue`, Runtime session identity, revisions, selection, and composition contracts remain unchanged; the fix stays at the Linux platform-service boundary.

## Text layout and rendering alignment

- Includes font family kind, shaping direction, locale, alignment, and wrap options in the appropriate cache keys.
- Honors explicit left-to-right and right-to-left shaping and applies direction-aware leading and trailing alignment.
- Wraps at UTF-8 scalar boundaries, uses bounded exponential and binary probes for long lines, and preserves trailing empty lines.
- Restores the primary font after fallback glyph runs and retains FreeType faces for the lifetime required by Cairo font faces.
- Includes underline and strike-through geometry in run bounds and paints both decorations consistently for text runs and paragraphs.
- Snaps text origins through the active Cairo transform only when the transform permits stable device-pixel alignment.
- Keeps repeated identical glyphs on the same device-pixel phase. This removes the password-field jitter where the same bullet rasterized as different heights or weights.
- Preserves the upstream `DrawExternalTextureCommand` Linux handling added on `main`.

## Linux backend performance

- Adds Linux process CPU, resident-memory, and processor-count metrics for the debug/performance overlay.
- Bounds font, fallback-font, shaped-run, paragraph, image, rounded-shadow, and path-shadow resources by entry count and/or byte budget.
- Reuses glyph, blur, and texture-upload scratch storage instead of allocating equivalent buffers for every draw.
- Caches blurred rounded-rectangle and path masks with explicit byte budgets and correct cleanup on DPI changes, discard, and destruction.
- Supports multiple small damage rectangles for GLES texture uploads and falls back to a full upload when damage count or pixel coverage makes partial upload more expensive.
- Packs padded Cairo rows into contiguous upload buffers so uploads avoid one GLES call per row.
- Preserves full-quad presentation after partial texture updates because EGL back buffers are not assumed to retain previous contents.
- Fixes Cairo A8 stride handling and font-cache eviction lifetimes.

## Tests and documentation

- Adds Linux texture-upload planning coverage for small multi-rect damage, large damage, new textures, and surface clamping.
- Adds renderer coverage for explicit direction, UTF-8 wrapping boundaries, trailing empty lines, and decoration bounds.
- Expands XIM/Fcitx tests for filtering, shortcut bypass, secure focus, UTF-8/UTF-16 conversions, frontend selection, surrounding text, and invalid ranges.
- Documents the optional Fcitx DBus frontend and Linux text-input lifecycle.
- Updates the platform summary to describe the optional Fcitx5 preedit path.

## Validation

- Incremental Linux configure and build: `example_ui_gallery`, `huxerui_tests`
- Independent clean Linux configure and build: `example_ui_gallery`, `huxerui_tests`
- Linux-focused tests: 36 test cases, 1,544 assertions passed
- Full common and Linux suite: 566 test cases, 5,675 assertions passed
- Isolated Xvfb raster check: all 10 password mask bullets produced the same 4x5 thresholded bounds and the same 18-pixel area
- Interactive Fcitx5 validation covered visible preedit, candidate selection and Chinese commit, direct English input, secure input, and Backspace routing
- `git diff --check` passed and the worktree was clean

## Platform scope and compatibility

- The behavioral implementation is Linux-only; macOS and Windows native IME adapters are unchanged.
- Fcitx5 support remains optional at build time, and XIM remains supported as the fallback.
- Secure-field data is not exposed to either surrounding-text API.
- No public HuxerUI API or controlled text-editing contract changes are introduced.