### PR TITLE
fix(http): avoid GCC coroutine aggregate ICE

### DIFF
--- a/tests/runtime/http.cpp
+++ b/tests/runtime/http.cpp
@@ -135,6 +135,21 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
   const std::thread::id ui_thread = std::this_thread::get_id();
 
   http_tasks.Launch([client = http_client]() -> Task<void> {
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 16 || (__GNUC__ == 16 && __GNUC_MINOR__ < 2))
+    HttpRequest request{
+        .url = "https://example.test/items",
+        .method = HttpMethod::Post,
+        .headers =
+            {
+                {"Accept", "application/json"},
+                {"X-Trace", "first"},
+                {"X-Trace", "second"},
+            },
+        .body = "{}",
+        .timeout = std::chrono::milliseconds{5000},
+    };
+    HttpResult result = co_await client->Send(std::move(request));
+#else
     HttpResult result = co_await client->Send({
         .url = "https://example.test/items",
         .method = HttpMethod::Post,
@@ -147,6 +162,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
         .body = "{}",
         .timeout = std::chrono::milliseconds{5000},
     });
+#endif
     if (result.HasResponse()) {
       http_response = std::move(result).Response();
     } else {


### PR DESCRIPTION
## Summary

Avoid a GCC front-end internal compiler error when compiling the HTTP coroutine test with GCC versions older than 16.2.

## Change

- Detect GNU GCC separately from Clang.
- On GCC < 16.2, explicitly construct the `HttpRequest` before passing it to the awaited `HttpClient::Send` call.
- Keep the existing direct aggregate expression for GCC 16.2+, Clang, and other compilers.
- Limit the workaround to the single reproducing test; no public API or production code changes.

## Validation

Executed with GCC 16.1.1:

- The unchanged direct nested aggregate reproduced the compiler ICE at `tests/runtime/http.cpp:143`.
- The guarded explicit construction compiled successfully with the same compiler and flags.
- All 8 HTTP tests passed: 36 assertions.
- `git diff --check` passed.

The full test binary later encountered an unrelated SIGSEGV in `CancelingFilePickerRequestsPreservesPlatformPresentationOrder`; this PR intentionally does not change file-picker behavior.