### PR TITLE
fix(linux): support Ubuntu 22.04 GLib

### DIFF
--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -417,17 +417,20 @@ public:
         },
         new std::shared_ptr<ReadState>(state)
     );
-    const guint timeout = g_timeout_add_once(
+    const guint timeout = g_timeout_add_full(
+        G_PRIORITY_DEFAULT,
         1000,
-        [](gpointer data) {
+        [](gpointer data) -> gboolean {
           auto& read = *static_cast<ReadState*>(data);
           if (!read.finished) {
             read.timed_out = true;
             g_cancellable_cancel(read.cancellable);
             g_main_loop_quit(read.loop);
           }
+          return G_SOURCE_REMOVE;
         },
-        state.get()
+        state.get(),
+        nullptr
     );
     g_main_loop_run(state->loop);
     if (!state->timed_out) {


### PR DESCRIPTION
## Summary

- replace the GLib 2.74-only clipboard timeout helper with g_timeout_add_full
- preserve the existing one-shot timeout and cancellation behavior
- restore Linux SDK builds against the Ubuntu 22.04 GLib 2.72 baseline

## Validation

- cmake --build build --target huxerui -j2
- cmake --build build --target huxerui_tests -j2
- ctest --test-dir build --output-on-failure -R ^HuxerUITests$
- git diff --check