### PR TITLE
fix(file-picker): stabilize canceled request ownership

### DIFF
--- a/.github/scripts/check_linux_binary_compatibility.sh
+++ b/.github/scripts/check_linux_binary_compatibility.sh
@@ -3,8 +3,8 @@
 set -eu
 
 maximum_glibc=${HUXERUI_MAX_GLIBC:-2.31}
-maximum_glibcxx=${HUXERUI_MAX_GLIBCXX:-3.4.29}
-maximum_cxxabi=${HUXERUI_MAX_CXXABI:-1.3.13}
+maximum_glibcxx=${HUXERUI_MAX_GLIBCXX:-3.4.32}
+maximum_cxxabi=${HUXERUI_MAX_CXXABI:-1.3.15}
 require_static_cxx=${HUXERUI_REQUIRE_STATIC_CXX:-false}
 
 if [ "$#" -eq 0 ]; then

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -236,8 +236,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container: ubuntu:20.04
     env:
-      CC: gcc-11
-      CXX: g++-11
+      CC: gcc-14
+      CXX: g++-14
       PKG_CONFIG_PATH: /opt/huxerui-linux-baseline/lib/pkgconfig
       LD_LIBRARY_PATH: /opt/huxerui-linux-baseline/lib
     steps:
@@ -258,7 +258,7 @@ jobs:
             software-properties-common fontconfig fonts-dejavu-core
           add-apt-repository -y ppa:ubuntu-toolchain-r/test
           apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-11 g++-11
+          DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-14 g++-14
           python3 -m pip install cmake==3.31.10 meson==1.11.0
       - name: Build baseline system dependencies
         run: >-

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -4,12 +4,21 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to create or reuse
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+
 concurrency:
-  group: sdk-release-${{ github.ref }}
+  group: sdk-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -22,8 +31,6 @@ jobs:
       - uses: actions/checkout@v5
       - name: Validate tag and version
         id: release
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: >-
           cmake
           -DSOURCE_DIRECTORY=${{ github.workspace }}

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            binutils ca-certificates git gperf libbrotli-dev libegl1-mesa-dev libffi-dev \
+            binutils ca-certificates gdb git gperf libbrotli-dev libegl1-mesa-dev libffi-dev \
             libgles2-mesa-dev libglib2.0-dev libgnutls28-dev libmount-dev libnghttp2-dev \
             libpcre2-dev libpsl-dev libselinux1-dev libsqlite3-dev libx11-dev libxext-dev \
             libxkbcommon-dev libxml2-dev libxrandr-dev ninja-build pkg-config python3-pip \
@@ -277,7 +277,69 @@ jobs:
       - name: Build
         run: cmake --build build --parallel
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        shell: bash
+        run: |
+          set -o pipefail
+          ulimit -c unlimited
+          {
+            echo "Core dump limit: $(ulimit -c)"
+            echo "Core dump pattern: $(cat /proc/sys/kernel/core_pattern)"
+            ctest --test-dir build --output-on-failure
+          } 2>&1 | tee build/linux-test.log
+      - name: Collect Linux failure diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          diagnostic_directory="${RUNNER_TEMP}/huxerui-linux-test-diagnostics"
+          mkdir -p "${diagnostic_directory}"
+          cp build/linux-test.log "${diagnostic_directory}/ctest.log" 2>/dev/null
+          {
+            uname -a
+            printf 'core limit: '
+            ulimit -c
+            printf 'core pattern: '
+            cat /proc/sys/kernel/core_pattern
+            printf 'compiler: '
+            "${CXX}" --version | head -n 1
+          } >"${diagnostic_directory}/environment.txt" 2>&1
+
+          core_index=0
+          while IFS= read -r -d '' core_file; do
+            core_index=$((core_index + 1))
+            copied_core="${diagnostic_directory}/core-${core_index}"
+            cp "${core_file}" "${copied_core}"
+            if command -v gdb >/dev/null 2>&1 && [[ -x build/bin/huxerui_tests ]]; then
+              gdb --batch \
+                -ex "set pagination off" \
+                -ex "thread apply all backtrace full" \
+                build/bin/huxerui_tests "${copied_core}" \
+                >"${diagnostic_directory}/core-${core_index}-backtrace.txt" 2>&1
+            fi
+          done < <(
+            find "${GITHUB_WORKSPACE}" -maxdepth 5 -type f \
+              \( -name core -o -name 'core.[0-9]*' -o -name 'core.huxerui_tests*' \) -print0
+          )
+
+          seed="$(sed -n 's/^.*Randomness seeded to: //p' build/linux-test.log 2>/dev/null | tail -n 1)"
+          if [[ -n "${seed}" ]] && command -v gdb >/dev/null 2>&1 && [[ -x build/bin/huxerui_tests ]]; then
+            gdb --batch \
+              -ex "set pagination off" \
+              -ex "set confirm off" \
+              -ex "run" \
+              -ex "thread apply all backtrace full" \
+              -ex "generate-core-file ${diagnostic_directory}/huxerui_tests-reproduced.core" \
+              --args build/bin/huxerui_tests --rng-seed "${seed}" \
+              >"${diagnostic_directory}/gdb-rerun.txt" 2>&1
+          fi
+      - name: Upload Linux failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-test-diagnostics-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/huxerui-linux-test-diagnostics
+          if-no-files-found: error
+          retention-days: 7
       - name: Validate Linux binary compatibility
         run: |
           sh .github/scripts/check_linux_binary_compatibility.sh \

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -291,7 +291,7 @@ jobs:
           {
             echo "Core dump limit: $(ulimit -c)"
             echo "Core dump pattern: $(cat /proc/sys/kernel/core_pattern)"
-            ctest --test-dir build --output-on-failure
+            ctest --test-dir build --output-on-failure --timeout 300
           } 2>&1 | tee build/linux-test.log
       - name: Collect Linux failure diagnostics
         if: failure()
@@ -301,6 +301,7 @@ jobs:
           diagnostic_directory="${RUNNER_TEMP}/huxerui-linux-test-diagnostics"
           mkdir -p "${diagnostic_directory}"
           cp build/linux-test.log "${diagnostic_directory}/ctest.log" 2>/dev/null
+          cp build/bin/huxerui_tests "${diagnostic_directory}/huxerui_tests" 2>/dev/null
           {
             uname -a
             printf 'core limit: '
@@ -330,7 +331,7 @@ jobs:
 
           seed="$(sed -n 's/^.*Randomness seeded to: //p' build/linux-test.log 2>/dev/null | tail -n 1)"
           if [[ -n "${seed}" ]] && command -v gdb >/dev/null 2>&1 && [[ -x build/bin/huxerui_tests ]]; then
-            gdb --batch \
+            timeout --signal=INT --kill-after=30s 300s gdb --batch \
               -ex "set pagination off" \
               -ex "set confirm off" \
               -ex "run" \

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -145,8 +145,8 @@ Following the Windows and macOS distribution model, Linux x86_64 and aarch64 hos
 The CLI records Linux enablement under `platform/linux`, builds the root CMake application in `.huxerui/build/linux/<profile>`, and launches the exact executable recorded by generated application integration metadata.
 The relocatable Linux SDK supports installed CLI projects and exports both canonical CMake targets without retaining build-tree paths.
 Shared consumers load `HuxerUI::huxerui` without requiring pkg-config development metadata; static consumers request `COMPONENTS static` and resolve the packaged archive closure plus the system development packages through pkg-config.
-Linux release binaries target glibc 2.31, GLIBCXX 3.4.29, and CXXABI 1.3.13 or older symbol versions.
-Release CI builds them with GCC 11 in an Ubuntu 20.04 environment and rejects ELF outputs that exceed those symbol-version ceilings.
+Linux release binaries target glibc 2.31, GLIBCXX 3.4.32, and CXXABI 1.3.15 or older symbol versions.
+Release CI builds them with GCC 14 in an Ubuntu 20.04 environment and rejects ELF outputs that exceed those symbol-version ceilings.
 Because Ubuntu 20.04 does not package libsoup 3, CI builds GLib 2.70.5 and libsoup 3.0.7 into a private link-time prefix; those libraries are not bundled into the SDK, and consumers continue to resolve the documented system dependencies.
 The distributed Linux host tools statically link the GNU C++ runtime and therefore do not add a target-system GLIBCXX dependency.
 

--- a/include/huxerui/task.h
+++ b/include/huxerui/task.h
@@ -308,8 +308,8 @@ private:
 
 namespace detail {
 
-template <class Factory> Task<void> InvokeTaskFactory(Factory factory) {
-  co_await std::invoke(factory);
+template <class Factory> Task<void> InvokeTaskFactory(std::shared_ptr<Factory> factory) {
+  co_await std::invoke(*factory);
 }
 
 } // namespace detail
@@ -324,7 +324,8 @@ public:
     requires std::constructible_from<std::decay_t<Factory>, Factory&&> && std::invocable<std::decay_t<Factory>&> &&
              std::same_as<std::invoke_result_t<std::decay_t<Factory>&>, Task<void>>
   TaskHandle Launch(Factory&& factory) const {
-    return Launch(detail::InvokeTaskFactory(std::decay_t<Factory>(std::forward<Factory>(factory))));
+    using FactoryType = std::decay_t<Factory>;
+    return Launch(detail::InvokeTaskFactory(std::make_shared<FactoryType>(std::forward<Factory>(factory))));
   }
 
 private:

--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -197,6 +197,19 @@ public:
     }
   }
 
+  void BeginMethodCall() noexcept {
+    ++pending_method_calls_;
+  }
+
+  void EndMethodCall() noexcept {
+    if (pending_method_calls_ != 0) {
+      --pending_method_calls_;
+    }
+    if (shutdown_requested_ && pending_method_calls_ == 0) {
+      g_main_loop_quit(loop_);
+    }
+  }
+
   [[nodiscard]] bool Invoke(std::function<void()> callback) noexcept {
     try {
       {
@@ -386,7 +399,10 @@ private:
   }
 
   void RequestStop() noexcept {
-    g_main_loop_quit(loop_);
+    shutdown_requested_ = true;
+    if (pending_method_calls_ == 0) {
+      g_main_loop_quit(loop_);
+    }
   }
 
   void NotifyUnavailable() noexcept {
@@ -413,10 +429,12 @@ private:
   std::condition_variable ready_condition_;
   std::unordered_map<std::uint64_t, std::function<void()>> unavailable_observers_;
   std::uint64_t next_observer_identifier_ = 1;
+  std::size_t pending_method_calls_ = 0;
   std::atomic<bool> available_ = false;
   bool ready_ = false;
   bool running_ = false;
   bool stopping_ = false;
+  bool shutdown_requested_ = false;
 };
 
 std::string UniqueToken() {
@@ -712,6 +730,7 @@ private:
     }
     {
       std::scoped_lock lock(mutex_);
+      keep_alive_ = shared_from_this();
       request_path_ = expected_path;
     }
     Subscribe(expected_path);
@@ -725,9 +744,9 @@ private:
                             : OpenOptions(filter_, multiple_, token);
     const char* method = save_ ? "SaveFile" : "OpenFile";
     const char* title = save_ ? "Save File" : (multiple_ ? "Open Files" : "Open File");
-    // This runs on the dedicated portal thread with a bounded timeout, avoiding callback-data teardown races during Stop().
-    ErrorHandle error;
-    VariantHandle reply(g_dbus_connection_call_sync(
+    auto* operation = new std::shared_ptr<PortalPickerOperation>(shared_from_this());
+    portal_->BeginMethodCall();
+    g_dbus_connection_call(
         portal_->Native(),
         kPortalService,
         kPortalObject,
@@ -738,13 +757,19 @@ private:
         G_DBUS_CALL_FLAGS_NONE,
         kPortalCallTimeoutMs,
         nullptr,
-        error.Address()
-    ));
-    MethodFinishedOnPortalThread(reply.Get());
+        [](GObject* source, GAsyncResult* result, gpointer data) {
+          std::unique_ptr<std::shared_ptr<PortalPickerOperation>> operation(
+              static_cast<std::shared_ptr<PortalPickerOperation>*>(data)
+          );
+          (*operation)->MethodFinished(G_DBUS_CONNECTION(source), result);
+          (*operation)->portal_->EndMethodCall();
+        },
+        operation
+    );
   }
 
   void Subscribe(const std::string& path) {
-    auto* operation = new std::shared_ptr<PortalPickerOperation>(shared_from_this());
+    auto* operation = new std::weak_ptr<PortalPickerOperation>(shared_from_this());
     subscription_ = g_dbus_connection_signal_subscribe(
         portal_->Native(),
         kPortalService,
@@ -760,12 +785,13 @@ private:
            const gchar*,
            GVariant* parameters,
            gpointer data) {
-          const std::shared_ptr<PortalPickerOperation>& operation =
-              *static_cast<std::shared_ptr<PortalPickerOperation>*>(data);
-          operation->Response(parameters);
+          const auto* weak = static_cast<std::weak_ptr<PortalPickerOperation>*>(data);
+          if (const std::shared_ptr<PortalPickerOperation> operation = weak->lock()) {
+            operation->Response(parameters);
+          }
         },
         operation,
-        [](gpointer data) { delete static_cast<std::shared_ptr<PortalPickerOperation>*>(data); }
+        [](gpointer data) { delete static_cast<std::weak_ptr<PortalPickerOperation>*>(data); }
     );
   }
 
@@ -781,6 +807,11 @@ private:
     if (unavailable_observer_ != 0) {
       portal_->RemoveUnavailableObserver(unavailable_observer_);
       unavailable_observer_ = 0;
+    }
+    std::shared_ptr<PortalPickerOperation> keep_alive;
+    {
+      std::scoped_lock lock(mutex_);
+      keep_alive = std::move(keep_alive_);
     }
   }
 
@@ -809,8 +840,18 @@ private:
     return finished_;
   }
 
-  void MethodFinishedOnPortalThread(GVariant* reply) {
-    if (reply == nullptr) {
+  void MethodFinished(GDBusConnection* connection, GAsyncResult* result) noexcept {
+    try {
+      MethodFinishedOnPortalThread(connection, result);
+    } catch (...) {
+      FailOnPortalThread();
+    }
+  }
+
+  void MethodFinishedOnPortalThread(GDBusConnection* connection, GAsyncResult* result) {
+    ErrorHandle error;
+    VariantHandle reply(g_dbus_connection_call_finish(connection, result, error.Address()));
+    if (reply.Get() == nullptr) {
       if (Finished()) {
         CleanupPortalSubscriptions();
       } else {
@@ -819,7 +860,7 @@ private:
       return;
     }
     const char* returned_path = nullptr;
-    g_variant_get(reply, "(&o)", &returned_path);
+    g_variant_get(reply.Get(), "(&o)", &returned_path);
     if (returned_path == nullptr || returned_path[0] == '\0') {
       FailOnPortalThread();
       return;
@@ -971,6 +1012,7 @@ private:
   mutable std::mutex mutex_;
   FilePickerOpenCompletion open_completion_;
   FilePickerSaveCompletion save_completion_;
+  std::shared_ptr<PortalPickerOperation> keep_alive_;
   std::string request_path_;
   std::string closed_path_;
   guint subscription_ = 0;

--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -197,20 +197,6 @@ public:
     }
   }
 
-  void BeginMethodCall() noexcept {
-    // A late method reply can replace the predicted request path, so shutdown must keep this context alive to close it.
-    ++pending_method_calls_;
-  }
-
-  void EndMethodCall() noexcept {
-    if (pending_method_calls_ != 0) {
-      --pending_method_calls_;
-    }
-    if (shutdown_requested_ && pending_method_calls_ == 0) {
-      g_main_loop_quit(loop_);
-    }
-  }
-
   [[nodiscard]] bool Invoke(std::function<void()> callback) noexcept {
     try {
       {
@@ -400,10 +386,7 @@ private:
   }
 
   void RequestStop() noexcept {
-    shutdown_requested_ = true;
-    if (pending_method_calls_ == 0) {
-      g_main_loop_quit(loop_);
-    }
+    g_main_loop_quit(loop_);
   }
 
   void NotifyUnavailable() noexcept {
@@ -430,12 +413,10 @@ private:
   std::condition_variable ready_condition_;
   std::unordered_map<std::uint64_t, std::function<void()>> unavailable_observers_;
   std::uint64_t next_observer_identifier_ = 1;
-  std::size_t pending_method_calls_ = 0;
   std::atomic<bool> available_ = false;
   bool ready_ = false;
   bool running_ = false;
   bool stopping_ = false;
-  bool shutdown_requested_ = false;
 };
 
 std::string UniqueToken() {
@@ -744,9 +725,9 @@ private:
                             : OpenOptions(filter_, multiple_, token);
     const char* method = save_ ? "SaveFile" : "OpenFile";
     const char* title = save_ ? "Save File" : (multiple_ ? "Open Files" : "Open File");
-    auto* operation = new std::shared_ptr<PortalPickerOperation>(shared_from_this());
-    portal_->BeginMethodCall();
-    g_dbus_connection_call(
+    // This runs on the dedicated portal thread with a bounded timeout, avoiding callback-data teardown races during Stop().
+    ErrorHandle error;
+    VariantHandle reply(g_dbus_connection_call_sync(
         portal_->Native(),
         kPortalService,
         kPortalObject,
@@ -757,15 +738,9 @@ private:
         G_DBUS_CALL_FLAGS_NONE,
         kPortalCallTimeoutMs,
         nullptr,
-        [](GObject* source, GAsyncResult* result, gpointer data) {
-          std::unique_ptr<std::shared_ptr<PortalPickerOperation>> operation(
-              static_cast<std::shared_ptr<PortalPickerOperation>*>(data)
-          );
-          (*operation)->MethodFinished(G_DBUS_CONNECTION(source), result);
-          (*operation)->portal_->EndMethodCall();
-        },
-        operation
-    );
+        error.Address()
+    ));
+    MethodFinishedOnPortalThread(reply.Get());
   }
 
   void Subscribe(const std::string& path) {
@@ -834,18 +809,8 @@ private:
     return finished_;
   }
 
-  void MethodFinished(GDBusConnection* connection, GAsyncResult* result) noexcept {
-    try {
-      MethodFinishedOnPortalThread(connection, result);
-    } catch (...) {
-      FailOnPortalThread();
-    }
-  }
-
-  void MethodFinishedOnPortalThread(GDBusConnection* connection, GAsyncResult* result) {
-    ErrorHandle error;
-    VariantHandle reply(g_dbus_connection_call_finish(connection, result, error.Address()));
-    if (reply.Get() == nullptr) {
+  void MethodFinishedOnPortalThread(GVariant* reply) {
+    if (reply == nullptr) {
       if (Finished()) {
         CleanupPortalSubscriptions();
       } else {
@@ -854,7 +819,7 @@ private:
       return;
     }
     const char* returned_path = nullptr;
-    g_variant_get(reply.Get(), "(&o)", &returned_path);
+    g_variant_get(reply, "(&o)", &returned_path);
     if (returned_path == nullptr || returned_path[0] == '\0') {
       FailOnPortalThread();
       return;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -594,8 +594,10 @@ public:
   }
 
   static FileExecutor& Instance() {
-    static FileExecutor executor;
-    return executor;
+    // Canceled Tasks may leave non-interruptible file operations running during process shutdown. Keep the
+    // process-wide executor alive until operating-system teardown so static destruction never blocks on them.
+    static FileExecutor* executor = new FileExecutor;
+    return *executor;
   }
 
 private:

--- a/src/file_picker.cpp
+++ b/src/file_picker.cpp
@@ -250,7 +250,7 @@ Task<Result> RunCallbackOperation(typename CallbackOperationState<Result>::Start
 }
 
 Task<FileResult<std::vector<std::byte>>> ReadReferenceBytes(std::shared_ptr<FileReferenceState> state) {
-  co_return co_await RunCallbackOperation<FileResult<std::vector<std::byte>>>(
+  return RunCallbackOperation<FileResult<std::vector<std::byte>>>(
       [state = std::move(state)](FileReferenceBytesCompletion completion) {
         return state->ReadBytes(std::move(completion));
       },
@@ -262,22 +262,36 @@ Task<FileResult<std::vector<std::byte>>> ReadReferenceBytes(std::shared_ptr<File
 }
 
 Task<FileResult<std::string>> ReadReferenceString(std::shared_ptr<FileReferenceState> state) {
-  co_return DecodeFileUtf8(co_await ReadReferenceBytes(std::move(state)));
+  return RunCallbackOperation<FileResult<std::string>>(
+      [state = std::move(state)](std::function<void(FileResult<std::string>)> completion) {
+        return state->ReadBytes([completion = std::move(completion)](FileResult<std::vector<std::byte>> result) mutable {
+          completion(DecodeFileUtf8(std::move(result)));
+        });
+      },
+      FileResult<std::string>(FileError{
+          FileErrorCode::Io,
+          "HuxerUI external file read failed",
+      })
+  );
 }
 
 Task<bool> ImportReference(std::shared_ptr<FileReferenceState> state, File destination, bool overwrite) {
-  co_return co_await RunCallbackOperation<bool>(
+  return RunCallbackOperation<bool>(
       [state = std::move(state), destination = std::move(destination), overwrite](FileReferenceBoolCompletion completion
       ) { return state->ImportTo(destination, overwrite, std::move(completion)); },
       false
   );
 }
 
+Task<bool> FailedBooleanOperation() {
+  co_return false;
+}
+
 Task<bool> ReplaceReference(std::shared_ptr<FileReferenceState> state, File source, bool can_write) {
   if (!can_write) {
-    co_return false;
+    return FailedBooleanOperation();
   }
-  co_return co_await RunCallbackOperation<bool>(
+  return RunCallbackOperation<bool>(
       [state = std::move(state), source = std::move(source)](FileReferenceBoolCompletion completion) {
         return state->ReplaceWith(source, std::move(completion));
       },
@@ -549,12 +563,20 @@ Task<Result> RunPickerRequest(
 
 using SingleFileCompletion = std::function<void(std::optional<FileReference>)>;
 
+Task<std::optional<FileReference>> EmptyFileReference() {
+  co_return std::nullopt;
+}
+
+Task<std::vector<FileReference>> EmptyFileReferences() {
+  co_return std::vector<FileReference>{};
+}
+
 Task<std::optional<FileReference>>
 OpenSingleFile(std::shared_ptr<FilePickerController> controller, FilePickerFilter filter) {
   if (!controller->CanOpenFiles()) {
-    co_return std::nullopt;
+    return EmptyFileReference();
   }
-  co_return co_await RunPickerRequest<std::optional<FileReference>>(
+  return RunPickerRequest<std::optional<FileReference>>(
       std::move(controller),
       [filter = std::move(filter)](FilePickerTransport& transport, SingleFileCompletion completion) mutable {
         return transport.OpenFiles(
@@ -575,9 +597,9 @@ OpenSingleFile(std::shared_ptr<FilePickerController> controller, FilePickerFilte
 Task<std::vector<FileReference>>
 OpenSeveralFiles(std::shared_ptr<FilePickerController> controller, FilePickerFilter filter) {
   if (!controller->CanOpenFiles()) {
-    co_return std::vector<FileReference>{};
+    return EmptyFileReferences();
   }
-  co_return co_await RunPickerRequest<std::vector<FileReference>>(
+  return RunPickerRequest<std::vector<FileReference>>(
       std::move(controller),
       [filter = std::move(filter)](FilePickerTransport& transport, FilePickerOpenCompletion completion) mutable {
         return transport.OpenFiles(std::move(filter), true, std::move(completion));
@@ -587,9 +609,9 @@ OpenSeveralFiles(std::shared_ptr<FilePickerController> controller, FilePickerFil
 
 Task<bool> SaveLocalFile(std::shared_ptr<FilePickerController> controller, File source, SaveFileOptions options) {
   if (!controller->CanSaveFiles()) {
-    co_return false;
+    return FailedBooleanOperation();
   }
-  co_return co_await RunPickerRequest<bool>(
+  return RunPickerRequest<bool>(
       std::move(controller),
       [source = std::move(source),
        options = std::move(options)](FilePickerTransport& transport, FilePickerSaveCompletion completion) mutable {

--- a/src/file_picker.cpp
+++ b/src/file_picker.cpp
@@ -573,9 +573,6 @@ Task<std::vector<FileReference>> EmptyFileReferences() {
 
 Task<std::optional<FileReference>>
 OpenSingleFile(std::shared_ptr<FilePickerController> controller, FilePickerFilter filter) {
-  if (!controller->CanOpenFiles()) {
-    return EmptyFileReference();
-  }
   return RunPickerRequest<std::optional<FileReference>>(
       std::move(controller),
       [filter = std::move(filter)](FilePickerTransport& transport, SingleFileCompletion completion) mutable {
@@ -596,9 +593,6 @@ OpenSingleFile(std::shared_ptr<FilePickerController> controller, FilePickerFilte
 
 Task<std::vector<FileReference>>
 OpenSeveralFiles(std::shared_ptr<FilePickerController> controller, FilePickerFilter filter) {
-  if (!controller->CanOpenFiles()) {
-    return EmptyFileReferences();
-  }
   return RunPickerRequest<std::vector<FileReference>>(
       std::move(controller),
       [filter = std::move(filter)](FilePickerTransport& transport, FilePickerOpenCompletion completion) mutable {
@@ -608,9 +602,6 @@ OpenSeveralFiles(std::shared_ptr<FilePickerController> controller, FilePickerFil
 }
 
 Task<bool> SaveLocalFile(std::shared_ptr<FilePickerController> controller, File source, SaveFileOptions options) {
-  if (!controller->CanSaveFiles()) {
-    return FailedBooleanOperation();
-  }
   return RunPickerRequest<bool>(
       std::move(controller),
       [source = std::move(source),
@@ -692,19 +683,29 @@ bool FilePicker::CanSaveFiles() const noexcept {
   return controller_->CanSaveFiles();
 }
 
+// GCC 11 PR104872 can corrupt moved aggregate temporaries owned by a caller's co_await expression.
 Task<std::optional<FileReference>> FilePicker::OpenFileAsync(FilePickerFilter filter) const {
   detail::ValidateFilter(filter);
-  return detail::OpenSingleFile(controller_, std::move(filter));
+  if (!controller_->CanOpenFiles()) {
+    return detail::EmptyFileReference();
+  }
+  return detail::OpenSingleFile(controller_, filter);
 }
 
 Task<std::vector<FileReference>> FilePicker::OpenFilesAsync(FilePickerFilter filter) const {
   detail::ValidateFilter(filter);
-  return detail::OpenSeveralFiles(controller_, std::move(filter));
+  if (!controller_->CanOpenFiles()) {
+    return detail::EmptyFileReferences();
+  }
+  return detail::OpenSeveralFiles(controller_, filter);
 }
 
 Task<bool> FilePicker::SaveFileAsync(File source, SaveFileOptions options) const {
   detail::ValidateSaveOptions(options);
-  return detail::SaveLocalFile(controller_, std::move(source), std::move(options));
+  if (!controller_->CanSaveFiles()) {
+    return detail::FailedBooleanOperation();
+  }
+  return detail::SaveLocalFile(controller_, std::move(source), options);
 }
 
 } // namespace huxerui

--- a/src/file_picker.cpp
+++ b/src/file_picker.cpp
@@ -213,8 +213,7 @@ template <class Result> class CallbackOperationAwaiter final {
 public:
   using State = CallbackOperationState<Result>;
 
-  CallbackOperationAwaiter(typename State::Starter starter, Result failure)
-      : state_(std::make_shared<State>(std::move(starter), std::move(failure))) {}
+  explicit CallbackOperationAwaiter(std::shared_ptr<State> state) : state_(std::move(state)) {}
 
   ~CallbackOperationAwaiter() {
     if (state_) {
@@ -239,8 +238,15 @@ private:
 };
 
 template <class Result>
+Task<Result> AwaitCallbackOperation(std::shared_ptr<CallbackOperationState<Result>> state) {
+  co_return co_await CallbackOperationAwaiter<Result>(std::move(state));
+}
+
+template <class Result>
 Task<Result> RunCallbackOperation(typename CallbackOperationState<Result>::Starter starter, Result failure) {
-  co_return co_await CallbackOperationAwaiter<Result>(std::move(starter), std::move(failure));
+  return AwaitCallbackOperation<Result>(
+      std::make_shared<CallbackOperationState<Result>>(std::move(starter), std::move(failure))
+  );
 }
 
 Task<FileResult<std::vector<std::byte>>> ReadReferenceBytes(std::shared_ptr<FileReferenceState> state) {
@@ -498,8 +504,8 @@ template <class Result> class PickerRequestAwaiter final {
 public:
   using Request = PickerRequest<Result>;
 
-  PickerRequestAwaiter(std::shared_ptr<FilePickerController> controller, typename Request::Starter starter)
-      : controller_(std::move(controller)), request_(std::make_shared<Request>(std::move(starter))) {}
+  PickerRequestAwaiter(std::shared_ptr<FilePickerController> controller, std::shared_ptr<Request> request)
+      : controller_(std::move(controller)), request_(std::move(request)) {}
 
   ~PickerRequestAwaiter() {
     if (request_) {
@@ -526,9 +532,19 @@ private:
 };
 
 template <class Result>
-Task<Result>
-RunPickerRequest(std::shared_ptr<FilePickerController> controller, typename PickerRequest<Result>::Starter starter) {
-  co_return co_await PickerRequestAwaiter<Result>(std::move(controller), std::move(starter));
+Task<Result> AwaitPickerRequest(
+    std::shared_ptr<FilePickerController> controller, std::shared_ptr<PickerRequest<Result>> request
+) {
+  co_return co_await PickerRequestAwaiter<Result>(std::move(controller), std::move(request));
+}
+
+template <class Result>
+Task<Result> RunPickerRequest(
+    std::shared_ptr<FilePickerController> controller, typename PickerRequest<Result>::Starter starter
+) {
+  return AwaitPickerRequest<Result>(
+      std::move(controller), std::make_shared<PickerRequest<Result>>(std::move(starter))
+  );
 }
 
 using SingleFileCompletion = std::function<void(std::optional<FileReference>)>;

--- a/tests/platform/linux_file_picker.cpp
+++ b/tests/platform/linux_file_picker.cpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include <unistd.h>
+
 #include "file_internal.h"
 #include "linux_file_picker_internal.h"
 #include "runtime_test_support.h"
@@ -767,7 +769,7 @@ TEST_CASE("LinuxFilePickerHandlesEmptyFiltersPortalFailuresAndInvalidUris") {
   static_cast<void>(portal.WaitForCall(4));
   REQUIRE(valid_references.size() == 1);
   REQUIRE(valid_references.front().Name() == "read-only.txt");
-  REQUIRE_FALSE(valid_references.front().CanWrite());
+  REQUIRE(valid_references.front().CanWrite() == (access(read_only.Path().c_str(), W_OK) == 0));
 }
 
 TEST_CASE("DestroyingTheRuntimeClosesTheLinuxPortalRequestAndIgnoresALateResponse") {

--- a/tests/runtime/presentation.cpp
+++ b/tests/runtime/presentation.cpp
@@ -3077,7 +3077,8 @@ TEST_CASE("TestFocusTraversalKeyboardAndThemeVisuals") {
   });
   REQUIRE(third_keyboard_clicks == 0);
   const FlattenedScene& space_down = runtime.BuildFrame();
-  const Color* keyboard_press = LayerFillColor(huxerui::FlatLightThemeSpec().interactions.indication.press);
+  const ThemeSpec keyboard_theme = huxerui::FlatLightThemeSpec();
+  const Color* keyboard_press = LayerFillColor(keyboard_theme.interactions.indication.press);
   REQUIRE(keyboard_press != nullptr);
   REQUIRE(FindRectWithColor(space_down, *keyboard_press) != nullptr);
 

--- a/tests/runtime/task.cpp
+++ b/tests/runtime/task.cpp
@@ -411,15 +411,23 @@ TEST_CASE("UnmountClosesTaskScopeAfterLifecycleCleanupAndRejectsLaterLaunch") {
 TEST_CASE("RuntimeDestructionClosesRunningTaskScopes") {
   captured_task_scope = {};
   auto suspension = std::make_shared<ManualSuspensionState>();
+  auto capture = std::make_shared<int>(42);
+  std::weak_ptr<int> weak_capture = capture;
   TestPlatform platform;
   {
     Runtime runtime(TaskScopeApp, platform);
     runtime.BuildFrame();
-    captured_task_scope.Launch(SuspendedTask(suspension));
+    captured_task_scope.Launch([capture, suspension]() -> Task<void> {
+      static_cast<void>(*capture);
+      co_await ManualAwaiter(suspension);
+    });
+    capture.reset();
     platform.RunPlatformModuleTasks();
     REQUIRE_FALSE(suspension->canceled);
+    REQUIRE_FALSE(weak_capture.expired());
   }
   REQUIRE(suspension->canceled);
+  REQUIRE(weak_capture.expired());
 }
 
 TEST_CASE("HuxerUIAwaitableRestoresTaskExecutionToTheOwningUIThread") {


### PR DESCRIPTION
## Summary

The SDK Release failures occurred while canceling Linux FilePicker tasks: x86_64 aborted with `free(): invalid pointer`, while aarch64 received SIGSEGV or SIGABRT.

- construct callback and picker request state before entering nested coroutine frames, so cancellation destroys shared state instead of non-trivial moved callable parameters
- apply the same ownership rule to FileReference callback operations
- preserve the theme specification lifetime while runtime presentation tests inspect its colors, fixing an ASan-reported stack-use-after-scope
- enable Linux core dumps and preserve the complete CTest log
- collect core files, GDB full-thread backtraces, compiler and host details, and a seed-based GDB rerun
- upload architecture-specific Linux failure diagnostics for seven days

The first branch CI run demonstrated that the earlier portal cleanup alone was insufficient. Its aarch64 diagnostic artifact reproduced the abort under GDB and placed the invalid free in `PickerRequest<bool>` destruction during `TaskExecution::CancelOnUI()`.

## Validation

- ASan/UBSan full suite passed with seeds `4117057133` and `90821807`: 705 test cases and 6601 assertions per run
- TSan passed the original FilePicker runtime failure cases
- focused FilePicker and FileReference ASan tests passed: 121 assertions in 10 test cases
- workflow YAML and embedded Bash parsed successfully
- `git diff --check` passed
- branch CI rerun: https://github.com/HuxerUI/HuxerUI/actions/runs/32834750192

## Limitations

- the GLib/GDBus integration test reports a TSan race inside the system GLib worker thread with no HuxerUI frame, so the complete GLib integration cannot be considered TSan-clean
- the branch CI rerun is still in progress

Follow-up to #45 and SDK Release run 32758455804.