### PR TITLE
feat(linux): add XDG application file storage

### DIFF
--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -273,6 +273,7 @@ function(huxerui_platform_configure)
     set(HUXERUI_PLATFORM_SOURCE_FILES
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_adapter.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_external_texture.cpp"
+            "${HUXERUI_PROJECT_DIR}/platform/linux/linux_file.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_http.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_renderer.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_text_input.cpp"

--- a/docs/design/files.md
+++ b/docs/design/files.md
@@ -533,7 +533,13 @@ It uses the Storage Access Framework for active selection.
 Windows uses the application's Local App Data identity for durable data, application-specific cache and temporary children, and the directory containing the process executable.
 It uses the native file dialogs for active selection.
 
-Linux follows XDG data and cache locations, prefers an application child of `XDG_RUNTIME_DIR` for temporary files with a safe temporary fallback, and resolves the executable directory independently of the process working directory.
+Linux uses the UTF-8 filename resolved from `/proc/self/exe` as its application identity and resolves the executable directory from that same path independently of the process working directory.
+Durable data uses `$XDG_DATA_HOME/<executable-name>` or `$HOME/.local/share/<executable-name>`, while cache data uses `$XDG_CACHE_HOME/<executable-name>` or `$HOME/.cache/<executable-name>`.
+Relative, empty, or invalid UTF-8 XDG paths are ignored.
+Temporary data uses `<XDG_RUNTIME_DIR>/<executable-name>` only when the runtime root is an owner-only directory belonging to the effective user.
+Otherwise it uses `<system-temporary-directory>/huxerui-<effective-uid>/<executable-name>` and requires both created children to remain owner-only directories.
+An unsafe existing fallback directory fails initialization rather than being reused.
+Renaming the executable selects different storage, and executable files with the same name share one per-user application directory.
 It prefers the desktop portal for active selection.
 
 Web maps application-private storage through the browser filesystem design below and has no executable directory.

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,7 +1,7 @@
 # Files and Application Storage
 
 HuxerUI represents local paths with `File` and publishes application-owned directories through the Runtime-installed `FileSystem` Root Service.
-The current implementation supports macOS, iOS, Android, and Web; Windows and Linux directory mappings remain staged work.
+The current implementation supports macOS, Linux, iOS, Android, and Web; the Windows directory mapping remains staged work.
 
 ## Application directories
 
@@ -23,6 +23,12 @@ File export_file(directories.temporary_directory, "export.bin");
 
 `CurrentDirectory()` reports the process working directory and is not an application storage location.
 Application data should not depend on the directory from which a launcher happened to start the process.
+
+On Linux, the executable filename identifies the application directory.
+Data uses `$XDG_DATA_HOME/<executable-name>` or `$HOME/.local/share/<executable-name>`, and cache uses `$XDG_CACHE_HOME/<executable-name>` or `$HOME/.cache/<executable-name>`.
+Temporary data uses a private `$XDG_RUNTIME_DIR/<executable-name>` when available, otherwise HuxerUI creates `<system-temporary-directory>/huxerui-<uid>/<executable-name>` with owner-only access.
+Renaming the executable selects different application storage, while independently installed executables with the same filename share these per-user locations.
+`executable_directory` is resolved from `/proc/self/exe` rather than the process working directory.
 
 ## Paths
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -114,6 +114,8 @@ The Linux backend creates an X11 window, measures text with FreeType and HarfBuz
 Partial Runtime damage limits Cairo redraw to the affected pixel bounds; the retained bitmap is then presented whole or as damaged rows, matching the Windows cost model of a retained scene bitmap plus swap-chain presentation.
 Canvas Paths map to Cairo path geometry for fill, stroke, clipping, and blurred shadow masks.
 Packaged resources are read from the executable-specific `<name>.resources` directory (overridable with `HUXERUI_RESOURCES_DIR`), locale and `Xft.dpi` changes update the Runtime resource configuration, and libpng/libjpeg decoding produces Cairo bitmap cache entries with a bounded byte budget.
+FileSystem uses the executable filename as its application identity, maps durable and cache files through `XDG_DATA_HOME` and `XDG_CACHE_HOME` with standard home-directory fallbacks, and obtains the executable directory from `/proc/self/exe` rather than the working directory.
+Temporary files use an owner-only application child under a valid `XDG_RUNTIME_DIR`, or an owner-only `huxerui-<uid>` subtree of the system temporary directory when the runtime directory is unavailable or unsafe.
 
 Text input uses the X Input Method protocol with full preedit callbacks, mirroring the Windows IMM32 adapter; when no input method is available the backend degrades gracefully to direct key text.
 Clipboard reads and writes use the X11 `CLIPBOARD` selection with UTF-8 string transfers.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(canvas)
 add_subdirectory(image)
 add_subdirectory(window_chrome)
 
-if (APPLE OR ANDROID OR EMSCRIPTEN)
+if (APPLE OR ANDROID OR EMSCRIPTEN OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_subdirectory(files)
 endif ()
 

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -32,6 +32,7 @@
 
 #include <huxerui/app.h>
 
+#include "linux_file_internal.h"
 #include "linux_http_internal.h"
 #include "linux_renderer.h"
 #include "linux_text_input.h"
@@ -272,6 +273,10 @@ public:
 
   PlatformResources* Resources() noexcept override {
     return this;
+  }
+
+  std::shared_ptr<FileSystem> CreateFileSystem() override {
+    return CreateLinuxFileSystem();
   }
 
   std::shared_ptr<HttpTransport> CreateHttpTransport() override {
@@ -587,15 +592,7 @@ private:
     if (const char* override_dir = std::getenv("HUXERUI_RESOURCES_DIR")) {
       return std::filesystem::path(override_dir);
     }
-    std::string executable_path;
-    executable_path.resize(4096);
-    const std::size_t length =
-        static_cast<std::size_t>(readlink("/proc/self/exe", executable_path.data(), executable_path.size()));
-    if (length == std::string::npos || length >= executable_path.size()) {
-      throw std::logic_error("HuxerUI Linux executable path could not be resolved");
-    }
-    executable_path.resize(length);
-    std::filesystem::path resource_root(executable_path);
+    std::filesystem::path resource_root(ResolveLinuxExecutablePath());
     resource_root.replace_extension(".resources");
     return resource_root;
   }

--- a/platform/linux/linux_file.cpp
+++ b/platform/linux/linux_file.cpp
@@ -1,0 +1,235 @@
+#include "linux_internal.h"
+
+#include "linux_file_internal.h"
+
+#include <pwd.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "file_internal.h"
+
+namespace huxerui::detail {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+std::optional<std::string> EnvironmentVariable(const char* name) {
+  const char* value = std::getenv(name);
+  if (value == nullptr) {
+    return std::nullopt;
+  }
+  return std::string(value);
+}
+
+std::string Utf8Path(const fs::path& path) {
+  const std::u8string value = path.generic_u8string();
+  return std::string(reinterpret_cast<const char*>(value.data()), value.size());
+}
+
+std::optional<std::string> ValidAbsolutePath(const std::optional<std::string>& value) {
+  if (!value.has_value() || value->empty() || value->front() != '/') {
+    return std::nullopt;
+  }
+  try {
+    return File(*value).Path();
+  } catch (const std::invalid_argument&) {
+    return std::nullopt;
+  }
+}
+
+std::optional<std::string> PasswdHomeDirectory(uid_t user_id) {
+  long initial_size = sysconf(_SC_GETPW_R_SIZE_MAX);
+  if (initial_size <= 0) {
+    initial_size = 16 * 1024;
+  }
+  std::vector<char> buffer(static_cast<std::size_t>(initial_size));
+  for (;;) {
+    passwd entry{};
+    passwd* result = nullptr;
+    const int error = getpwuid_r(user_id, &entry, buffer.data(), buffer.size(), &result);
+    if (error == 0) {
+      if (result == nullptr || result->pw_dir == nullptr) {
+        return std::nullopt;
+      }
+      return std::string(result->pw_dir);
+    }
+    if (error != ERANGE || buffer.size() > std::numeric_limits<std::size_t>::max() / 2U) {
+      return std::nullopt;
+    }
+    buffer.resize(buffer.size() * 2U);
+  }
+}
+
+bool IsPrivateDirectory(std::string_view path, uid_t user_id) noexcept {
+  struct stat status{};
+  const std::string value(path);
+  if (lstat(value.c_str(), &status) != 0) {
+    return false;
+  }
+  return S_ISDIR(status.st_mode) && status.st_uid == user_id && (status.st_mode & 0777) == 0700;
+}
+
+void EnsurePrivateDirectory(std::string_view path, uid_t user_id) {
+  const std::string value(path);
+  bool created = false;
+  if (mkdir(value.c_str(), 0700) == 0) {
+    created = true;
+  } else if (errno != EEXIST) {
+    throw std::runtime_error("HuxerUI Linux file system could not create a private temporary directory");
+  }
+  if (created && chmod(value.c_str(), 0700) != 0) {
+    throw std::runtime_error("HuxerUI Linux file system could not secure a private temporary directory");
+  }
+  if (!IsPrivateDirectory(path, user_id)) {
+    throw std::runtime_error("HuxerUI Linux file system temporary directory is not private");
+  }
+}
+
+std::string RequiredHomeDirectory(const LinuxFileSystemEnvironment& environment) {
+  if (std::optional<std::string> home = ValidAbsolutePath(environment.home_directory)) {
+    return std::move(*home);
+  }
+  if (std::optional<std::string> home = ValidAbsolutePath(environment.passwd_home_directory)) {
+    return std::move(*home);
+  }
+  throw std::runtime_error("HuxerUI Linux home directory could not be resolved");
+}
+
+std::string ApplicationChild(std::string_view base, std::string_view identity) {
+  return File(base).Child(identity).Path();
+}
+
+} // namespace
+
+std::string ResolveLinuxExecutablePath() {
+  std::vector<char> buffer(256);
+  for (;;) {
+    const ssize_t length = readlink("/proc/self/exe", buffer.data(), buffer.size());
+    if (length < 0) {
+      throw std::runtime_error("HuxerUI Linux executable path could not be resolved");
+    }
+    if (static_cast<std::size_t>(length) < buffer.size()) {
+      std::string path(buffer.data(), static_cast<std::size_t>(length));
+      try {
+        File file(path);
+        if (!file.Parent().has_value() || file.Name().empty()) {
+          throw std::runtime_error("HuxerUI Linux executable path is invalid");
+        }
+        return file.Path();
+      } catch (const std::invalid_argument&) {
+        throw std::runtime_error("HuxerUI Linux executable path is not valid UTF-8");
+      }
+    }
+    if (buffer.size() > std::numeric_limits<std::size_t>::max() / 2U) {
+      throw std::runtime_error("HuxerUI Linux executable path is too long");
+    }
+    buffer.resize(buffer.size() * 2U);
+  }
+}
+
+FileSystemPaths
+ResolveLinuxFileSystemPaths(std::string_view executable_path, const LinuxFileSystemEnvironment& environment) {
+  if (executable_path.empty() || executable_path.front() != '/') {
+    throw std::runtime_error("HuxerUI Linux executable path is invalid");
+  }
+  File executable = [&] {
+    try {
+      return File(executable_path);
+    } catch (const std::invalid_argument&) {
+      throw std::runtime_error("HuxerUI Linux executable path is not valid UTF-8");
+    }
+  }();
+  const std::optional<File> executable_directory = executable.Parent();
+  const std::string identity = executable.Name();
+  if (!executable_directory.has_value() || identity.empty()) {
+    throw std::runtime_error("HuxerUI Linux executable path is invalid");
+  }
+
+  std::optional<std::string> data_base = ValidAbsolutePath(environment.data_home);
+  std::optional<std::string> cache_base = ValidAbsolutePath(environment.cache_home);
+  if (!data_base.has_value() || !cache_base.has_value()) {
+    const std::string home = RequiredHomeDirectory(environment);
+    if (!data_base.has_value()) {
+      data_base = File(home).Resolve(".local/share").Path();
+    }
+    if (!cache_base.has_value()) {
+      cache_base = File(home).Child(".cache").Path();
+    }
+  }
+
+  std::string temporary_base;
+  if (std::optional<std::string> runtime = ValidAbsolutePath(environment.runtime_directory);
+      runtime.has_value() && IsPrivateDirectory(*runtime, environment.effective_user_id)) {
+    temporary_base = std::move(*runtime);
+  } else {
+    const std::optional<std::string> fallback = ValidAbsolutePath(environment.fallback_temporary_root);
+    if (!fallback.has_value()) {
+      throw std::runtime_error("HuxerUI Linux temporary directory could not be resolved");
+    }
+    temporary_base = File(*fallback).Child("huxerui-" + std::to_string(environment.effective_user_id)).Path();
+  }
+
+  return {
+      .executable_directory = executable_directory->Path(),
+      .data_directory = ApplicationChild(*data_base, identity),
+      .cache_directory = ApplicationChild(*cache_base, identity),
+      .temporary_directory = ApplicationChild(temporary_base, identity),
+  };
+}
+
+std::shared_ptr<FileSystem>
+CreateLinuxFileSystem(std::string_view executable_path, LinuxFileSystemEnvironment environment) {
+  FileSystemPaths paths = ResolveLinuxFileSystemPaths(executable_path, environment);
+
+  const std::optional<std::string> runtime = ValidAbsolutePath(environment.runtime_directory);
+  const bool uses_runtime_directory =
+      runtime.has_value() && IsPrivateDirectory(*runtime, environment.effective_user_id);
+  if (!uses_runtime_directory) {
+    const std::optional<File> application_temporary_parent = File(paths.temporary_directory).Parent();
+    if (!application_temporary_parent.has_value()) {
+      throw std::runtime_error("HuxerUI Linux temporary directory is invalid");
+    }
+    EnsurePrivateDirectory(application_temporary_parent->Path(), environment.effective_user_id);
+  }
+  EnsurePrivateDirectory(paths.temporary_directory, environment.effective_user_id);
+  return MakeFileSystem(std::move(paths));
+}
+
+std::shared_ptr<FileSystem> CreateLinuxFileSystem() {
+  const uid_t user_id = geteuid();
+  std::error_code temporary_error;
+  const fs::path temporary_root = fs::temp_directory_path(temporary_error);
+  if (temporary_error) {
+    throw std::runtime_error("HuxerUI Linux temporary directory could not be resolved");
+  }
+
+  return CreateLinuxFileSystem(
+      ResolveLinuxExecutablePath(),
+      {
+          .home_directory = EnvironmentVariable("HOME"),
+          .passwd_home_directory = PasswdHomeDirectory(user_id),
+          .data_home = EnvironmentVariable("XDG_DATA_HOME"),
+          .cache_home = EnvironmentVariable("XDG_CACHE_HOME"),
+          .runtime_directory = EnvironmentVariable("XDG_RUNTIME_DIR"),
+          .fallback_temporary_root = Utf8Path(temporary_root),
+          .effective_user_id = user_id,
+      }
+  );
+}
+
+} // namespace huxerui::detail

--- a/platform/linux/linux_file_internal.h
+++ b/platform/linux/linux_file_internal.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <sys/types.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace huxerui {
+
+class FileSystem;
+
+namespace detail {
+
+struct FileSystemPaths;
+
+struct LinuxFileSystemEnvironment {
+  std::optional<std::string> home_directory;
+  std::optional<std::string> passwd_home_directory;
+  std::optional<std::string> data_home;
+  std::optional<std::string> cache_home;
+  std::optional<std::string> runtime_directory;
+  std::string fallback_temporary_root;
+  uid_t effective_user_id = 0;
+};
+
+[[nodiscard]] std::string ResolveLinuxExecutablePath();
+[[nodiscard]] FileSystemPaths
+ResolveLinuxFileSystemPaths(std::string_view executable_path, const LinuxFileSystemEnvironment& environment);
+[[nodiscard]] std::shared_ptr<FileSystem>
+CreateLinuxFileSystem(std::string_view executable_path, LinuxFileSystemEnvironment environment);
+[[nodiscard]] std::shared_ptr<FileSystem> CreateLinuxFileSystem();
+
+} // namespace detail
+} // namespace huxerui

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "${HUXERUI_PROJECT_DIR}/examples/platform_module/timer.cpp"
             platform/linux_damage.cpp
             platform/linux_external_texture.cpp
+            platform/linux_file.cpp
             platform/linux_http.cpp
             platform/linux_platform_module.cpp
             platform/linux_renderer.cpp

--- a/tests/platform/linux_file.cpp
+++ b/tests/platform/linux_file.cpp
@@ -1,0 +1,242 @@
+#include "linux_internal.h"
+
+#include <catch2/catch_amalgamated.hpp>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "file_internal.h"
+#include "linux_file_internal.h"
+
+namespace huxerui::test {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+std::string Utf8Path(const fs::path& path) {
+  const std::u8string value = path.generic_u8string();
+  return std::string(reinterpret_cast<const char*>(value.data()), value.size());
+}
+
+class TemporaryDirectory final {
+public:
+  TemporaryDirectory() {
+    static std::atomic<std::uint64_t> sequence = 0;
+    path_ = fs::temp_directory_path() /
+            ("huxerui-linux-file-tests-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+             "-" + std::to_string(sequence.fetch_add(1)));
+    REQUIRE(fs::create_directories(path_));
+  }
+
+  ~TemporaryDirectory() {
+    std::error_code error;
+    fs::remove_all(path_, error);
+  }
+
+  [[nodiscard]] std::string Path(std::string_view relative = {}) const {
+    if (relative.empty()) {
+      return Utf8Path(path_);
+    }
+    return Utf8Path(path_ / fs::path(relative));
+  }
+
+  [[nodiscard]] std::string CreateDirectory(std::string_view relative, fs::perms permissions) const {
+    const fs::path directory = path_ / fs::path(relative);
+    REQUIRE(fs::create_directories(directory));
+    fs::permissions(directory, permissions, fs::perm_options::replace);
+    return Utf8Path(directory);
+  }
+
+private:
+  fs::path path_;
+};
+
+class CurrentDirectoryScope final {
+public:
+  CurrentDirectoryScope() : original_(fs::current_path()) {}
+
+  ~CurrentDirectoryScope() {
+    std::error_code error;
+    fs::current_path(original_, error);
+  }
+
+  CurrentDirectoryScope(const CurrentDirectoryScope&) = delete;
+  CurrentDirectoryScope& operator=(const CurrentDirectoryScope&) = delete;
+
+private:
+  fs::path original_;
+};
+
+mode_t Permissions(std::string_view path) {
+  struct stat status{};
+  const std::string value(path);
+  REQUIRE(lstat(value.c_str(), &status) == 0);
+  return status.st_mode & 0777;
+}
+
+detail::LinuxFileSystemEnvironment
+Environment(const TemporaryDirectory& temporary, std::string runtime_directory, uid_t user_id = geteuid()) {
+  return {
+      .home_directory = temporary.Path("home"),
+      .passwd_home_directory = std::nullopt,
+      .data_home = temporary.Path("data"),
+      .cache_home = temporary.Path("cache"),
+      .runtime_directory = std::move(runtime_directory),
+      .fallback_temporary_root = temporary.Path("fallback"),
+      .effective_user_id = user_id,
+  };
+}
+
+} // namespace
+
+TEST_CASE("LinuxFileSystemResolvesXdgApplicationDirectories") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory =
+      temporary.CreateDirectory("bin", fs::perms::owner_all | fs::perms::group_read);
+  const std::string runtime = temporary.CreateDirectory("runtime", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("示例程序").Path();
+
+  const detail::FileSystemPaths paths =
+      detail::ResolveLinuxFileSystemPaths(executable, Environment(temporary, runtime));
+
+  REQUIRE(paths.executable_directory == executable_directory);
+  REQUIRE(paths.data_directory == File(temporary.Path("data")).Child("示例程序").Path());
+  REQUIRE(paths.cache_directory == File(temporary.Path("cache")).Child("示例程序").Path());
+  REQUIRE(paths.temporary_directory == File(runtime).Child("示例程序").Path());
+}
+
+TEST_CASE("LinuxFileSystemIgnoresInvalidXdgPathsAndUsesHomeDefaults") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory = temporary.CreateDirectory("bin", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("sample").Path();
+  std::string invalid_utf8 = temporary.Path();
+  invalid_utf8.append("/\xFF", 2);
+  detail::LinuxFileSystemEnvironment environment{
+      .home_directory = "relative-home",
+      .passwd_home_directory = temporary.Path("passwd-home"),
+      .data_home = "relative-data",
+      .cache_home = invalid_utf8,
+      .runtime_directory = "relative-runtime",
+      .fallback_temporary_root = temporary.Path("fallback"),
+      .effective_user_id = geteuid(),
+  };
+
+  const detail::FileSystemPaths paths = detail::ResolveLinuxFileSystemPaths(executable, environment);
+
+  REQUIRE(paths.data_directory == File(temporary.Path("passwd-home")).Resolve(".local/share/sample").Path());
+  REQUIRE(paths.cache_directory == File(temporary.Path("passwd-home")).Resolve(".cache/sample").Path());
+  REQUIRE(
+      paths.temporary_directory == File(temporary.Path("fallback"))
+                                       .Child("huxerui-" + std::to_string(environment.effective_user_id))
+                                       .Child("sample")
+                                       .Path()
+  );
+  REQUIRE_THROWS_AS(detail::ResolveLinuxFileSystemPaths("relative/sample", environment), std::runtime_error);
+}
+
+TEST_CASE("LinuxFileSystemRejectsUnsafeRuntimeDirectories") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory = temporary.CreateDirectory("bin", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("sample").Path();
+  const std::string runtime = temporary.CreateDirectory("runtime", fs::perms::owner_all);
+  const std::string fallback =
+      File(temporary.Path("fallback")).Child("huxerui-" + std::to_string(geteuid())).Child("sample").Path();
+
+  detail::LinuxFileSystemEnvironment wrong_owner =
+      Environment(temporary, runtime, geteuid() == std::numeric_limits<uid_t>::max() ? geteuid() - 1 : geteuid() + 1);
+  REQUIRE(
+      detail::ResolveLinuxFileSystemPaths(executable, wrong_owner).temporary_directory !=
+      File(runtime).Child("sample").Path()
+  );
+
+  fs::permissions(fs::path(runtime), fs::perms::owner_all | fs::perms::group_read, fs::perm_options::replace);
+  REQUIRE(
+      detail::ResolveLinuxFileSystemPaths(executable, Environment(temporary, runtime)).temporary_directory == fallback
+  );
+
+  const std::string private_runtime = temporary.CreateDirectory("private-runtime", fs::perms::owner_all);
+  const fs::path runtime_link = fs::path(temporary.Path()) / "runtime-link";
+  fs::create_directory_symlink(fs::path(private_runtime), runtime_link);
+  REQUIRE(
+      detail::ResolveLinuxFileSystemPaths(executable, Environment(temporary, Utf8Path(runtime_link)))
+          .temporary_directory == fallback
+  );
+}
+
+TEST_CASE("LinuxFileSystemCreatesAndProtectsPrivateApplicationDirectories") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory = temporary.CreateDirectory("bin", fs::perms::owner_all);
+  const std::string runtime = temporary.CreateDirectory("runtime", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("sample").Path();
+
+  std::shared_ptr<FileSystem> file_system = detail::CreateLinuxFileSystem(executable, Environment(temporary, runtime));
+  const AppDirectories& directories = file_system->Directories();
+
+  REQUIRE(directories.executable_directory == File(executable_directory));
+  REQUIRE(directories.data_directory.IsDirectory());
+  REQUIRE(directories.cache_directory.IsDirectory());
+  REQUIRE(directories.temporary_directory.IsDirectory());
+  REQUIRE(Permissions(directories.temporary_directory.Path()) == 0700);
+  REQUIRE_FALSE(directories.data_directory.DeleteRecursively());
+  REQUIRE_FALSE(directories.cache_directory.DeleteRecursively());
+  REQUIRE_FALSE(directories.temporary_directory.DeleteRecursively());
+}
+
+TEST_CASE("LinuxFileSystemCreatesAUidIsolatedTemporaryFallback") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory = temporary.CreateDirectory("bin", fs::perms::owner_all);
+  const std::string fallback = temporary.CreateDirectory("fallback", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("sample").Path();
+  detail::LinuxFileSystemEnvironment environment = Environment(temporary, {});
+  environment.fallback_temporary_root = fallback;
+
+  std::shared_ptr<FileSystem> file_system = detail::CreateLinuxFileSystem(executable, environment);
+  const File temporary_directory = file_system->Directories().temporary_directory;
+  const File user_directory = *temporary_directory.Parent();
+
+  REQUIRE(user_directory.Name() == "huxerui-" + std::to_string(geteuid()));
+  REQUIRE(Permissions(user_directory.Path()) == 0700);
+  REQUIRE(Permissions(temporary_directory.Path()) == 0700);
+}
+
+TEST_CASE("LinuxFileSystemRefusesAnInsecureTemporaryFallback") {
+  TemporaryDirectory temporary;
+  const std::string executable_directory = temporary.CreateDirectory("bin", fs::perms::owner_all);
+  const std::string fallback = temporary.CreateDirectory("fallback", fs::perms::owner_all);
+  const std::string executable = File(executable_directory).Child("sample").Path();
+  detail::LinuxFileSystemEnvironment environment = Environment(temporary, {});
+  environment.fallback_temporary_root = fallback;
+  static_cast<void>(temporary.CreateDirectory(
+      "fallback/huxerui-" + std::to_string(geteuid()),
+      fs::perms::owner_all | fs::perms::group_read
+  ));
+
+  REQUIRE_THROWS_AS(detail::CreateLinuxFileSystem(executable, environment), std::runtime_error);
+}
+
+TEST_CASE("LinuxExecutablePathDoesNotDependOnTheWorkingDirectory") {
+  TemporaryDirectory temporary;
+  CurrentDirectoryScope current_directory;
+  const std::string before = detail::ResolveLinuxExecutablePath();
+  fs::current_path(fs::path(temporary.Path()));
+  const std::string after = detail::ResolveLinuxExecutablePath();
+
+  REQUIRE(after == before);
+  REQUIRE(File(after).Parent().has_value());
+  REQUIRE(File(after).Parent()->Path() != temporary.Path());
+}
+
+} // namespace huxerui::test


### PR DESCRIPTION
## Summary

Add the existing `FileSystem` Root Service to the Linux Runtime without changing the public API.

The Linux implementation now:

- resolves the running executable through `/proc/self/exe` with a dynamically resized `readlink` buffer;
- uses the executable's UTF-8 filename as the per-application storage identity;
- derives the executable directory from `/proc/self/exe`, independently of the process working directory;
- follows the XDG Base Directory rules for durable data, cache data, and runtime files;
- creates a UID-isolated, owner-only temporary fallback when `XDG_RUNTIME_DIR` is unavailable or unsafe;
- installs the resolved directories through the shared `MakeFileSystem()` implementation so the existing root-protection behavior remains consistent across platforms.

## Directory mapping

| Root service directory | Linux location |
| --- | --- |
| `data_directory` | `$XDG_DATA_HOME/<executable-name>`, or `$HOME/.local/share/<executable-name>` |
| `cache_directory` | `$XDG_CACHE_HOME/<executable-name>`, or `$HOME/.cache/<executable-name>` |
| `temporary_directory` | `$XDG_RUNTIME_DIR/<executable-name>` when the runtime directory is safe; otherwise `<system-temp>/huxerui-<effective-uid>/<executable-name>` |
| `executable_directory` | Parent directory of `/proc/self/exe` |

Only non-empty, absolute, valid UTF-8 XDG paths are accepted. Invalid XDG values are ignored. If `HOME` is unavailable or invalid, the implementation falls back to the effective user's passwd entry; initialization fails with a `HuxerUI` runtime error if neither source provides a usable home directory.

The executable filename intentionally defines application identity. Renaming a binary selects different storage, while separate binaries with the same filename share the same per-user XDG application directories.

## Temporary-directory safety

`XDG_RUNTIME_DIR` is used only when `lstat` confirms that it is:

- a real directory rather than a symbolic link;
- owned by the current effective UID;
- permissioned exactly as `0700`, with no group or other access.

When those conditions are not met, HuxerUI uses the system temporary directory and creates both the `huxerui-<effective-uid>` directory and its application child with mode `0700`. Existing fallback directories are validated before use, and initialization fails instead of reusing a directory with an unsafe type, owner, or permission mode.

## Implementation details

- Add `ResolveLinuxExecutablePath()` for dynamically sized `/proc/self/exe` resolution and UTF-8 validation.
- Add injectable Linux environment/path resolution helpers so XDG, passwd, temporary-root, and effective-UID behavior can be tested without mutating process-global environment state.
- Override Linux `CreateFileSystem()` and register the implementation in the Linux platform source list.
- Reuse the executable-path resolver for the Linux resource root instead of maintaining a second `/proc/self/exe` implementation.
- Enable the existing `example_files` target on Linux.
- Update the file guide, platform support guide, and file-system design documentation with the Linux mapping, security requirements, and executable-name identity consequences.

## Tests

Focused Linux FileSystem coverage includes:

- complete XDG mapping with a Unicode executable filename;
- relative and invalid UTF-8 XDG values, plus passwd-home fallback;
- unsafe runtime directories caused by ownership, permissions, or symbolic links;
- creation of application directories and shared root deletion protection;
- UID-isolated fallback directories and enforced `0700` permissions;
- rejection of an existing insecure temporary fallback;
- `/proc/self/exe` resolution remaining stable after changing the process working directory.

Validation performed on Linux:

- `./build/bin/huxerui_linux_file_tests --reporter compact` — passed, 49 assertions in 7 test cases.
- `cmake --build build --target example_files --parallel 2` — passed.
- `git diff --check` — passed.
- Worktree remained clean after validation.

The full `huxerui_tests` target could not be rebuilt with the host's Arch GCC `16.1.1 20260625`: GCC encounters an internal compiler error in the pre-existing coroutine expression at `tests/runtime/http.cpp:143` (`gimple_add_tmp_var`, `gimplify.cc:841`). The failure is outside this change. A reduced reproducer also fails with GCC 14.3 through 16.1 and compiles with GCC 16.2 and trunk, consistent with the upstream `co_await`/`TARGET_EXPR` fix in [GCC PR121094](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121094).
