### PR TITLE
fix(linux): synchronize file picker portal cleanup

### DIFF
--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -373,6 +373,12 @@ private:
       g_object_unref(connection_);
       connection_ = nullptr;
     }
+    // Drain pending GSource releases (e.g. GDestroyNotify callbacks from
+    // g_dbus_connection_signal_unsubscribe) before leaving the context, so
+    // GLib worker threads finish accessing connection state here rather than
+    // after the context is no longer thread-default.
+    while (g_main_context_iteration(context_, FALSE)) {
+    }
     g_main_context_pop_thread_default(context_);
   }
 

--- a/tests/platform/linux_file_picker.cpp
+++ b/tests/platform/linux_file_picker.cpp
@@ -252,11 +252,11 @@ public:
               request->failure = "The fake portal did not own its bus name";
             }
             request->finished = true;
+            request->condition.notify_all();
           }
           if (error != nullptr) {
             g_error_free(error);
           }
-          request->condition.notify_all();
           return G_SOURCE_REMOVE;
         },
         &request,
@@ -375,6 +375,8 @@ private:
       static_cast<void>(g_dbus_connection_close_sync(connection_, nullptr, nullptr));
       g_object_unref(connection_);
       connection_ = nullptr;
+    }
+    while (g_main_context_iteration(context_, FALSE)) {
     }
     g_main_context_pop_thread_default(context_);
   }
@@ -588,10 +590,8 @@ template <class Value> Value WaitFor(std::function<void(std::function<void(Value
   std::condition_variable condition;
   std::optional<Value> value;
   start([&](Value result) {
-    {
-      std::scoped_lock lock(mutex);
-      value.emplace(std::move(result));
-    }
+    std::scoped_lock lock(mutex);
+    value.emplace(std::move(result));
     condition.notify_all();
   });
   std::unique_lock lock(mutex);


### PR DESCRIPTION
## Summary

- Drain pending GLib sources before the Linux file picker portal context leaves its thread-default scope.
- Apply the same shutdown behavior to the fake portal used by platform tests.
- Keep condition-variable notification under the associated mutex so stack-owned synchronization state cannot be destroyed while a callback is still notifying it.

## Problem

The latest Linux CI run failed `LinuxFilePickerUsesThePortalForReferencesSavingAndCancellation` on x86_64 with `free(): double free detected in tcache 2`; the aarch64 job later stalled until cancellation. The failure was intermittent and occurred after an asynchronous portal request completed.

ThreadSanitizer identified a concrete lifetime race in the test synchronization helper: the worker callback updated the completion predicate, released the mutex, and then called `notify_all()`. The waiting thread could observe the predicate, return from the helper, and destroy its stack-owned `std::condition_variable` while the callback was still inside `pthread_cond_broadcast`. The fake portal name-release path used the same notification pattern.

Portal shutdown could also leave GLib destroy notifications queued after the D-Bus connection was unsubscribed and unreferenced. Those pending sources could continue touching connection-related state after the thread-default context was popped.

## Changes

- Iterate the portal `GMainContext` after disconnecting and releasing the D-Bus connection, before popping the thread-default context.
- Mirror that context drain in `FakePortal` so production and test teardown have equivalent lifetime boundaries.
- Move `FakePortal::ReleaseName()` notification into the request mutex critical section.
- Hold the `WaitFor()` mutex through both predicate publication and `notify_all()`.

## Validation

- `ctest --test-dir build -R ^HuxerUITests$ --output-on-failure`
- Reproduced the CI test with random seed `1895247836`: 33 assertions passed.
- Normal build stress: 500 repetitions of the failing picker test and 200 repetitions of portal-disappearance cleanup.
- AddressSanitizer: 200 and 100 repetitions respectively.
- ThreadSanitizer: 20 repetitions of each path; the `condition_variable` destruction/broadcast race no longer appears.
- `git diff --check`

## TSan note

The host GLib/GIO packages are not TSan-instrumented and still produce allocator/interceptor noise under TSan. The directly actionable C++ condition-variable race reported from this test code is resolved.