### PR TITLE
fix(ci): isolate freetype cpack and install linux fontconfig

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -248,7 +248,7 @@ jobs:
             libgles2-mesa-dev libglib2.0-dev libgnutls28-dev libmount-dev libnghttp2-dev \
             libpcre2-dev libpsl-dev libselinux1-dev libsqlite3-dev libx11-dev libxext-dev \
             libxkbcommon-dev libxml2-dev libxrandr-dev ninja-build pkg-config python3-pip \
-            software-properties-common
+            software-properties-common fontconfig fonts-dejavu-core
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-11 g++-11

--- a/cmake/platform/Linux.cmake
+++ b/cmake/platform/Linux.cmake
@@ -143,6 +143,14 @@ foreach (HUXERUI_FETCHED_CMAKE_DEPENDENCY IN ITEMS expat libpng freetype harfbuz
         endif ()
     endif ()
 endforeach ()
+# FreeType unconditionally invokes include(CPack), which writes
+# CPackConfig.cmake and CPackSourceConfig.cmake into the top-level binary
+# directory. When HuxerUI is consumed through add_subdirectory, those files
+# leak into the consumer build and break source-subdirectory validation;
+# remove them so only the consumer's own CPack configuration, if any,
+# remains. Top-level HuxerUI builds regenerate them through HuxerUISdk.cmake.
+file(REMOVE "${CMAKE_BINARY_DIR}/CPackConfig.cmake")
+file(REMOVE "${CMAKE_BINARY_DIR}/CPackSourceConfig.cmake")
 # libpng appends a Debug postfix to its archive name. The fetched
 # libraries build as Release, but the staging target records their
 # outputs through the parent build type, so the postfix would leave a


### PR DESCRIPTION
## Summary

Fixes two CI failures blocking the SDK release workflow on Linux.

## Root Causes and Fixes

### 1. HuxerUISourceSubdirectoryTests — CPackConfig.cmake leak

**Root cause:** [cmake/platform/Linux.cmake](cmake/platform/Linux.cmake) pulls in FreeType via `add_subdirectory`. FreeType's CMakeLists.txt calls `include(CPack)` unconditionally, writing `CPackConfig.cmake` and `CPackSourceConfig.cmake` into the top-level binary directory. When a consumer adds HuxerUI via `add_subdirectory`, these files leak into the consumer build tree and trip the assertion in [tests/cmake/source_subdirectory.cmake](tests/cmake/source_subdirectory.cmake).

**Fix:** Remove the two leaked files after the FreeType `add_subdirectory` call in [cmake/platform/Linux.cmake](cmake/platform/Linux.cmake). The top-level HuxerUI build regenerates them through the `include(CPack)` in `HuxerUISdk.cmake`.

### 2. HuxerUITests — fontconfig Cannot load default config file

**Root cause:** fontconfig is built with hardcoded `FONTCONFIG_PATH=/etc/fonts` and `FC_DEFAULT_FONTS=/usr/share/fonts`. The `sdk-release.yml` Linux build job (ubuntu:20.04 container) did not install `fontconfig` config or font packages, so `FcInit()` failed to load the default config and `FcFontMatch` could not match any font, raising "HuxerUI could not match a font for the requested family".

**Fix:** Add `fontconfig` and `fonts-dejavu-core` to the apt install list in the `build-linux` job of [.github/workflows/sdk-release.yml](.github/workflows/sdk-release.yml).

## Verification

- `HuxerUISourceSubdirectoryTests`: **PASSED** (48.73s) — CPack leak fixed.
- fontconfig errors: **gone** — the five `Linux*` renderer tests that previously failed with "could not match a font" no longer error.
- New failure (unrelated to this PR): `LinuxFilePickerUsesThePortalForReferencesSavingAndCancellation` aborts with `free(): double free detected in tcache 2` on ubuntu:20.04. This is a pre-existing main-branch bug (the test file was not touched by this PR) that was previously masked because CI aborted before reaching it. The test passes locally. Likely a GLib/dbus reference-counting interaction specific to the container's library versions. Needs separate investigation.

## Files Changed

- [cmake/platform/Linux.cmake](cmake/platform/Linux.cmake) — remove leaked CPack files after FreeType subdirectory.
- [.github/workflows/sdk-release.yml](.github/workflows/sdk-release.yml) — install fontconfig config and DejaVu fonts in the Linux build container.