### PR TITLE
feat(linux): add portal file picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ See [Platform Support](docs/platform-support.md) for backend responsibilities an
 | `example_lifecycle` | Component setup, dependency restarts, and unmount cleanup |
 | `example_task` | Coroutine tasks, structured cancellation, Lifecycle launch, and direct State updates |
 | `example_http` | Windows, macOS, iOS, Linux, Android, and Web platform HTTP requests, Task resumption, response status, and transport errors |
-| `example_files` | macOS, iOS, Android, and Web application directories, UTF-8 local files, asynchronous operations, persistence, and Task resumption |
+| `example_files` | macOS, Linux, iOS, Android, and Web application directories, UTF-8 local files, external pickers, asynchronous operations, persistence, and Task resumption |
 | `example_canvas` | Tabbed Canvas effects, retained transforms, paths, clipping, and shadows |
 | `example_image` | Raster variants, compiled SVG resources, VectorAsset tint, localized strings, and Image fitting |
 | `example_window_chrome` | Application-defined desktop title-bar content with platform-appropriate window controls |

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -11,6 +11,7 @@ function(huxerui_platform_configure)
     pkg_check_modules(HUXERUI_XRANDR REQUIRED IMPORTED_TARGET xrandr)
     pkg_check_modules(HUXERUI_EGL REQUIRED IMPORTED_TARGET egl)
     pkg_check_modules(HUXERUI_GLES2 REQUIRED IMPORTED_TARGET glesv2)
+    pkg_check_modules(HUXERUI_GIO REQUIRED IMPORTED_TARGET gio-2.0)
     pkg_check_modules(HUXERUI_LIBSOUP QUIET IMPORTED_TARGET libsoup-3.0>=3.0)
     if(NOT TARGET PkgConfig::HUXERUI_LIBSOUP)
         message(FATAL_ERROR
@@ -274,6 +275,7 @@ function(huxerui_platform_configure)
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_adapter.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_external_texture.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_file.cpp"
+            "${HUXERUI_PROJECT_DIR}/platform/linux/linux_file_picker.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_http.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_renderer.cpp"
             "${HUXERUI_PROJECT_DIR}/platform/linux/linux_text_input.cpp"
@@ -320,6 +322,7 @@ function(huxerui_platform_configure)
             PkgConfig::HUXERUI_XRANDR
             PkgConfig::HUXERUI_EGL
             PkgConfig::HUXERUI_GLES2
+            PkgConfig::HUXERUI_GIO
             PkgConfig::HUXERUI_LIBSOUP
             PARENT_SCOPE
     )

--- a/docs/design/files.md
+++ b/docs/design/files.md
@@ -4,8 +4,7 @@
 
 This document defines the public API, ownership, error, threading, path, picker, external-reference, and platform contracts for files and application storage.
 The shared `File`, `FileInfo`, `FileResult<T>`, `FileSystem`, `FileReference`, and `FilePicker` surfaces, bounded platform asynchronous executor, Runtime service integration, Windows, macOS, Linux, iOS, Android, and Web local implementations, focused local-file example, and fake picker/reference tests are implemented.
-The Windows, macOS, iOS, Android, and Web picker/reference transports and the external-file flows in the focused example are also implemented.
-The Linux picker/reference transport remains proposed.
+The Windows, macOS, Linux, iOS, Android, and Web picker/reference transports and the external-file flows in the focused example are also implemented.
 
 ## Goals
 
@@ -554,7 +553,14 @@ Temporary data uses `<XDG_RUNTIME_DIR>/<executable-name>` only when the runtime 
 Otherwise it uses `<system-temporary-directory>/huxerui-<effective-uid>/<executable-name>` and requires both created children to remain owner-only directories.
 An unsafe existing fallback directory fails initialization rather than being reused.
 Renaming the executable selects different storage, and executable files with the same name share one per-user application directory.
-Its proposed picker transport prefers the desktop portal for active selection.
+Its picker transport uses `org.freedesktop.portal.FileChooser` through GDBus on a dedicated GLib main-context thread and reports both capabilities as unavailable when the session bus or portal service cannot be reached.
+The current X11 window is encoded as `x11:<hex-xid>` for the portal parent, or as an empty parent before the window is ready.
+One unpredictable handle token is used per request, the predicted Request path is subscribed before the method call, and a backend-returned legacy path replaces that subscription when necessary.
+Task cancellation completes the transport operation immediately and closes the portal Request so Runtime-level picker serialization can advance without waiting for a Response that will not arrive after Close.
+Filters map extensions to glob rules and MIME values to MIME rules inside one union filter.
+Successful `file://` results remain private Linux `FileReference` state; metadata reflects the selected file, while reads, imports, replacements, and save copies reuse the shared bounded native file executor.
+Saving reports success only after the source file has been copied over the portal-confirmed destination.
+This implementation does not add GTK or Qt fallback dialogs, Wayland parent handles, directory selection, or persistent grants.
 
 Web maps application-private storage through the browser filesystem design below and has no executable directory.
 Its picker transport uses browser file handles when available and an input-element fallback for opening; unsupported save capabilities remain visible through the capability contract.
@@ -682,6 +688,9 @@ Shared local-file tests use isolated temporary directories to cover empty and no
 Shared fake picker and reference tests cover single and multiple selection, active and queued cancellation, unsupported capabilities, filter validation, serialized presentation, grant retention, import and replacement, and UI-thread resumption.
 Each platform picker phase adds revoked-access, Runtime-teardown, platform dismissal, and grant-cleanup coverage appropriate to that platform.
 
+Linux picker integration tests use `GTestDBus` with a private bus and fake `org.freedesktop.portal.Desktop` service.
+They cover capability probing, X11 parenting, filter and suggested-name wire values, predicted and returned Request handles, success and failure responses, URI validation, cancellation with Request.Close, late responses, metadata, reference I/O, and completed save copies without displaying desktop UI.
+
 Each platform phase verifies its application-directory mapping, Unicode conversion, protected roots, platform picker mapping, platform failure mapping, asynchronous execution, and grant cleanup without claiming unavailable implementations.
 
 Web storage validation should additionally cover initial restoration before Runtime mounting, persistence across page reloads, temporary-data loss across reloads, isolation between two storage keys on one origin, rejection of synchronous persistent mutation without an in-memory change, serialized asynchronous persistence, IndexedDB failure mapping, cancellation, Runtime teardown, and reuse of one initialized mount by multiple Runtime instances.
@@ -689,4 +698,3 @@ Web storage validation should additionally cover initial restoration before Runt
 ## Remaining delivery sequence
 
 - Expand Web browser integration coverage for persistence failure, storage eviction, and multiple sessions without changing the shared file contract.
-- Implement the Linux picker adapter without expanding the shared contract into application activation, directory selection, persistent grants, drag-and-drop, or clipboard APIs.

--- a/docs/files.md
+++ b/docs/files.md
@@ -2,7 +2,7 @@
 
 HuxerUI represents local paths with `File` and publishes application-owned directories through the Runtime-installed `FileSystem` Root Service.
 The current application-directory implementation supports Windows, macOS, Linux, iOS, Android, and Web.
-The shared `FileReference` and `FilePicker` contract and its Windows, macOS, iOS, Android, and Web platform adapters are available; the Linux picker adapter remains staged work.
+The shared `FileReference` and `FilePicker` contract and its Windows, macOS, Linux, iOS, Android, and Web platform adapters are available.
 
 ## Application directories
 
@@ -139,6 +139,11 @@ Selected `content://` values remain inside `FileReference`, require no broad sto
 On Windows, opening and saving use the system file dialogs owned by the HuxerUI window.
 Selected filesystem paths remain private to `FileReference`; reads, imports, replacements, and save copies run on the bounded platform file executor instead of blocking the UI thread.
 Extensions and MIME types are translated into advisory system filters, while unsupported MIME mappings widen the filter rather than hiding valid files.
+
+On Linux, opening and saving use `org.freedesktop.portal.FileChooser` on the session D-Bus without a GTK or Qt fallback.
+The adapter supplies the current X11 window identifier when available, retains returned `file://` locations privately inside `FileReference`, and performs reads, imports, replacements, and save copies on the shared bounded file executor.
+If the session bus or xdg-desktop-portal service is unavailable, both picker capability predicates return `false` while local `FileSystem` access remains available.
+Canceling an active Task closes the corresponding portal Request so the next serialized picker operation can begin.
 
 On Web, opening prefers the File System Access API and falls back to a transient `<input type="file">` where that API is unavailable.
 Handle-backed references can report write support, while input-backed references remain read-only; both can be read or imported into application storage.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,7 +146,7 @@ Debian or Ubuntu:
 
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential cmake git pkg-config meson ninja-build gperf nasm \
+sudo apt-get install build-essential cmake git pkg-config meson ninja-build gperf nasm libglib2.0-dev \
     libx11-dev libxext-dev libxkbcommon-dev libxrandr-dev \
     libegl1-mesa-dev libgles2-mesa-dev libsoup-3.0-dev
 ```
@@ -154,7 +154,7 @@ sudo apt-get install build-essential cmake git pkg-config meson ninja-build gper
 Fedora:
 
 ```bash
-sudo dnf install gcc-c++ cmake git pkgconf-pkg-config meson ninja-build gperf nasm \
+sudo dnf install gcc-c++ cmake git pkgconf-pkg-config meson ninja-build gperf nasm glib2-devel \
     libX11-devel libXext-devel libxkbcommon-devel libXrandr-devel \
     libglvnd-devel libsoup3-devel
 ```
@@ -163,11 +163,11 @@ Arch Linux:
 
 ```bash
 sudo pacman -S --needed base-devel cmake git pkgconf meson ninja gperf nasm \
-    libx11 libxext libxkbcommon libxrandr libglvnd libsoup3
+    libx11 libxext libxkbcommon libxrandr libglvnd glib2 libsoup3
 ```
 
-`libsoup-3.0` is a required system dynamic library and is not part of HuxerUI's fetched static dependency stack.
-The selected package must provide `libsoup-3.0.pc`, the headers, and the shared library; GLib/GIO and TLS support are installed through its distribution dependencies.
+`gio-2.0` and `libsoup-3.0` are required system dynamic libraries and are not part of HuxerUI's fetched static dependency stack.
+The selected packages must provide their pkg-config metadata, headers, and shared libraries; TLS support is installed through the distribution dependencies.
 
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
@@ -175,7 +175,7 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-The Linux backend resolves the manually installed X11, Xext, XKB common, XRandR, EGL, OpenGL ES 2, and libsoup 3 packages through pkg-config.
+The Linux backend resolves the manually installed X11, Xext, XKB common, XRandR, EGL, OpenGL ES 2, GIO, and libsoup 3 packages through pkg-config.
 Source-checkout builds fetch the pinned Cairo, FreeType, HarfBuzz, fontconfig, pixman, libpng, libjpeg, zlib, and expat stack and require the upstream build tools reported by CMake.
 Host tools are distributed as prebuilt executables under `tools/prebuilt/linux/<architecture>/` and CMake stops configuration when a matching host package is unavailable.
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -119,6 +119,9 @@ Canvas Paths map to Cairo path geometry for fill, stroke, clipping, and blurred 
 Packaged resources are read from the executable-specific `<name>.resources` directory (overridable with `HUXERUI_RESOURCES_DIR`), locale and `Xft.dpi` changes update the Runtime resource configuration, and libpng/libjpeg decoding produces Cairo bitmap cache entries with a bounded byte budget.
 FileSystem uses the executable filename as its application identity, maps durable and cache files through `XDG_DATA_HOME` and `XDG_CACHE_HOME` with standard home-directory fallbacks, and obtains the executable directory from `/proc/self/exe` rather than the working directory.
 Temporary files use an owner-only application child under a valid `XDG_RUNTIME_DIR`, or an owner-only `huxerui-<uid>` subtree of the system temporary directory when the runtime directory is unavailable or unsafe.
+FilePicker uses `org.freedesktop.portal.FileChooser` on the session D-Bus and passes the current X11 window as an `x11:<hex-xid>` parent when available.
+Portal `file://` results remain private inside FileReference, while reads, imports, replacements, and completed save copies reuse the shared bounded file executor.
+The picker capabilities are unavailable when the session bus or xdg-desktop-portal service cannot be reached; the backend does not fall back to GTK or Qt dialogs.
 
 Text input uses the X Input Method protocol with full preedit callbacks, mirroring the Windows IMM32 adapter; when no input method is available the backend degrades gracefully to direct key text.
 Clipboard reads and writes use the X11 `CLIPBOARD` selection with UTF-8 string transfers.
@@ -130,7 +133,7 @@ This path is bounded and does not claim zero-copy or direct DMA-BUF import.
 The Linux `example_platform_module` registers a platform-neutral timer factory backed by `timerfd` and a background RGBA color stream, exposing the same typed Root Services and disposal behavior as the other supported platform implementations.
 HttpClient uses one libsoup 3 Session on a dedicated GLib network thread, preserving connection reuse, redirects, system proxy configuration, and the system TLS trust store without adding network descriptors to the X11 event loop.
 Requests and responses remain complete in-memory values, GCancellable backs Task cancellation, and a GLib timeout source enforces the complete request deadline.
-X11, Xext, XKB common, XRandR, EGL, OpenGL ES 2, and libsoup 3 are manually installed system dependencies resolved through pkg-config; source-checkout builds do not download them.
+X11, Xext, XKB common, XRandR, EGL, OpenGL ES 2, GIO, and libsoup 3 are manually installed system dependencies resolved through pkg-config; source-checkout builds do not download them.
 Source-checkout builds fetch only the pinned graphics, text, image, and compression libraries used by the renderer.
 Following the Windows and macOS distribution model, Linux host tools are distributed as prebuilt executables under `tools/prebuilt/linux/<architecture>/`.
 The CLI records Linux enablement under `platform/linux`, builds the root CMake application in `.huxerui/build/linux/<profile>`, and launches the exact executable recorded by generated application integration metadata.

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -33,6 +33,7 @@
 #include <huxerui/app.h>
 
 #include "linux_file_internal.h"
+#include "linux_file_picker_internal.h"
 #include "linux_http_internal.h"
 #include "linux_renderer.h"
 #include "linux_text_input.h"
@@ -277,6 +278,10 @@ public:
 
   std::shared_ptr<FileSystem> CreateFileSystem() override {
     return CreateLinuxFileSystem();
+  }
+
+  std::shared_ptr<FilePickerTransport> CreateFilePickerTransport() override {
+    return CreateLinuxFilePickerTransport([this] { return static_cast<unsigned long>(window_); });
   }
 
   std::shared_ptr<HttpTransport> CreateHttpTransport() override {

--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -1,0 +1,1097 @@
+#include "linux_internal.h"
+
+#include "linux_file_picker_internal.h"
+
+#include <gio/gio.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "file_internal.h"
+
+namespace huxerui::detail {
+
+namespace {
+
+constexpr const char* kPortalService = "org.freedesktop.portal.Desktop";
+constexpr const char* kPortalObject = "/org/freedesktop/portal/desktop";
+constexpr const char* kFileChooserInterface = "org.freedesktop.portal.FileChooser";
+constexpr const char* kRequestInterface = "org.freedesktop.portal.Request";
+constexpr int kPortalCallTimeoutMs = 5000;
+
+template <class Type, void (*Release)(Type*)> class GObjectHandle final {
+public:
+  GObjectHandle() = default;
+  explicit GObjectHandle(Type* value) : value_(value) {}
+
+  ~GObjectHandle() {
+    Reset();
+  }
+
+  GObjectHandle(const GObjectHandle&) = delete;
+  GObjectHandle& operator=(const GObjectHandle&) = delete;
+
+  GObjectHandle(GObjectHandle&& other) noexcept : value_(std::exchange(other.value_, nullptr)) {}
+
+  GObjectHandle& operator=(GObjectHandle&& other) noexcept {
+    if (this != &other) {
+      Reset(std::exchange(other.value_, nullptr));
+    }
+    return *this;
+  }
+
+  [[nodiscard]] Type* Get() const noexcept {
+    return value_;
+  }
+
+  [[nodiscard]] Type* ReleaseValue() noexcept {
+    return std::exchange(value_, nullptr);
+  }
+
+  void Reset(Type* value = nullptr) noexcept {
+    if (value_ != nullptr) {
+      Release(value_);
+    }
+    value_ = value;
+  }
+
+private:
+  Type* value_ = nullptr;
+};
+
+using VariantHandle = GObjectHandle<GVariant, g_variant_unref>;
+
+class ErrorHandle final {
+public:
+  ErrorHandle() = default;
+
+  ~ErrorHandle() {
+    if (value_ != nullptr) {
+      g_error_free(value_);
+    }
+  }
+
+  ErrorHandle(const ErrorHandle&) = delete;
+  ErrorHandle& operator=(const ErrorHandle&) = delete;
+
+  [[nodiscard]] GError** Address() noexcept {
+    return &value_;
+  }
+
+private:
+  GError* value_ = nullptr;
+};
+
+std::optional<std::string> SessionBusAddress() {
+  ErrorHandle error;
+  char* address = g_dbus_address_get_for_bus_sync(G_BUS_TYPE_SESSION, nullptr, error.Address());
+  if (address == nullptr) {
+    return std::nullopt;
+  }
+  std::string result(address);
+  g_free(address);
+  return result;
+}
+
+bool NameHasOwner(GDBusConnection* connection, std::string_view name) {
+  ErrorHandle error;
+  VariantHandle reply(g_dbus_connection_call_sync(
+      connection,
+      "org.freedesktop.DBus",
+      "/org/freedesktop/DBus",
+      "org.freedesktop.DBus",
+      "NameHasOwner",
+      g_variant_new("(s)", std::string(name).c_str()),
+      G_VARIANT_TYPE("(b)"),
+      G_DBUS_CALL_FLAGS_NONE,
+      kPortalCallTimeoutMs,
+      nullptr,
+      error.Address()
+  ));
+  if (reply.Get() == nullptr) {
+    return false;
+  }
+  gboolean owned = false;
+  g_variant_get(reply.Get(), "(b)", &owned);
+  return owned;
+}
+
+bool StartService(GDBusConnection* connection, std::string_view name) {
+  ErrorHandle error;
+  VariantHandle reply(g_dbus_connection_call_sync(
+      connection,
+      "org.freedesktop.DBus",
+      "/org/freedesktop/DBus",
+      "org.freedesktop.DBus",
+      "StartServiceByName",
+      g_variant_new("(su)", std::string(name).c_str(), 0U),
+      G_VARIANT_TYPE("(u)"),
+      G_DBUS_CALL_FLAGS_NONE,
+      kPortalCallTimeoutMs,
+      nullptr,
+      error.Address()
+  ));
+  return reply.Get() != nullptr;
+}
+
+class PortalConnection final : public std::enable_shared_from_this<PortalConnection> {
+public:
+  static std::shared_ptr<PortalConnection> Create(std::optional<std::string> bus_address) {
+    auto connection = std::shared_ptr<PortalConnection>(new PortalConnection(std::move(bus_address)));
+    if (!connection->Start()) {
+      return {};
+    }
+    return connection;
+  }
+
+  ~PortalConnection() {
+    Stop();
+    if (loop_ != nullptr) {
+      g_main_loop_unref(loop_);
+    }
+    if (context_ != nullptr) {
+      g_main_context_unref(context_);
+    }
+  }
+
+  PortalConnection(const PortalConnection&) = delete;
+  PortalConnection& operator=(const PortalConnection&) = delete;
+
+  [[nodiscard]] GDBusConnection* Native() const noexcept {
+    return connection_;
+  }
+
+  [[nodiscard]] bool Available() const noexcept {
+    return available_.load(std::memory_order_acquire);
+  }
+
+  [[nodiscard]] std::uint64_t ObserveUnavailable(std::function<void()> callback) {
+    if (!Available()) {
+      callback();
+      return 0;
+    }
+    const std::uint64_t identifier = next_observer_identifier_++;
+    unavailable_observers_.emplace(identifier, std::move(callback));
+    return identifier;
+  }
+
+  void RemoveUnavailableObserver(std::uint64_t identifier) noexcept {
+    if (identifier != 0) {
+      unavailable_observers_.erase(identifier);
+    }
+  }
+
+  void BeginMethodCall() noexcept {
+    // A late method reply can replace the predicted request path, so shutdown must keep this context alive to close it.
+    ++pending_method_calls_;
+  }
+
+  void EndMethodCall() noexcept {
+    if (pending_method_calls_ != 0) {
+      --pending_method_calls_;
+    }
+    if (shutdown_requested_ && pending_method_calls_ == 0) {
+      g_main_loop_quit(loop_);
+    }
+  }
+
+  [[nodiscard]] bool Invoke(std::function<void()> callback) noexcept {
+    try {
+      {
+        std::scoped_lock lock(mutex_);
+        if (!running_ || stopping_) {
+          return false;
+        }
+      }
+      struct Invocation {
+        std::function<void()> callback;
+      };
+      auto* invocation = new Invocation{std::move(callback)};
+      g_main_context_invoke_full(
+          context_,
+          G_PRIORITY_DEFAULT,
+          [](gpointer data) -> gboolean {
+            auto* value = static_cast<Invocation*>(data);
+            try {
+              value->callback();
+            } catch (...) {
+            }
+            return G_SOURCE_REMOVE;
+          },
+          invocation,
+          [](gpointer data) { delete static_cast<Invocation*>(data); }
+      );
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  void Stop() noexcept {
+    std::thread thread;
+    {
+      std::scoped_lock lock(mutex_);
+      if (!thread_.joinable()) {
+        return;
+      }
+      stopping_ = true;
+      thread = std::move(thread_);
+    }
+    g_main_context_invoke_full(
+        context_,
+        G_PRIORITY_LOW,
+        [](gpointer data) -> gboolean {
+          static_cast<PortalConnection*>(data)->RequestStop();
+          return G_SOURCE_REMOVE;
+        },
+        this,
+        nullptr
+    );
+    thread.join();
+  }
+
+private:
+  explicit PortalConnection(std::optional<std::string> bus_address)
+      : bus_address_(std::move(bus_address)), context_(g_main_context_new()), loop_(g_main_loop_new(context_, false)) {}
+
+  bool Start() {
+    thread_ = std::thread([this] { Run(); });
+    std::unique_lock lock(mutex_);
+    ready_condition_.wait(lock, [this] { return ready_; });
+    if (Available()) {
+      return true;
+    }
+    lock.unlock();
+    thread_.join();
+    return false;
+  }
+
+  void Run() noexcept {
+    g_main_context_push_thread_default(context_);
+    try {
+      const std::optional<std::string> address = bus_address_.has_value() ? bus_address_ : SessionBusAddress();
+      if (address.has_value()) {
+        ErrorHandle error;
+        connection_ = g_dbus_connection_new_for_address_sync(
+            address->c_str(),
+            static_cast<GDBusConnectionFlags>(
+                G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION
+            ),
+            nullptr,
+            nullptr,
+            error.Address()
+        );
+      }
+      if (connection_ != nullptr) {
+        owner_subscription_ = g_dbus_connection_signal_subscribe(
+            connection_,
+            "org.freedesktop.DBus",
+            "org.freedesktop.DBus",
+            "NameOwnerChanged",
+            "/org/freedesktop/DBus",
+            kPortalService,
+            G_DBUS_SIGNAL_FLAGS_NONE,
+            [](GDBusConnection*,
+               const gchar*,
+               const gchar*,
+               const gchar*,
+               const gchar*,
+               GVariant* parameters,
+               gpointer data) {
+              const char* name = nullptr;
+              const char* old_owner = nullptr;
+              const char* new_owner = nullptr;
+              g_variant_get(parameters, "(&s&s&s)", &name, &old_owner, &new_owner);
+              static_cast<void>(name);
+              static_cast<void>(old_owner);
+              static_cast<PortalConnection*>(data)->PortalOwnerChanged(new_owner);
+            },
+            this,
+            nullptr
+        );
+        closed_handler_ = g_signal_connect(
+            connection_,
+            "closed",
+            G_CALLBACK(+[](GDBusConnection*, gboolean, GError*, gpointer data) {
+              static_cast<PortalConnection*>(data)->ConnectionClosed();
+            }),
+            this
+        );
+      }
+      available_.store(
+          connection_ != nullptr &&
+              (NameHasOwner(connection_, kPortalService) || StartService(connection_, kPortalService)),
+          std::memory_order_release
+      );
+    } catch (...) {
+      available_.store(false, std::memory_order_release);
+    }
+    {
+      std::scoped_lock lock(mutex_);
+      running_ = Available();
+      ready_ = true;
+    }
+    ready_condition_.notify_all();
+    if (Available()) {
+      g_main_loop_run(loop_);
+    }
+    {
+      std::scoped_lock lock(mutex_);
+      running_ = false;
+    }
+    available_.store(false, std::memory_order_release);
+    if (connection_ != nullptr) {
+      if (owner_subscription_ != 0) {
+        g_dbus_connection_signal_unsubscribe(connection_, owner_subscription_);
+        owner_subscription_ = 0;
+      }
+      if (closed_handler_ != 0) {
+        g_signal_handler_disconnect(connection_, closed_handler_);
+        closed_handler_ = 0;
+      }
+      if (!g_dbus_connection_is_closed(connection_)) {
+        // Request.Close replies are intentionally ignored, but their calls must reach the bus before the connection closes.
+        static_cast<void>(g_dbus_connection_flush_sync(connection_, nullptr, nullptr));
+        static_cast<void>(g_dbus_connection_close_sync(connection_, nullptr, nullptr));
+      }
+      g_object_unref(connection_);
+      connection_ = nullptr;
+    }
+    g_main_context_pop_thread_default(context_);
+  }
+
+  void PortalOwnerChanged(const char* new_owner) noexcept {
+    if (new_owner != nullptr && new_owner[0] != '\0') {
+      available_.store(true, std::memory_order_release);
+      return;
+    }
+    NotifyUnavailable();
+  }
+
+  void ConnectionClosed() noexcept {
+    {
+      std::scoped_lock lock(mutex_);
+      running_ = false;
+    }
+    NotifyUnavailable();
+    RequestStop();
+  }
+
+  void RequestStop() noexcept {
+    shutdown_requested_ = true;
+    if (pending_method_calls_ == 0) {
+      g_main_loop_quit(loop_);
+    }
+  }
+
+  void NotifyUnavailable() noexcept {
+    available_.store(false, std::memory_order_release);
+    std::unordered_map<std::uint64_t, std::function<void()>> observers = std::move(unavailable_observers_);
+    unavailable_observers_.clear();
+    for (auto& [identifier, callback] : observers) {
+      static_cast<void>(identifier);
+      try {
+        callback();
+      } catch (...) {
+      }
+    }
+  }
+
+  std::optional<std::string> bus_address_;
+  GMainContext* context_ = nullptr;
+  GMainLoop* loop_ = nullptr;
+  GDBusConnection* connection_ = nullptr;
+  guint owner_subscription_ = 0;
+  gulong closed_handler_ = 0;
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable ready_condition_;
+  std::unordered_map<std::uint64_t, std::function<void()>> unavailable_observers_;
+  std::uint64_t next_observer_identifier_ = 1;
+  std::size_t pending_method_calls_ = 0;
+  std::atomic<bool> available_ = false;
+  bool ready_ = false;
+  bool running_ = false;
+  bool stopping_ = false;
+  bool shutdown_requested_ = false;
+};
+
+std::string UniqueToken() {
+  char* uuid = g_uuid_string_random();
+  std::string token = "huxerui_" + std::string(uuid != nullptr ? uuid : "request");
+  g_free(uuid);
+  std::replace(token.begin(), token.end(), '-', '_');
+  return token;
+}
+
+std::string ExpectedRequestPath(GDBusConnection* connection, std::string_view token) {
+  const char* unique_name = g_dbus_connection_get_unique_name(connection);
+  if (unique_name == nullptr || unique_name[0] == '\0') {
+    return {};
+  }
+  std::string sender(unique_name[0] == ':' ? unique_name + 1 : unique_name);
+  std::replace(sender.begin(), sender.end(), '.', '_');
+  return "/org/freedesktop/portal/desktop/request/" + sender + "/" + std::string(token);
+}
+
+GVariant* PickerFilterVariant(const FilePickerFilter& filter) {
+  GVariantBuilder rules;
+  g_variant_builder_init(&rules, G_VARIANT_TYPE("a(us)"));
+  for (const std::string& extension : filter.extensions) {
+    const std::string pattern = "*." + extension;
+    g_variant_builder_add(&rules, "(us)", 0U, pattern.c_str());
+  }
+  for (const std::string& content_type : filter.content_types) {
+    g_variant_builder_add(&rules, "(us)", 1U, content_type.c_str());
+  }
+  return g_variant_new("(s@a(us))", filter.name.c_str(), g_variant_builder_end(&rules));
+}
+
+GVariant* OpenOptions(const FilePickerFilter& filter, bool multiple, std::string_view token) {
+  GVariantBuilder options;
+  g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(std::string(token).c_str()));
+  g_variant_builder_add(&options, "{sv}", "modal", g_variant_new_boolean(true));
+  g_variant_builder_add(&options, "{sv}", "multiple", g_variant_new_boolean(multiple));
+  if (!filter.name.empty()) {
+    GVariantBuilder filters;
+    g_variant_builder_init(&filters, G_VARIANT_TYPE("a(sa(us))"));
+    g_variant_builder_add_value(&filters, PickerFilterVariant(filter));
+    g_variant_builder_add(&options, "{sv}", "filters", g_variant_builder_end(&filters));
+    g_variant_builder_add(&options, "{sv}", "current_filter", PickerFilterVariant(filter));
+  }
+  return g_variant_builder_end(&options);
+}
+
+GVariant* SaveOptionsVariant(const SaveFileOptions& options, std::string_view current_name, std::string_view token) {
+  GVariantBuilder values;
+  g_variant_builder_init(&values, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_add(&values, "{sv}", "handle_token", g_variant_new_string(std::string(token).c_str()));
+  g_variant_builder_add(&values, "{sv}", "modal", g_variant_new_boolean(true));
+  g_variant_builder_add(&values, "{sv}", "current_name", g_variant_new_string(std::string(current_name).c_str()));
+  if (!options.filter.name.empty()) {
+    GVariantBuilder filters;
+    g_variant_builder_init(&filters, G_VARIANT_TYPE("a(sa(us))"));
+    g_variant_builder_add_value(&filters, PickerFilterVariant(options.filter));
+    g_variant_builder_add(&values, "{sv}", "filters", g_variant_builder_end(&filters));
+    g_variant_builder_add(&values, "{sv}", "current_filter", PickerFilterVariant(options.filter));
+  }
+  return g_variant_builder_end(&values);
+}
+
+std::optional<File> FileFromPortalUri(std::string_view uri) {
+  ErrorHandle error;
+  char* hostname = nullptr;
+  char* path = g_filename_from_uri(std::string(uri).c_str(), &hostname, error.Address());
+  std::unique_ptr<char, decltype(&g_free)> owned_path(path, g_free);
+  std::unique_ptr<char, decltype(&g_free)> owned_hostname(hostname, g_free);
+  if (path == nullptr || (hostname != nullptr && hostname[0] != '\0')) {
+    return std::nullopt;
+  }
+  try {
+    File file(path);
+    if (file.Name().empty()) {
+      return std::nullopt;
+    }
+    return file;
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+std::optional<std::string> ContentType(const File& file) {
+  gboolean uncertain = false;
+  char* guessed = g_content_type_guess(file.Path().c_str(), nullptr, 0, &uncertain);
+  static_cast<void>(uncertain);
+  std::unique_ptr<char, decltype(&g_free)> owned_guessed(guessed, g_free);
+  if (guessed == nullptr) {
+    return std::nullopt;
+  }
+  char* mime = g_content_type_get_mime_type(guessed);
+  std::unique_ptr<char, decltype(&g_free)> owned_mime(mime, g_free);
+  if (mime == nullptr || mime[0] == '\0') {
+    return std::nullopt;
+  }
+  return std::string(mime);
+}
+
+class LinuxFileReferenceState final : public FileReferenceState {
+public:
+  explicit LinuxFileReferenceState(File file) : file_(std::move(file)) {}
+
+  std::function<void()> ReadBytes(FileReferenceBytesCompletion completion) override {
+    const File file = file_;
+    EnqueueFileOperation([file, completion = std::move(completion)]() mutable {
+      FileResult<std::vector<std::byte>> result = [&] {
+        try {
+          return file.ReadBytes();
+        } catch (...) {
+          return FileResult<std::vector<std::byte>>(FileError{
+              FileErrorCode::Io,
+              "HuxerUI Linux external file read failed",
+          });
+        }
+      }();
+      completion(std::move(result));
+    });
+    return {};
+  }
+
+  std::function<void()> ImportTo(File destination, bool overwrite, FileReferenceBoolCompletion completion) override {
+    const File file = file_;
+    EnqueueFileOperation(
+        [file, destination = std::move(destination), overwrite, completion = std::move(completion)]() mutable {
+          try {
+            completion(file.CopyTo(destination, overwrite));
+          } catch (...) {
+            completion(false);
+          }
+        }
+    );
+    return {};
+  }
+
+  std::function<void()> ReplaceWith(File source, FileReferenceBoolCompletion completion) override {
+    const File destination = file_;
+    EnqueueFileOperation([source = std::move(source), destination, completion = std::move(completion)]() mutable {
+      try {
+        completion(source.CopyTo(destination, true));
+      } catch (...) {
+        completion(false);
+      }
+    });
+    return {};
+  }
+
+private:
+  File file_;
+};
+
+std::optional<FileReference> MakeLinuxFileReference(const File& file) {
+  FileReferenceMetadata metadata{
+      .name = file.Name(),
+      .size = std::nullopt,
+      .content_type = std::nullopt,
+      .can_write = false,
+  };
+  const FileResult<FileInfo> info = file.Stat();
+  if (info.Succeeded()) {
+    if (info.Value().type == FileType::Directory) {
+      return std::nullopt;
+    }
+    if (info.Value().type == FileType::File) {
+      metadata.size = info.Value().size;
+    }
+  }
+  metadata.content_type = ContentType(file);
+  metadata.can_write = access(file.Path().c_str(), W_OK) == 0;
+  try {
+    return MakeFileReference(std::move(metadata), std::make_shared<LinuxFileReferenceState>(file));
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+std::vector<std::string> ResponseUris(GVariant* results) {
+  std::vector<std::string> uris;
+  VariantHandle values(g_variant_lookup_value(results, "uris", G_VARIANT_TYPE("as")));
+  if (values.Get() == nullptr) {
+    return uris;
+  }
+  GVariantIter iterator;
+  g_variant_iter_init(&iterator, values.Get());
+  const char* uri = nullptr;
+  while (g_variant_iter_next(&iterator, "&s", &uri)) {
+    if (uri != nullptr) {
+      uris.emplace_back(uri);
+    }
+  }
+  return uris;
+}
+
+std::vector<FileReference> ReferencesFromUris(const std::vector<std::string>& uris) {
+  std::vector<FileReference> references;
+  references.reserve(uris.size());
+  for (const std::string& uri : uris) {
+    const std::optional<File> file = FileFromPortalUri(uri);
+    if (!file.has_value()) {
+      continue;
+    }
+    std::optional<FileReference> reference = MakeLinuxFileReference(*file);
+    if (reference.has_value()) {
+      references.push_back(std::move(*reference));
+    }
+  }
+  return references;
+}
+
+class PortalPickerOperation final : public std::enable_shared_from_this<PortalPickerOperation> {
+public:
+  PortalPickerOperation(
+      std::shared_ptr<PortalConnection> portal,
+      std::string parent_window,
+      FilePickerFilter filter,
+      bool multiple,
+      FilePickerOpenCompletion completion
+  )
+      : portal_(std::move(portal)), parent_window_(std::move(parent_window)), filter_(std::move(filter)),
+        multiple_(multiple), open_completion_(std::move(completion)) {}
+
+  PortalPickerOperation(
+      std::shared_ptr<PortalConnection> portal,
+      std::string parent_window,
+      File source,
+      SaveFileOptions options,
+      FilePickerSaveCompletion completion
+  )
+      : portal_(std::move(portal)), parent_window_(std::move(parent_window)), source_(std::move(source)),
+        save_options_(std::move(options)), save_completion_(std::move(completion)), save_(true) {}
+
+  void Start() noexcept {
+    try {
+      StartOnPortalThread();
+    } catch (...) {
+      FailOnPortalThread();
+    }
+  }
+
+  void Cancel() noexcept {
+    FilePickerOpenCompletion open_completion;
+    FilePickerSaveCompletion save_completion;
+    std::string request_path;
+    {
+      std::scoped_lock lock(mutex_);
+      if (finished_) {
+        return;
+      }
+      finished_ = true;
+      canceled_ = true;
+      request_path = request_path_;
+      closed_path_ = request_path;
+      open_completion = std::move(open_completion_);
+      save_completion = std::move(save_completion_);
+    }
+    const std::shared_ptr<PortalPickerOperation> self = shared_from_this();
+    static_cast<void>(portal_->Invoke([self, request_path = std::move(request_path)] {
+      self->CloseRequest(request_path);
+      self->CleanupPortalSubscriptions();
+    }));
+    if (open_completion) {
+      open_completion({});
+    }
+    if (save_completion) {
+      save_completion(false);
+    }
+  }
+
+private:
+  void StartOnPortalThread() {
+    {
+      std::scoped_lock lock(mutex_);
+      if (finished_) {
+        return;
+      }
+    }
+    const std::weak_ptr<PortalPickerOperation> weak = shared_from_this();
+    unavailable_observer_ = portal_->ObserveUnavailable([weak] {
+      if (const std::shared_ptr<PortalPickerOperation> operation = weak.lock()) {
+        operation->PortalUnavailable();
+      }
+    });
+    if (unavailable_observer_ == 0 || Finished()) {
+      return;
+    }
+    const std::string token = UniqueToken();
+    const std::string expected_path = ExpectedRequestPath(portal_->Native(), token);
+    if (expected_path.empty()) {
+      FailOnPortalThread();
+      return;
+    }
+    {
+      std::scoped_lock lock(mutex_);
+      request_path_ = expected_path;
+    }
+    Subscribe(expected_path);
+
+    GVariant* options = save_
+                            ? SaveOptionsVariant(
+                                  save_options_,
+                                  save_options_.suggested_name.empty() ? source_->Name() : save_options_.suggested_name,
+                                  token
+                              )
+                            : OpenOptions(filter_, multiple_, token);
+    const char* method = save_ ? "SaveFile" : "OpenFile";
+    const char* title = save_ ? "Save File" : (multiple_ ? "Open Files" : "Open File");
+    auto* operation = new std::shared_ptr<PortalPickerOperation>(shared_from_this());
+    portal_->BeginMethodCall();
+    g_dbus_connection_call(
+        portal_->Native(),
+        kPortalService,
+        kPortalObject,
+        kFileChooserInterface,
+        method,
+        g_variant_new("(ss@a{sv})", parent_window_.c_str(), title, options),
+        G_VARIANT_TYPE("(o)"),
+        G_DBUS_CALL_FLAGS_NONE,
+        kPortalCallTimeoutMs,
+        nullptr,
+        [](GObject* source, GAsyncResult* result, gpointer data) {
+          std::unique_ptr<std::shared_ptr<PortalPickerOperation>> operation(
+              static_cast<std::shared_ptr<PortalPickerOperation>*>(data)
+          );
+          (*operation)->MethodFinished(G_DBUS_CONNECTION(source), result);
+          (*operation)->portal_->EndMethodCall();
+        },
+        operation
+    );
+  }
+
+  void Subscribe(const std::string& path) {
+    auto* operation = new std::shared_ptr<PortalPickerOperation>(shared_from_this());
+    subscription_ = g_dbus_connection_signal_subscribe(
+        portal_->Native(),
+        kPortalService,
+        kRequestInterface,
+        "Response",
+        path.c_str(),
+        nullptr,
+        G_DBUS_SIGNAL_FLAGS_NONE,
+        [](GDBusConnection*,
+           const gchar*,
+           const gchar*,
+           const gchar*,
+           const gchar*,
+           GVariant* parameters,
+           gpointer data) {
+          const std::shared_ptr<PortalPickerOperation>& operation =
+              *static_cast<std::shared_ptr<PortalPickerOperation>*>(data);
+          operation->Response(parameters);
+        },
+        operation,
+        [](gpointer data) { delete static_cast<std::shared_ptr<PortalPickerOperation>*>(data); }
+    );
+  }
+
+  void Unsubscribe() noexcept {
+    if (subscription_ != 0) {
+      g_dbus_connection_signal_unsubscribe(portal_->Native(), subscription_);
+      subscription_ = 0;
+    }
+  }
+
+  void CleanupPortalSubscriptions() noexcept {
+    Unsubscribe();
+    if (unavailable_observer_ != 0) {
+      portal_->RemoveUnavailableObserver(unavailable_observer_);
+      unavailable_observer_ = 0;
+    }
+  }
+
+  void CloseRequest(const std::string& path) noexcept {
+    if (path.empty()) {
+      return;
+    }
+    g_dbus_connection_call(
+        portal_->Native(),
+        kPortalService,
+        path.c_str(),
+        kRequestInterface,
+        "Close",
+        nullptr,
+        nullptr,
+        G_DBUS_CALL_FLAGS_NONE,
+        kPortalCallTimeoutMs,
+        nullptr,
+        nullptr,
+        nullptr
+    );
+  }
+
+  [[nodiscard]] bool Finished() const noexcept {
+    std::scoped_lock lock(mutex_);
+    return finished_;
+  }
+
+  void MethodFinished(GDBusConnection* connection, GAsyncResult* result) noexcept {
+    try {
+      MethodFinishedOnPortalThread(connection, result);
+    } catch (...) {
+      FailOnPortalThread();
+    }
+  }
+
+  void MethodFinishedOnPortalThread(GDBusConnection* connection, GAsyncResult* result) {
+    ErrorHandle error;
+    VariantHandle reply(g_dbus_connection_call_finish(connection, result, error.Address()));
+    if (reply.Get() == nullptr) {
+      if (Finished()) {
+        CleanupPortalSubscriptions();
+      } else {
+        FailOnPortalThread();
+      }
+      return;
+    }
+    const char* returned_path = nullptr;
+    g_variant_get(reply.Get(), "(&o)", &returned_path);
+    if (returned_path == nullptr || returned_path[0] == '\0') {
+      FailOnPortalThread();
+      return;
+    }
+    std::string expected_path;
+    bool finished = false;
+    bool close_returned_path = false;
+    {
+      std::scoped_lock lock(mutex_);
+      expected_path = request_path_;
+      request_path_ = returned_path;
+      finished = finished_;
+      close_returned_path = canceled_ && closed_path_ != returned_path;
+      if (close_returned_path) {
+        closed_path_ = returned_path;
+      }
+    }
+    if (finished) {
+      if (close_returned_path) {
+        CloseRequest(request_path_);
+      }
+      CleanupPortalSubscriptions();
+      return;
+    }
+    if (expected_path != returned_path) {
+      Unsubscribe();
+      Subscribe(returned_path);
+    }
+  }
+
+  void Response(GVariant* parameters) noexcept {
+    try {
+      ResponseOnPortalThread(parameters);
+    } catch (...) {
+      FailOnPortalThread();
+    }
+  }
+
+  void ResponseOnPortalThread(GVariant* parameters) {
+    if (Finished()) {
+      CleanupPortalSubscriptions();
+      return;
+    }
+    guint32 response = 2;
+    GVariant* results = nullptr;
+    g_variant_get(parameters, "(u@a{sv})", &response, &results);
+    VariantHandle owned_results(results);
+    CleanupPortalSubscriptions();
+    if (response != 0 || results == nullptr) {
+      FinishFailure();
+      return;
+    }
+    const std::vector<std::string> uris = ResponseUris(results);
+    if (save_) {
+      if (uris.size() != 1) {
+        FinishSave(false);
+        return;
+      }
+      const File source = *source_;
+      const std::shared_ptr<PortalPickerOperation> self = shared_from_this();
+      try {
+        EnqueueFileOperation([self, source, uri = uris.front()] {
+          try {
+            const std::optional<File> destination = FileFromPortalUri(uri);
+            self->FinishSave(destination.has_value() && source.CopyTo(*destination, true));
+          } catch (...) {
+            self->FinishSave(false);
+          }
+        });
+      } catch (...) {
+        FinishSave(false);
+      }
+      return;
+    }
+    const std::shared_ptr<PortalPickerOperation> self = shared_from_this();
+    try {
+      EnqueueFileOperation([self, uris] {
+        try {
+          self->FinishOpen(ReferencesFromUris(uris));
+        } catch (...) {
+          self->FinishOpen({});
+        }
+      });
+    } catch (...) {
+      FinishOpen({});
+    }
+  }
+
+  void FailOnPortalThread() noexcept {
+    std::string request_path;
+    {
+      std::scoped_lock lock(mutex_);
+      request_path = request_path_;
+    }
+    CloseRequest(request_path);
+    CleanupPortalSubscriptions();
+    FinishFailure();
+  }
+
+  void PortalUnavailable() noexcept {
+    CleanupPortalSubscriptions();
+    FinishFailure();
+  }
+
+  void FinishFailure() noexcept {
+    if (save_) {
+      FinishSave(false);
+    } else {
+      FinishOpen({});
+    }
+  }
+
+  void FinishOpen(std::vector<FileReference> references) noexcept {
+    FilePickerOpenCompletion completion;
+    {
+      std::scoped_lock lock(mutex_);
+      if (finished_) {
+        return;
+      }
+      finished_ = true;
+      completion = std::move(open_completion_);
+    }
+    if (completion) {
+      completion(std::move(references));
+    }
+  }
+
+  void FinishSave(bool succeeded) noexcept {
+    FilePickerSaveCompletion completion;
+    {
+      std::scoped_lock lock(mutex_);
+      if (finished_) {
+        return;
+      }
+      finished_ = true;
+      completion = std::move(save_completion_);
+    }
+    if (completion) {
+      completion(succeeded);
+    }
+  }
+
+  std::shared_ptr<PortalConnection> portal_;
+  std::string parent_window_;
+  FilePickerFilter filter_;
+  bool multiple_ = false;
+  std::optional<File> source_;
+  SaveFileOptions save_options_;
+  mutable std::mutex mutex_;
+  FilePickerOpenCompletion open_completion_;
+  FilePickerSaveCompletion save_completion_;
+  std::string request_path_;
+  std::string closed_path_;
+  guint subscription_ = 0;
+  std::uint64_t unavailable_observer_ = 0;
+  bool save_ = false;
+  bool finished_ = false;
+  bool canceled_ = false;
+};
+
+class LinuxFilePickerTransport final : public FilePickerTransport {
+public:
+  LinuxFilePickerTransport(std::shared_ptr<PortalConnection> portal, std::function<unsigned long()> window_provider)
+      : portal_(std::move(portal)), window_provider_(std::move(window_provider)) {}
+
+  ~LinuxFilePickerTransport() override {
+    portal_->Stop();
+  }
+
+  [[nodiscard]] bool CanOpenFiles() const noexcept override {
+    return portal_->Available();
+  }
+
+  [[nodiscard]] bool CanSaveFiles() const noexcept override {
+    return portal_->Available();
+  }
+
+  std::function<void()>
+  OpenFiles(FilePickerFilter filter, bool multiple, FilePickerOpenCompletion completion) override {
+    auto operation = std::make_shared<PortalPickerOperation>(
+        portal_,
+        ParentWindow(),
+        std::move(filter),
+        multiple,
+        std::move(completion)
+    );
+    if (!portal_->Invoke([operation] { operation->Start(); })) {
+      operation->Cancel();
+    }
+    return [operation] { operation->Cancel(); };
+  }
+
+  std::function<void()> SaveFile(File source, SaveFileOptions options, FilePickerSaveCompletion completion) override {
+    auto operation = std::make_shared<PortalPickerOperation>(
+        portal_,
+        ParentWindow(),
+        std::move(source),
+        std::move(options),
+        std::move(completion)
+    );
+    if (!portal_->Invoke([operation] { operation->Start(); })) {
+      operation->Cancel();
+    }
+    return [operation] { operation->Cancel(); };
+  }
+
+private:
+  [[nodiscard]] std::string ParentWindow() const noexcept {
+    if (!window_provider_) {
+      return {};
+    }
+    try {
+      return LinuxPortalParentWindow(window_provider_());
+    } catch (...) {
+      return {};
+    }
+  }
+
+  std::shared_ptr<PortalConnection> portal_;
+  std::function<unsigned long()> window_provider_;
+};
+
+} // namespace
+
+std::string LinuxPortalParentWindow(unsigned long window) {
+  if (window == 0) {
+    return {};
+  }
+  std::array<char, sizeof(window) * 2> buffer{};
+  const auto [end, error] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), window, 16);
+  if (error != std::errc{}) {
+    return {};
+  }
+  return "x11:" + std::string(buffer.data(), end);
+}
+
+std::shared_ptr<FilePickerTransport>
+CreateLinuxFilePickerTransport(std::function<unsigned long()> window_provider, std::optional<std::string> bus_address) {
+  std::shared_ptr<PortalConnection> portal = PortalConnection::Create(std::move(bus_address));
+  if (!portal) {
+    return {};
+  }
+  return std::make_shared<LinuxFilePickerTransport>(std::move(portal), std::move(window_provider));
+}
+
+} // namespace huxerui::detail

--- a/platform/linux/linux_file_picker_internal.h
+++ b/platform/linux/linux_file_picker_internal.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace huxerui::detail {
+
+class FilePickerTransport;
+
+[[nodiscard]] std::string LinuxPortalParentWindow(unsigned long window);
+[[nodiscard]] std::shared_ptr<FilePickerTransport> CreateLinuxFilePickerTransport(
+    std::function<unsigned long()> window_provider, std::optional<std::string> bus_address = std::nullopt
+);
+
+} // namespace huxerui::detail

--- a/src/file_internal.h
+++ b/src/file_internal.h
@@ -57,6 +57,10 @@ MakeFileReference(FileReferenceMetadata metadata, std::shared_ptr<FileReferenceS
 [[nodiscard]] FileResult<std::string> DecodeFileUtf8(FileResult<std::vector<std::byte>> bytes);
 [[nodiscard]] bool IsValidFileUtf8(std::string_view text) noexcept;
 
+#if !defined(__EMSCRIPTEN__)
+void EnqueueFileOperation(std::function<void()> operation);
+#endif
+
 #if defined(__EMSCRIPTEN__)
 [[nodiscard]] bool IsWebPersistentFilePath(std::string_view path) noexcept;
 void EnqueueWebFileOperation(std::function<void(std::function<void()>)> operation);

--- a/src/file_internal.h
+++ b/src/file_internal.h
@@ -57,10 +57,6 @@ MakeFileReference(FileReferenceMetadata metadata, std::shared_ptr<FileReferenceS
 [[nodiscard]] FileResult<std::string> DecodeFileUtf8(FileResult<std::vector<std::byte>> bytes);
 [[nodiscard]] bool IsValidFileUtf8(std::string_view text) noexcept;
 
-#if !defined(__EMSCRIPTEN__)
-void EnqueueFileOperation(std::function<void()> operation);
-#endif
-
 #if defined(__EMSCRIPTEN__)
 [[nodiscard]] bool IsWebPersistentFilePath(std::string_view path) noexcept;
 void EnqueueWebFileOperation(std::function<void(std::function<void()>)> operation);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             platform/linux_damage.cpp
             platform/linux_external_texture.cpp
             platform/linux_file.cpp
+            platform/linux_file_picker.cpp
             platform/linux_http.cpp
             platform/linux_platform_module.cpp
             platform/linux_renderer.cpp
@@ -117,6 +118,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_include_directories(huxerui_tests PRIVATE
             "${HUXERUI_PROJECT_DIR}/examples/platform_module"
     )
+    target_link_libraries(huxerui_tests PRIVATE PkgConfig::HUXERUI_GIO)
 endif ()
 
 if (EMSCRIPTEN)

--- a/tests/platform/linux_file_picker.cpp
+++ b/tests/platform/linux_file_picker.cpp
@@ -1,0 +1,923 @@
+#include "linux_internal.h"
+
+#include <catch2/catch_amalgamated.hpp>
+#include <gio/gio.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "file_internal.h"
+#include "linux_file_picker_internal.h"
+#include "runtime_test_support.h"
+
+namespace huxerui::test {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* kPortalService = "org.freedesktop.portal.Desktop";
+constexpr const char* kPortalObject = "/org/freedesktop/portal/desktop";
+constexpr const char* kFileChooserInterface = "org.freedesktop.portal.FileChooser";
+constexpr const char* kRequestInterface = "org.freedesktop.portal.Request";
+
+constexpr const char* kPortalXml = R"xml(
+<node>
+  <interface name="org.freedesktop.portal.FileChooser">
+    <method name="OpenFile">
+      <arg type="s" direction="in"/>
+      <arg type="s" direction="in"/>
+      <arg type="a{sv}" direction="in"/>
+      <arg type="o" direction="out"/>
+    </method>
+    <method name="SaveFile">
+      <arg type="s" direction="in"/>
+      <arg type="s" direction="in"/>
+      <arg type="a{sv}" direction="in"/>
+      <arg type="o" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.portal.Request">
+    <method name="Close"/>
+    <signal name="Response">
+      <arg type="u"/>
+      <arg type="a{sv}"/>
+    </signal>
+  </interface>
+</node>
+)xml";
+
+std::string Utf8Path(const fs::path& path) {
+  const std::u8string value = path.generic_u8string();
+  return std::string(reinterpret_cast<const char*>(value.data()), value.size());
+}
+
+class TemporaryDirectory final {
+public:
+  TemporaryDirectory() {
+    static std::atomic<std::uint64_t> sequence = 0;
+    path_ = fs::temp_directory_path() / ("huxerui-linux-picker-tests-" +
+                                         std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) +
+                                         "-" + std::to_string(sequence.fetch_add(1)));
+    REQUIRE(fs::create_directories(path_));
+  }
+
+  ~TemporaryDirectory() {
+    std::error_code error;
+    fs::remove_all(path_, error);
+  }
+
+  [[nodiscard]] File Child(std::string_view name) const {
+    return File(Utf8Path(path_)).Child(name);
+  }
+
+private:
+  fs::path path_;
+};
+
+std::string FileUri(const File& file) {
+  GError* error = nullptr;
+  char* uri = g_filename_to_uri(file.Path().c_str(), nullptr, &error);
+  if (error != nullptr) {
+    const std::string message = error->message != nullptr ? error->message : "URI conversion failed";
+    g_error_free(error);
+    throw std::runtime_error(message);
+  }
+  if (uri == nullptr) {
+    throw std::runtime_error("URI conversion failed");
+  }
+  std::string result(uri);
+  g_free(uri);
+  return result;
+}
+
+struct PortalScenario {
+  std::uint32_t response = 0;
+  std::vector<std::string> uris;
+  bool defer_response = false;
+  bool unexpected_handle = false;
+  bool method_error = false;
+  bool request_exists_on_method_error = false;
+};
+
+struct PortalRule {
+  std::uint32_t kind = 0;
+  std::string value;
+
+  bool operator==(const PortalRule&) const = default;
+};
+
+struct PortalCall {
+  std::string method;
+  std::string parent_window;
+  std::string title;
+  std::string filter_name;
+  std::vector<PortalRule> rules;
+  std::string current_name;
+  bool multiple = false;
+  bool has_current_filter = false;
+};
+
+class FakePortal final {
+public:
+  FakePortal()
+      : bus_(g_test_dbus_new(G_TEST_DBUS_NONE)), context_(g_main_context_new()),
+        loop_(g_main_loop_new(context_, false)) {
+    g_test_dbus_up(bus_);
+    address_ = g_test_dbus_get_bus_address(bus_);
+    thread_ = std::thread([this] { Run(); });
+    std::unique_lock lock(mutex_);
+    ready_condition_.wait(lock, [this] { return ready_; });
+    if (!failure_.empty()) {
+      throw std::runtime_error(failure_);
+    }
+  }
+
+  ~FakePortal() {
+    g_main_context_invoke_full(
+        context_,
+        G_PRIORITY_DEFAULT,
+        [](gpointer data) -> gboolean {
+          g_main_loop_quit(static_cast<FakePortal*>(data)->loop_);
+          return G_SOURCE_REMOVE;
+        },
+        this,
+        nullptr
+    );
+    thread_.join();
+    g_main_loop_unref(loop_);
+    g_main_context_unref(context_);
+    g_test_dbus_down(bus_);
+    g_object_unref(bus_);
+  }
+
+  FakePortal(const FakePortal&) = delete;
+  FakePortal& operator=(const FakePortal&) = delete;
+
+  [[nodiscard]] const std::string& Address() const noexcept {
+    return address_;
+  }
+
+  void SetScenario(PortalScenario scenario) {
+    std::scoped_lock lock(mutex_);
+    scenario_ = std::move(scenario);
+  }
+
+  [[nodiscard]] PortalCall WaitForCall(std::size_t count) {
+    std::unique_lock lock(mutex_);
+    if (!condition_.wait_for(lock, std::chrono::seconds(5), [this, count] { return calls_.size() >= count; })) {
+      throw std::runtime_error("Timed out waiting for the fake portal call");
+    }
+    return calls_[count - 1];
+  }
+
+  void WaitForClose(std::size_t count) {
+    std::unique_lock lock(mutex_);
+    if (!condition_.wait_for(lock, std::chrono::seconds(5), [this, count] { return close_count_ >= count; })) {
+      throw std::runtime_error("Timed out waiting for the fake portal request to close");
+    }
+  }
+
+  void WaitForResponse(std::size_t count) {
+    std::unique_lock lock(mutex_);
+    if (!condition_.wait_for(lock, std::chrono::seconds(5), [this, count] { return response_count_ >= count; })) {
+      throw std::runtime_error("Timed out waiting for the fake portal response");
+    }
+  }
+
+  void EmitDeferredResponse() {
+    std::optional<std::pair<std::string, PortalScenario>> response;
+    {
+      std::scoped_lock lock(mutex_);
+      if (!deferred_response_.has_value()) {
+        throw std::runtime_error("No deferred fake portal response is available");
+      }
+      response = std::move(deferred_response_);
+      deferred_response_.reset();
+    }
+    ScheduleResponse(std::move(response->first), std::move(response->second));
+  }
+
+  void ReleaseName() {
+    struct ReleaseRequest {
+      FakePortal* portal = nullptr;
+      std::mutex mutex;
+      std::condition_variable condition;
+      bool finished = false;
+      std::string failure;
+    } request{.portal = this};
+    g_main_context_invoke_full(
+        context_,
+        G_PRIORITY_DEFAULT,
+        [](gpointer data) -> gboolean {
+          auto* request = static_cast<ReleaseRequest*>(data);
+          GError* error = nullptr;
+          GVariant* reply = g_dbus_connection_call_sync(
+              request->portal->connection_,
+              "org.freedesktop.DBus",
+              "/org/freedesktop/DBus",
+              "org.freedesktop.DBus",
+              "ReleaseName",
+              g_variant_new("(s)", kPortalService),
+              G_VARIANT_TYPE("(u)"),
+              G_DBUS_CALL_FLAGS_NONE,
+              5000,
+              nullptr,
+              &error
+          );
+          guint32 result = 0;
+          if (reply != nullptr) {
+            g_variant_get(reply, "(u)", &result);
+            g_variant_unref(reply);
+          }
+          {
+            std::scoped_lock lock(request->mutex);
+            if (error != nullptr) {
+              request->failure = error->message != nullptr ? error->message : "Failed to release portal name";
+            } else if (result != 1) {
+              request->failure = "The fake portal did not own its bus name";
+            }
+            request->finished = true;
+          }
+          if (error != nullptr) {
+            g_error_free(error);
+          }
+          request->condition.notify_all();
+          return G_SOURCE_REMOVE;
+        },
+        &request,
+        nullptr
+    );
+    std::unique_lock lock(request.mutex);
+    if (!request.condition.wait_for(lock, std::chrono::seconds(5), [&request] { return request.finished; })) {
+      throw std::runtime_error("Timed out releasing the fake portal name");
+    }
+    if (!request.failure.empty()) {
+      throw std::runtime_error(request.failure);
+    }
+  }
+
+private:
+  struct ResponseData {
+    FakePortal* portal = nullptr;
+    std::string path;
+    PortalScenario scenario;
+  };
+
+  static void HandleMethodCall(
+      GDBusConnection*,
+      const gchar*,
+      const gchar*,
+      const gchar* interface_name,
+      const gchar* method_name,
+      GVariant* parameters,
+      GDBusMethodInvocation* invocation,
+      gpointer user_data
+  ) {
+    static_cast<FakePortal*>(user_data)->MethodCall(interface_name, method_name, parameters, invocation);
+  }
+
+  static const GDBusInterfaceVTable& VTable() {
+    static const GDBusInterfaceVTable table{
+        .method_call = HandleMethodCall,
+        .get_property = nullptr,
+        .set_property = nullptr,
+        .padding = {},
+    };
+    return table;
+  }
+
+  void Run() noexcept {
+    g_main_context_push_thread_default(context_);
+    GError* error = nullptr;
+    connection_ = g_dbus_connection_new_for_address_sync(
+        address_.c_str(),
+        static_cast<GDBusConnectionFlags>(
+            G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION
+        ),
+        nullptr,
+        nullptr,
+        &error
+    );
+    if (connection_ != nullptr) {
+      GVariant* reply = g_dbus_connection_call_sync(
+          connection_,
+          "org.freedesktop.DBus",
+          "/org/freedesktop/DBus",
+          "org.freedesktop.DBus",
+          "RequestName",
+          g_variant_new("(su)", kPortalService, 0U),
+          G_VARIANT_TYPE("(u)"),
+          G_DBUS_CALL_FLAGS_NONE,
+          5000,
+          nullptr,
+          &error
+      );
+      if (reply != nullptr) {
+        g_variant_unref(reply);
+      }
+    }
+    if (connection_ != nullptr && error == nullptr) {
+      node_ = g_dbus_node_info_new_for_xml(kPortalXml, &error);
+    }
+    if (node_ != nullptr && error == nullptr) {
+      portal_registration_ = g_dbus_connection_register_object(
+          connection_,
+          kPortalObject,
+          g_dbus_node_info_lookup_interface(node_, kFileChooserInterface),
+          &VTable(),
+          this,
+          nullptr,
+          &error
+      );
+    }
+    {
+      std::scoped_lock lock(mutex_);
+      if (error != nullptr) {
+        failure_ = error->message != nullptr ? error->message : "Fake portal initialization failed";
+      } else if (portal_registration_ == 0) {
+        failure_ = "Fake portal registration failed";
+      }
+      ready_ = true;
+    }
+    ready_condition_.notify_all();
+    if (error != nullptr) {
+      g_error_free(error);
+    }
+    if (portal_registration_ != 0) {
+      g_main_loop_run(loop_);
+    }
+    for (const guint registration : request_registrations_) {
+      g_dbus_connection_unregister_object(connection_, registration);
+    }
+    if (portal_registration_ != 0) {
+      g_dbus_connection_unregister_object(connection_, portal_registration_);
+    }
+    if (node_ != nullptr) {
+      g_dbus_node_info_unref(node_);
+      node_ = nullptr;
+    }
+    if (connection_ != nullptr) {
+      static_cast<void>(g_dbus_connection_close_sync(connection_, nullptr, nullptr));
+      g_object_unref(connection_);
+      connection_ = nullptr;
+    }
+    g_main_context_pop_thread_default(context_);
+  }
+
+  PortalCall ParseCall(const char* method_name, GVariant* parameters, std::string& token) {
+    const char* parent_window = nullptr;
+    const char* title = nullptr;
+    GVariant* options = nullptr;
+    g_variant_get(parameters, "(&s&s@a{sv})", &parent_window, &title, &options);
+    PortalCall call{
+        .method = method_name != nullptr ? method_name : "",
+        .parent_window = parent_window != nullptr ? parent_window : "",
+        .title = title != nullptr ? title : "",
+    };
+    const char* token_value = nullptr;
+    if (g_variant_lookup(options, "handle_token", "&s", &token_value) && token_value != nullptr) {
+      token = token_value;
+    }
+    gboolean multiple = false;
+    if (g_variant_lookup(options, "multiple", "b", &multiple)) {
+      call.multiple = multiple;
+    }
+    const char* current_name = nullptr;
+    if (g_variant_lookup(options, "current_name", "&s", &current_name) && current_name != nullptr) {
+      call.current_name = current_name;
+    }
+    GVariant* current_filter = g_variant_lookup_value(options, "current_filter", G_VARIANT_TYPE("(sa(us))"));
+    call.has_current_filter = current_filter != nullptr;
+    if (current_filter != nullptr) {
+      g_variant_unref(current_filter);
+    }
+    GVariant* filters = g_variant_lookup_value(options, "filters", G_VARIANT_TYPE("a(sa(us))"));
+    if (filters != nullptr && g_variant_n_children(filters) != 0) {
+      GVariant* filter = g_variant_get_child_value(filters, 0);
+      const char* filter_name = nullptr;
+      GVariant* rules = nullptr;
+      g_variant_get(filter, "(&s@a(us))", &filter_name, &rules);
+      if (filter_name != nullptr) {
+        call.filter_name = filter_name;
+      }
+      GVariantIter iterator;
+      g_variant_iter_init(&iterator, rules);
+      guint32 kind = 0;
+      const char* value = nullptr;
+      while (g_variant_iter_next(&iterator, "(u&s)", &kind, &value)) {
+        call.rules.push_back({kind, value != nullptr ? value : ""});
+      }
+      g_variant_unref(rules);
+      g_variant_unref(filter);
+      g_variant_unref(filters);
+    } else if (filters != nullptr) {
+      g_variant_unref(filters);
+    }
+    g_variant_unref(options);
+    return call;
+  }
+
+  void MethodCall(
+      const char* interface_name, const char* method_name, GVariant* parameters, GDBusMethodInvocation* invocation
+  ) noexcept {
+    try {
+      if (g_strcmp0(interface_name, kRequestInterface) == 0 && g_strcmp0(method_name, "Close") == 0) {
+        {
+          std::scoped_lock lock(mutex_);
+          ++close_count_;
+        }
+        condition_.notify_all();
+        g_dbus_method_invocation_return_value(invocation, nullptr);
+        return;
+      }
+
+      std::string token;
+      PortalCall call = ParseCall(method_name, parameters, token);
+      const char* sender_value = g_dbus_method_invocation_get_sender(invocation);
+      std::string sender = sender_value != nullptr && sender_value[0] == ':' ? sender_value + 1 : sender_value;
+      std::replace(sender.begin(), sender.end(), '.', '_');
+
+      PortalScenario scenario;
+      std::size_t call_count = 0;
+      {
+        std::scoped_lock lock(mutex_);
+        calls_.push_back(std::move(call));
+        call_count = calls_.size();
+        scenario = scenario_;
+      }
+      condition_.notify_all();
+
+      std::string path = "/org/freedesktop/portal/desktop/request/" + sender + "/" + token;
+      if (scenario.unexpected_handle) {
+        path = "/org/freedesktop/portal/desktop/request/huxerui_test/unexpected_" + std::to_string(call_count);
+      }
+      if (scenario.method_error && !scenario.request_exists_on_method_error) {
+        g_dbus_method_invocation_return_dbus_error(
+            invocation,
+            "org.freedesktop.portal.Error.Failed",
+            "Fake portal method failure"
+        );
+        return;
+      }
+      GError* error = nullptr;
+      const guint registration = g_dbus_connection_register_object(
+          connection_,
+          path.c_str(),
+          g_dbus_node_info_lookup_interface(node_, kRequestInterface),
+          &VTable(),
+          this,
+          nullptr,
+          &error
+      );
+      if (registration == 0 || error != nullptr) {
+        const char* message =
+            error != nullptr && error->message != nullptr ? error->message : "Request registration failed";
+        g_dbus_method_invocation_return_dbus_error(invocation, "org.huxerui.TestError", message);
+        if (error != nullptr) {
+          g_error_free(error);
+        }
+        return;
+      }
+      request_registrations_.push_back(registration);
+      if (scenario.method_error) {
+        g_dbus_method_invocation_return_dbus_error(
+            invocation,
+            "org.freedesktop.portal.Error.Failed",
+            "Fake portal method failure"
+        );
+        return;
+      }
+      g_dbus_method_invocation_return_value(invocation, g_variant_new("(o)", path.c_str()));
+      if (scenario.defer_response) {
+        std::scoped_lock lock(mutex_);
+        deferred_response_.emplace(std::move(path), std::move(scenario));
+      } else {
+        ScheduleResponse(std::move(path), std::move(scenario));
+      }
+    } catch (const std::exception& error) {
+      g_dbus_method_invocation_return_dbus_error(invocation, "org.huxerui.TestError", error.what());
+    } catch (...) {
+      g_dbus_method_invocation_return_dbus_error(invocation, "org.huxerui.TestError", "Fake portal failure");
+    }
+  }
+
+  void ScheduleResponse(std::string path, PortalScenario scenario) {
+    GSource* source = g_timeout_source_new(20);
+    auto* data = new ResponseData{this, std::move(path), std::move(scenario)};
+    g_source_set_callback(
+        source,
+        [](gpointer value) -> gboolean {
+          auto* response = static_cast<ResponseData*>(value);
+          response->portal->EmitResponse(response->path, response->scenario);
+          return G_SOURCE_REMOVE;
+        },
+        data,
+        [](gpointer value) { delete static_cast<ResponseData*>(value); }
+    );
+    g_source_attach(source, context_);
+    g_source_unref(source);
+  }
+
+  void EmitResponse(const std::string& path, const PortalScenario& scenario) noexcept {
+    GVariantBuilder uris;
+    g_variant_builder_init(&uris, G_VARIANT_TYPE("as"));
+    for (const std::string& uri : scenario.uris) {
+      g_variant_builder_add(&uris, "s", uri.c_str());
+    }
+    GVariantBuilder results;
+    g_variant_builder_init(&results, G_VARIANT_TYPE_VARDICT);
+    g_variant_builder_add(&results, "{sv}", "uris", g_variant_builder_end(&uris));
+    GError* error = nullptr;
+    static_cast<void>(g_dbus_connection_emit_signal(
+        connection_,
+        nullptr,
+        path.c_str(),
+        kRequestInterface,
+        "Response",
+        g_variant_new("(u@a{sv})", scenario.response, g_variant_builder_end(&results)),
+        &error
+    ));
+    if (error != nullptr) {
+      g_error_free(error);
+    }
+    {
+      std::scoped_lock lock(mutex_);
+      ++response_count_;
+    }
+    condition_.notify_all();
+  }
+
+  GTestDBus* bus_ = nullptr;
+  std::string address_;
+  GMainContext* context_ = nullptr;
+  GMainLoop* loop_ = nullptr;
+  GDBusConnection* connection_ = nullptr;
+  GDBusNodeInfo* node_ = nullptr;
+  guint portal_registration_ = 0;
+  std::vector<guint> request_registrations_;
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable ready_condition_;
+  std::condition_variable condition_;
+  PortalScenario scenario_;
+  std::optional<std::pair<std::string, PortalScenario>> deferred_response_;
+  std::vector<PortalCall> calls_;
+  std::size_t close_count_ = 0;
+  std::size_t response_count_ = 0;
+  bool ready_ = false;
+  std::string failure_;
+};
+
+template <class Value> Value WaitFor(std::function<void(std::function<void(Value)>)> start) {
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::optional<Value> value;
+  start([&](Value result) {
+    {
+      std::scoped_lock lock(mutex);
+      value.emplace(std::move(result));
+    }
+    condition.notify_all();
+  });
+  std::unique_lock lock(mutex);
+  if (!condition.wait_for(lock, std::chrono::seconds(5), [&] { return value.has_value(); })) {
+    throw std::runtime_error("Timed out waiting for a Linux picker operation");
+  }
+  return std::move(*value);
+}
+
+struct UiTaskQueue {
+  std::mutex mutex;
+  std::vector<std::function<void()>> tasks;
+};
+
+class LinuxFilePickerTestPlatform final : public TestPlatform {
+public:
+  LinuxFilePickerTestPlatform(
+      std::shared_ptr<UiTaskQueue> ui_tasks, std::shared_ptr<detail::FilePickerTransport> transport
+  )
+      : TestPlatform([ui_tasks](std::function<void()> task) {
+          std::scoped_lock lock(ui_tasks->mutex);
+          ui_tasks->tasks.push_back(std::move(task));
+        }),
+        ui_tasks_(std::move(ui_tasks)), transport_(std::move(transport)) {}
+
+  void RunUiTasks() {
+    std::vector<std::function<void()>> tasks;
+    {
+      std::scoped_lock lock(ui_tasks_->mutex);
+      tasks = std::move(ui_tasks_->tasks);
+      ui_tasks_->tasks.clear();
+    }
+    for (const auto& task : tasks) {
+      task();
+    }
+  }
+
+  void ReleaseTransport() {
+    transport_.reset();
+  }
+
+protected:
+  std::shared_ptr<detail::FilePickerTransport> CreateFilePickerTransport() override {
+    return transport_;
+  }
+
+private:
+  std::shared_ptr<UiTaskQueue> ui_tasks_;
+  std::shared_ptr<detail::FilePickerTransport> transport_;
+};
+
+TaskScope reference_tasks;
+std::shared_ptr<FilePicker> runtime_file_picker;
+std::optional<FileResult<std::string>> reference_text;
+bool reference_imported = false;
+bool reference_replaced = false;
+bool reference_operations_complete = false;
+bool runtime_picker_resumed = false;
+
+View LinuxFileReferenceApp() {
+  runtime_file_picker = UseService<FilePicker>();
+  reference_tasks = UseTaskScope();
+  return Text("Linux file reference");
+}
+
+template <class Predicate> void WaitForUi(LinuxFilePickerTestPlatform& platform, Predicate predicate) {
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!predicate()) {
+    platform.RunUiTasks();
+    if (std::chrono::steady_clock::now() >= deadline) {
+      throw std::runtime_error("Timed out waiting for a Linux file reference operation");
+    }
+    std::this_thread::yield();
+  }
+  platform.RunUiTasks();
+}
+
+} // namespace
+
+TEST_CASE("LinuxFilePickerFormatsX11ParentAndRejectsAnUnavailablePortal") {
+  REQUIRE(detail::LinuxPortalParentWindow(0).empty());
+  REQUIRE(detail::LinuxPortalParentWindow(0x12ABUL) == "x11:12ab");
+
+  GTestDBus* bus = g_test_dbus_new(G_TEST_DBUS_NONE);
+  g_test_dbus_up(bus);
+  const std::string address = g_test_dbus_get_bus_address(bus);
+  REQUIRE_FALSE(detail::CreateLinuxFilePickerTransport([] { return 0UL; }, address));
+  g_test_dbus_down(bus);
+  g_object_unref(bus);
+}
+
+TEST_CASE("LinuxFilePickerCompletesAnActiveRequestWhenThePortalDisappears") {
+  FakePortal portal;
+  portal.SetScenario({.defer_response = true});
+  std::shared_ptr<detail::FilePickerTransport> transport =
+      detail::CreateLinuxFilePickerTransport([] { return 0UL; }, portal.Address());
+  REQUIRE(transport);
+  REQUIRE(transport->CanOpenFiles());
+  REQUIRE(transport->CanSaveFiles());
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool completed = false;
+  std::function<void()> cancel = transport->OpenFiles({}, false, [&](std::vector<FileReference> references) {
+    {
+      std::scoped_lock lock(mutex);
+      completed = references.empty();
+    }
+    condition.notify_all();
+  });
+  static_cast<void>(portal.WaitForCall(1));
+  portal.ReleaseName();
+  {
+    std::unique_lock lock(mutex);
+    REQUIRE(condition.wait_for(lock, std::chrono::seconds(5), [&] { return completed; }));
+  }
+  REQUIRE_FALSE(transport->CanOpenFiles());
+  REQUIRE_FALSE(transport->CanSaveFiles());
+  REQUIRE(WaitFor<std::vector<FileReference>>([&](auto completion) {
+            static_cast<void>(transport->OpenFiles({}, false, std::move(completion)));
+          }).empty());
+  cancel();
+}
+
+TEST_CASE("LinuxFilePickerHandlesEmptyFiltersPortalFailuresAndInvalidUris") {
+  FakePortal portal;
+  TemporaryDirectory temporary;
+  const File selected = temporary.Child("selected.txt");
+  REQUIRE(selected.WriteString("selected"));
+
+  std::shared_ptr<detail::FilePickerTransport> transport =
+      detail::CreateLinuxFilePickerTransport([] { return 0UL; }, portal.Address());
+  REQUIRE(transport);
+
+  portal.SetScenario({.uris = {FileUri(selected)}});
+  REQUIRE(WaitFor<std::vector<FileReference>>([&](auto completion) {
+            static_cast<void>(transport->OpenFiles({}, false, std::move(completion)));
+          }).size() == 1);
+  const PortalCall empty_filter_call = portal.WaitForCall(1);
+  REQUIRE(empty_filter_call.parent_window.empty());
+  REQUIRE(empty_filter_call.title == "Open File");
+  REQUIRE_FALSE(empty_filter_call.multiple);
+  REQUIRE(empty_filter_call.filter_name.empty());
+  REQUIRE(empty_filter_call.rules.empty());
+  REQUIRE_FALSE(empty_filter_call.has_current_filter);
+
+  portal.SetScenario({.method_error = true, .request_exists_on_method_error = true});
+  REQUIRE(WaitFor<std::vector<FileReference>>([&](auto completion) {
+            static_cast<void>(transport->OpenFiles({}, false, std::move(completion)));
+          }).empty());
+  static_cast<void>(portal.WaitForCall(2));
+  portal.WaitForClose(1);
+
+  portal.SetScenario({.response = 2});
+  REQUIRE(WaitFor<std::vector<FileReference>>([&](auto completion) {
+            static_cast<void>(transport->OpenFiles({}, false, std::move(completion)));
+          }).empty());
+  static_cast<void>(portal.WaitForCall(3));
+
+  const File read_only = temporary.Child("read-only.txt");
+  REQUIRE(read_only.WriteString("read only"));
+  fs::permissions(
+      fs::path(read_only.Path()),
+      fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read,
+      fs::perm_options::replace
+  );
+  portal.SetScenario({
+      .uris = {"not a URI", "file://remote-host/tmp/document.txt", FileUri(read_only)},
+  });
+  const std::vector<FileReference> valid_references = WaitFor<std::vector<FileReference>>([&](auto completion) {
+    static_cast<void>(transport->OpenFiles({}, true, std::move(completion)));
+  });
+  static_cast<void>(portal.WaitForCall(4));
+  REQUIRE(valid_references.size() == 1);
+  REQUIRE(valid_references.front().Name() == "read-only.txt");
+  REQUIRE_FALSE(valid_references.front().CanWrite());
+}
+
+TEST_CASE("DestroyingTheRuntimeClosesTheLinuxPortalRequestAndIgnoresALateResponse") {
+  FakePortal portal;
+  portal.SetScenario({.defer_response = true, .unexpected_handle = true});
+  std::shared_ptr<detail::FilePickerTransport> transport =
+      detail::CreateLinuxFilePickerTransport([] { return 1UL; }, portal.Address());
+  REQUIRE(transport);
+  auto ui_tasks = std::make_shared<UiTaskQueue>();
+  LinuxFilePickerTestPlatform platform(ui_tasks, transport);
+  runtime_file_picker.reset();
+  reference_tasks = {};
+  runtime_picker_resumed = false;
+
+  {
+    Runtime runtime(LinuxFileReferenceApp, platform);
+    runtime.BuildFrame();
+    reference_tasks.Launch([picker = runtime_file_picker]() -> Task<void> {
+      static_cast<void>(co_await picker->OpenFileAsync());
+      runtime_picker_resumed = true;
+    });
+    platform.RunUiTasks();
+    static_cast<void>(portal.WaitForCall(1));
+    platform.ReleaseTransport();
+    transport.reset();
+    runtime_file_picker.reset();
+  }
+  reference_tasks = {};
+  portal.WaitForClose(1);
+  portal.EmitDeferredResponse();
+  portal.WaitForResponse(1);
+  platform.RunUiTasks();
+  REQUIRE_FALSE(runtime_picker_resumed);
+}
+
+TEST_CASE("LinuxFilePickerUsesThePortalForReferencesSavingAndCancellation") {
+  FakePortal portal;
+  TemporaryDirectory temporary;
+  const File first = temporary.Child("外部.txt");
+  const File second = temporary.Child("second.txt");
+  REQUIRE(first.WriteString("first value"));
+  REQUIRE(second.WriteString("second"));
+
+  std::shared_ptr<detail::FilePickerTransport> transport =
+      detail::CreateLinuxFilePickerTransport([] { return 0x2AUL; }, portal.Address());
+  REQUIRE(transport);
+  REQUIRE(transport->CanOpenFiles());
+  REQUIRE(transport->CanSaveFiles());
+
+  portal.SetScenario({
+      .response = 0,
+      .uris = {FileUri(first), "https://example.test/not-a-file", FileUri(second)},
+  });
+  const std::vector<FileReference> references = WaitFor<std::vector<FileReference>>([&](auto completion) {
+    static_cast<void>(transport->OpenFiles(
+        {
+            .name = "Text",
+            .extensions = {"txt"},
+            .content_types = {"text/plain", "text/*"},
+        },
+        true,
+        std::move(completion)
+    ));
+  });
+  const PortalCall open_call = portal.WaitForCall(1);
+  REQUIRE(open_call.method == "OpenFile");
+  REQUIRE(open_call.parent_window == "x11:2a");
+  REQUIRE(open_call.title == "Open Files");
+  REQUIRE(open_call.multiple);
+  REQUIRE(open_call.filter_name == "Text");
+  REQUIRE(open_call.has_current_filter);
+  REQUIRE(open_call.rules == std::vector<PortalRule>{{0, "*.txt"}, {1, "text/plain"}, {1, "text/*"}});
+  REQUIRE(references.size() == 2);
+  REQUIRE(references[0].Name() == "外部.txt");
+  REQUIRE(references[0].Size() == std::optional<std::uint64_t>{11});
+  REQUIRE(references[0].ContentType().has_value());
+  REQUIRE(references[0].CanWrite());
+
+  const File imported = temporary.Child("imported.txt");
+  const File replacement = temporary.Child("replacement.txt");
+  REQUIRE(replacement.WriteString("replacement"));
+  auto ui_tasks = std::make_shared<UiTaskQueue>();
+  LinuxFilePickerTestPlatform platform(ui_tasks, transport);
+  runtime_file_picker.reset();
+  reference_tasks = {};
+  Runtime runtime(LinuxFileReferenceApp, platform);
+  runtime.BuildFrame();
+  reference_text.reset();
+  reference_imported = false;
+  reference_replaced = false;
+  reference_operations_complete = false;
+  reference_tasks.Launch([reference = references[0], imported, replacement]() -> Task<void> {
+    reference_text = co_await reference.ReadStringAsync();
+    reference_imported = co_await reference.ImportToAsync(imported, false);
+    reference_replaced = co_await reference.ReplaceWithAsync(replacement);
+    reference_operations_complete = true;
+  });
+  WaitForUi(platform, [] { return reference_operations_complete; });
+  REQUIRE(reference_text.has_value());
+  REQUIRE(reference_text->Succeeded());
+  REQUIRE(reference_text->Value() == "first value");
+  REQUIRE(reference_imported);
+  REQUIRE(reference_replaced);
+  REQUIRE(imported.ReadString().Value() == "first value");
+  REQUIRE(first.ReadString().Value() == "replacement");
+
+  const File saved = temporary.Child("saved.txt");
+  portal.SetScenario({.response = 0, .uris = {FileUri(saved)}, .unexpected_handle = true});
+  REQUIRE(WaitFor<bool>([&](auto completion) {
+    static_cast<void>(transport->SaveFile(
+        first,
+        {
+            .suggested_name = "exported.txt",
+            .filter = {.name = "Text", .extensions = {"txt"}, .content_types = {"text/plain"}},
+        },
+        std::move(completion)
+    ));
+  }));
+  const PortalCall save_call = portal.WaitForCall(2);
+  REQUIRE(save_call.method == "SaveFile");
+  REQUIRE(save_call.title == "Save File");
+  REQUIRE(save_call.current_name == "exported.txt");
+  REQUIRE(saved.ReadString().Value() == "replacement");
+
+  portal.SetScenario({.defer_response = true, .unexpected_handle = true});
+  std::mutex cancel_mutex;
+  std::condition_variable cancel_condition;
+  bool canceled_complete = false;
+  std::function<void()> cancel = transport->OpenFiles({}, false, [&](std::vector<FileReference> values) {
+    {
+      std::scoped_lock lock(cancel_mutex);
+      canceled_complete = values.empty();
+    }
+    cancel_condition.notify_all();
+  });
+  static_cast<void>(portal.WaitForCall(3));
+  cancel();
+  {
+    std::unique_lock lock(cancel_mutex);
+    REQUIRE(cancel_condition.wait_for(lock, std::chrono::seconds(5), [&] { return canceled_complete; }));
+  }
+  portal.WaitForClose(1);
+
+  portal.SetScenario({.response = 1});
+  REQUIRE(WaitFor<std::vector<FileReference>>([&](auto completion) {
+            static_cast<void>(transport->OpenFiles({}, false, std::move(completion)));
+          }).empty());
+  static_cast<void>(portal.WaitForCall(4));
+  reference_tasks = {};
+  runtime_file_picker.reset();
+}
+
+} // namespace huxerui::test


### PR DESCRIPTION
## Overview

This PR completes the existing cross-platform `FilePicker` and `FileReference` contract on Linux without changing the public API. The backend uses `org.freedesktop.portal.FileChooser` over the session D-Bus, so applications receive the desktop environment picker while HuxerUI stays independent of GTK and Qt.

The implementation is intentionally portal-only. If the session bus or `org.freedesktop.portal.Desktop` service is unavailable, `CanOpenFiles()` and `CanSaveFiles()` report `false`; local `FileSystem` functionality remains unaffected.

## Implementation

### Portal connection and window ownership

- Creates one private GDBus session-bus connection on a dedicated GLib main-context thread.
- Detects or activates `org.freedesktop.portal.Desktop` through the bus daemon and observes `NameOwnerChanged` plus connection closure.
- Updates picker capabilities when the portal disappears and completes active requests instead of leaving the Runtime picker queue blocked.
- Encodes the current X11 window as `x11:<hex-xid>` for the portal parent. An empty parent is used while the native window is not ready.

### Open and save request lifecycle

- Implements `FileChooser.OpenFile` and `FileChooser.SaveFile` with `modal=true`, `multiple`, `current_name`, and an unpredictable `handle_token`.
- Subscribes to `Request.Response` at the predicted request path before invoking the chooser method, then switches to the returned handle when a backend provides a different path.
- Converts extension filters to `*.ext` glob rules and content types to MIME rules inside one union portal filter. Empty filters omit the portal filter options.
- Treats successful responses as valid only when their `uris` values can be converted from local `file://` URIs. Cancellation, portal errors, invalid responses, remote-host URIs, and unsupported URI schemes produce the existing empty/false results.
- Completes Task cancellation immediately, sends `Request.Close`, and allows the shared picker serialization queue to advance. Shutdown waits for in-flight chooser method replies so a late non-predicted request handle can still be closed, then flushes pending Close calls before closing the D-Bus connection.

### File references and saving

- Keeps selected filesystem paths inside a private Linux `FileReferenceState`; no native path is added to the public API.
- Populates name, size, detected MIME type, and currently observable write capability in existing metadata.
- Reuses the shared bounded file executor for reads, imports, replacements, and save copies instead of adding another worker pool.
- Reports `SaveFileAsync` success only after the selected destination has been overwritten successfully with the source file.

### Build and documentation

- Resolves and links `gio-2.0` explicitly in the Linux CMake configuration and registers the Linux picker source and tests.
- Updates dependency installation guidance, platform support, file API documentation, design status, and the files example description.
- The existing `example_files` application exercises the Linux implementation through the unchanged public API.

## Test coverage

The Linux integration suite uses `GTestDBus` and a private fake `org.freedesktop.portal.Desktop`, so tests do not display a real desktop dialog. Coverage includes:

- capability probing and portal owner disappearance
- empty and populated filters, extension/MIME wire shapes, single/multiple selection, X11 parenting, and suggested names
- predicted and unexpected request handles
- success, user cancellation, portal method errors, response errors, invalid URIs, and non-local `file://` URIs
- Task cancellation issuing `Request.Close`, Runtime destruction, connection shutdown, and late responses
- Unicode filenames, metadata, reads, imports, write capability, replacement, and save-copy content consistency

## Validation

- Linux FilePicker focused tests: 5 test cases, 61 assertions
- Full HuxerUI test executable: 669 test cases, 6435 assertions
- Remaining CTest targets: 6/6 passed
- `huxerui_tests` and `example_files` built successfully
- `clang-format --dry-run --Werror` passed for the new Linux implementation and tests
- `git diff --check` passed

A real xdg-desktop-portal service is available on the validation host. Interactive dialog smoke testing was not automated.

## Current scope

- X11 parent handles only; Wayland exported window handles are not added here.
- Files only; directory selection is not introduced.
- No GTK/Qt fallback, persistent grants, application activation, drag-and-drop, or clipboard expansion.
- `CanWrite()` reflects the selected path current observable permission rather than requesting a new writable-open option.