### PR TITLE
feat(data): standardize owned binary APIs

### DIFF
--- a/cmake/HuxerUISdk.cmake
+++ b/cmake/HuxerUISdk.cmake
@@ -138,8 +138,10 @@ if (HUXERUI_INTERNAL_SDK_ARTIFACT_ROOT)
         )
         foreach (HUXERUI_REQUIRED_IOS_ARTIFACT IN ITEMS
                 "${HUXERUI_IOS_XCFRAMEWORK}/Info.plist"
+                "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64/Headers/huxerui/data.h"
                 "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64/Headers/huxerui/huxerui.h"
                 "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64/libhuxerui_static.a"
+                "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64_x86_64-simulator/Headers/huxerui/data.h"
                 "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64_x86_64-simulator/Headers/huxerui/huxerui.h"
                 "${HUXERUI_IOS_XCFRAMEWORK}/ios-arm64_x86_64-simulator/libhuxerui_static.a"
         )

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ User guides describe the current public SDK, development guides cover this repos
 - [Components and Input](guide/components.md): controls, navigation, gestures, and text editing.
 - [Themes and Presentation](guide/themes-and-presentation.md): themes, indication, animation, and layers.
 - [Files and Storage](guide/files.md): application storage, external files, and pickers.
+- [HTTP Client](guide/http.md): binary request and response bodies, Tasks, and errors.
 - [Extending HuxerUI](guide/extending.md): custom components, layouts, modifiers, and platform services.
 - [Platform Support](guide/platforms.md): supported hosts, toolchains, and platform capabilities.
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -437,7 +437,7 @@ This does not introduce a Runtime subclass, a public Library base class, platfor
 ### Platform payload and instance protocol
 
 Direct registration from Objective-C, Swift, Java, Kotlin, JavaScript, C++, and additional platform languages requires one value model that every boundary can represent.
-`PlatformPayload` is an immutable equality-comparable tree containing null, boolean, signed 64-bit integer, double, UTF-8 string, bytes, list, string-keyed object, and one closed framework capability kind, `ExternalTexture`.
+`PlatformPayload` is an immutable equality-comparable tree containing null, boolean, signed 64-bit integer, double, UTF-8 string, `Bytes`, list, string-keyed object, and one closed framework capability kind, `ExternalTexture`.
 The capability kind does not admit arbitrary objects.
 Objects require unique keys and compare independently of insertion order; encoders preserve the distinction between integers, doubles, strings, and bytes rather than routing through JSON.
 Strings and object keys must be valid UTF-8, doubles must be finite, and positive and negative zero compare equal.
@@ -450,7 +450,7 @@ Boundary bridges preserve these kinds directly rather than relying on implicit c
 
 | Boundary | Scalars | Bytes and containers |
 | --- | --- | --- |
-| C++, Windows, and Linux | `bool`, `std::int64_t`, `double`, and UTF-8 string alternatives | Owned bytes, list, and object alternatives |
+| C++, Windows, and Linux | `bool`, `std::int64_t`, `double`, and UTF-8 string alternatives | `huxerui::Bytes`, list, and object alternatives |
 | Objective-C and Swift | Kind-preserving NSNumber values and NSString | NSData, NSArray, and NSDictionary with NSString keys |
 | Java and Kotlin | Boolean, Long, Double, and String | byte array, List, and String-keyed Map |
 | JavaScript and future JS-hosted adapters | Boolean, BigInt, Number, and string | Uint8Array, Array, and a prototype-free string-keyed object |
@@ -460,6 +460,7 @@ Platform ExternalTexture bridge phases represent the value with an unforgeable f
 
 The shared public surface remains focused:
 
+- `<huxerui/data.h>` owns the cross-subsystem `Bytes` alias and depends only on standard byte-container facilities.
 - `<huxerui/platform_module.h>` owns `PlatformPayload`, `PlatformError`, `PlatformModuleFactory`, `UIThreadDispatcher`, the move-only `PlatformInstance`, and the per-surface `PlatformModules` registry.
 - `<huxerui/platform_view.h>` owns the low-level `PlatformView` leaf and its event-key declaration API.
 - `<huxerui/external_texture.h>` owns the platform-neutral `ExternalTexture` consumer value; platform-specific headers own frame producers.

--- a/docs/design/files.md
+++ b/docs/design/files.md
@@ -202,15 +202,15 @@ Operational failures never escape these result-returning methods as filesystem e
 ## Reading
 
 ```cpp
-[[nodiscard]] FileResult<std::vector<std::byte>> ReadBytes() const;
-[[nodiscard]] Task<FileResult<std::vector<std::byte>>> ReadBytesAsync() const;
+[[nodiscard]] FileResult<Bytes> ReadBytes() const;
+[[nodiscard]] Task<FileResult<Bytes>> ReadBytesAsync() const;
 
 [[nodiscard]] FileResult<std::string> ReadString() const;
 [[nodiscard]] Task<FileResult<std::string>> ReadStringAsync() const;
 ```
 
 Read operations load the complete file into memory.
-An empty vector or string is a successful empty file, which is why reads retain `FileResult<T>`.
+An empty `Bytes` or string value is a successful empty file, which is why reads retain `FileResult<T>`.
 The implementation reports a file that cannot fit in the owned result as `TooLarge` before allocating an invalid buffer.
 
 `ReadString()` defines text as UTF-8.
@@ -223,13 +223,13 @@ Mutating operations report whether they reached their documented target state:
 
 ```cpp
 [[nodiscard]] bool WriteBytes(std::span<const std::byte> bytes) const;
-[[nodiscard]] Task<bool> WriteBytesAsync(std::vector<std::byte> bytes) const;
+[[nodiscard]] Task<bool> WriteBytesAsync(Bytes bytes) const;
 
 [[nodiscard]] bool WriteString(std::string_view value) const;
 [[nodiscard]] Task<bool> WriteStringAsync(std::string value) const;
 
 [[nodiscard]] bool AppendBytes(std::span<const std::byte> bytes) const;
-[[nodiscard]] Task<bool> AppendBytesAsync(std::vector<std::byte> bytes) const;
+[[nodiscard]] Task<bool> AppendBytesAsync(Bytes bytes) const;
 
 [[nodiscard]] bool AppendString(std::string_view value) const;
 [[nodiscard]] Task<bool> AppendStringAsync(std::string value) const;
@@ -365,7 +365,7 @@ public:
   [[nodiscard]] std::optional<std::string> ContentType() const;
   [[nodiscard]] bool CanWrite() const noexcept;
 
-  [[nodiscard]] Task<FileResult<std::vector<std::byte>>> ReadBytesAsync() const;
+  [[nodiscard]] Task<FileResult<Bytes>> ReadBytesAsync() const;
   [[nodiscard]] Task<FileResult<std::string>> ReadStringAsync() const;
   [[nodiscard]] Task<bool> ImportToAsync(File destination, bool overwrite = false) const;
   [[nodiscard]] Task<bool> ReplaceWithAsync(File source) const;

--- a/docs/design/http.md
+++ b/docs/design/http.md
@@ -35,7 +35,7 @@ struct HttpRequest {
   std::string url;
   HttpMethod method = HttpMethod::Get;
   std::vector<HttpHeader> headers;
-  std::string body;
+  Bytes body;
   std::optional<std::chrono::milliseconds> timeout =
       std::chrono::milliseconds{30000};
 };
@@ -44,7 +44,7 @@ struct HttpResponse {
   std::string url;
   int status_code = 0;
   std::vector<HttpHeader> headers;
-  std::string body;
+  Bytes body;
 };
 
 enum class HttpErrorCode {
@@ -79,7 +79,8 @@ public:
 };
 ```
 
-Request and response bodies are binary-safe byte strings.
+Request and response bodies are owned binary values using `Bytes` from `<huxerui/data.h>`.
+They preserve embedded null bytes and byte sequences that are not valid UTF-8.
 HttpClient does not infer an encoding, parse JSON, construct form bodies, or decode application payloads.
 Header entries remain a sequence because repeated field names are meaningful, although a platform may combine fields when its response API no longer exposes individual lines.
 
@@ -95,6 +96,12 @@ Runtime installs one HttpClient Root Service before application RootHooks run.
 Components retrieve it through the existing typed service function and launch requests through their existing TaskScope:
 
 ```cpp
+std::string Utf8Text(std::span<const std::byte> bytes) {
+  return bytes.empty()
+      ? std::string{}
+      : std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+}
+
 [[huxerui::composable]]
 View RepositoryPage() {
   auto http = UseService<HttpClient>();
@@ -109,7 +116,7 @@ View RepositoryPage() {
       });
       if (request.HasResponse()) {
         HttpResponse response = std::move(request).Response();
-        result = response.body;
+        result = Utf8Text(response.body);
       } else {
         result = request.Error().message;
       }
@@ -117,6 +124,9 @@ View RepositoryPage() {
   });
 }
 ```
+
+This example's API contract declares a UTF-8 JSON response.
+Applications remain responsible for selecting and validating the encoding when converting response bytes to text.
 
 HTTP status codes, including 4xx and 5xx, produce an HttpResult containing HttpResponse.
 Transport failures, timeout, and an unavailable platform transport produce an HttpResult containing HttpError.
@@ -195,7 +205,7 @@ Streaming and file-transfer APIs remain separate operations instead of changing 
 
 ## Validation
 
-Shared tests use a deterministic fake HttpTransport to verify request preservation, response delivery, HTTP error separation, parameter validation, transport failures, Task cancellation, late completion, unsupported adapters, and UI-thread resumption.
+Shared tests use a deterministic fake HttpTransport to verify arbitrary binary request and response preservation, HTTP error separation, parameter validation, transport failures, Task cancellation, late completion, unsupported adapters, and UI-thread resumption.
 Each platform phase adds its implementation to the corresponding platform build and validates that platform without claiming unexecuted backends.
 Windows transport tests use a deterministic loopback server to verify WinHTTP request and response conversion plus the complete-operation deadline.
 Linux transport tests use a deterministic loopback server to verify binary bodies, repeated headers, redirects, errors, cancellation, deadlines, races, and shutdown.

--- a/docs/design/resources.md
+++ b/docs/design/resources.md
@@ -355,7 +355,7 @@ public:
   ImageAsset() = default;
 
   static ImageAsset FromFile(const std::filesystem::path& path, float scale = 1.0F);
-  static ImageAsset FromEncoded(std::vector<std::byte> bytes, float scale = 1.0F);
+  static ImageAsset FromEncoded(Bytes bytes, float scale = 1.0F);
   static ImageAsset CopyEncoded(std::span<const std::byte> bytes, float scale = 1.0F);
 
   [[nodiscard]] std::span<const std::byte> EncodedBytes() const noexcept;
@@ -431,7 +431,7 @@ class RawAsset {
 public:
   RawAsset() = default;
 
-  static RawAsset FromBytes(std::vector<std::byte> bytes, std::string mime_type = {});
+  static RawAsset FromBytes(Bytes bytes, std::string mime_type = {});
   static RawAsset CopyBytes(std::span<const std::byte> bytes, std::string mime_type = {});
   static RawAsset FromSharedBytes(
       std::shared_ptr<const void> owner,

--- a/docs/design/sdk-cli.md
+++ b/docs/design/sdk-cli.md
@@ -792,7 +792,7 @@ Camera normally provides a Camera service plus ExternalTexture preview, while Au
 The application retrieves services through their typed `UseXxx()` helpers; there is no generic library-service lookup.
 
 PlatformView and nonvisual PlatformModule instances share the PlatformPayload protocol defined in [Architecture Design](architecture.md#platform-payload-and-instance-protocol).
-PlatformPayload is the only dynamic in-process cross-language representation and is restricted to null, scalar, bytes, list, string-keyed object data, and the closed framework capability ExternalTexture.
+PlatformPayload is the only dynamic in-process cross-language representation and is restricted to null, scalar, `Bytes`, list, string-keyed object data, and the closed framework capability ExternalTexture.
 Concrete library headers keep application properties, calls, results, and events strongly typed and own all PlatformPayload encoding and decoding.
 Callbacks, arbitrary C++ objects, system handles, and media frames never enter the payload; an ExternalTexture value only retains the opaque platform-owned source state.
 

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -12,6 +12,10 @@ Use `TextRole` for theme typography or provide an explicit `TextStyle`.
 `Image` also accepts `ExternalTexture` through a separate overload because a live platform texture is not an application image value.
 Configure fit, alignment, sampling, and tint with typed methods.
 
+`ImageAsset::FromEncoded(Bytes)` and `RawAsset::FromBytes(Bytes)` take ownership of encoded or arbitrary binary data.
+Use `CopyEncoded(std::span<const std::byte>)` and `CopyBytes(std::span<const std::byte>)` when the source is borrowed.
+The returned byte views remain standard immutable spans rather than introducing another view type.
+
 `Canvas` and `Path` provide custom platform-neutral drawing that is replayed by every renderer.
 
 ## Buttons and selection controls

--- a/docs/guide/extending.md
+++ b/docs/guide/extending.md
@@ -80,6 +80,8 @@ Install custom root behavior through the existing RootHook boundary rather than 
 
 `PlatformModule` exposes a typed nonvisual platform service to shared application code.
 The application-facing service owns typed requests, results, and events; the platform implementation owns operating-system objects and UI-thread delivery.
+`PlatformPayload` uses the top-level `Bytes` type for owned binary payloads, while `AsBytes()` returns a borrowed `std::span<const std::byte>`.
+Keep strings for valid UTF-8 text and bytes for encoding-independent data; `PlatformPayload` does not convert between them.
 
 Use PlatformView only when a real platform visual control must participate in HuxerUI layout and ordering.
 Use ExternalTexture when a producer supplies image frames rather than an interactive platform view.

--- a/docs/guide/files.md
+++ b/docs/guide/files.md
@@ -34,7 +34,18 @@ Task<FileResult<std::string>> LoadSettings(const std::shared_ptr<FileSystem>& fi
 }
 ```
 
-Use byte operations for arbitrary payloads and text operations only for UTF-8 content.
+Use `Bytes` from `<huxerui/data.h>` for owned binary data and `std::span<const std::byte>` for borrowed binary input.
+Use byte operations for arbitrary payloads and string operations only for UTF-8 content.
+
+```cpp
+Task<FileResult<Bytes>> LoadPayload(const std::shared_ptr<FileSystem>& files) {
+  File file(files->Directories().data_directory, "payload.bin");
+  co_return co_await file.ReadBytesAsync();
+}
+```
+
+Synchronous `WriteBytes()` and `AppendBytes()` borrow a span only for the call.
+Their asynchronous counterparts take `Bytes` by value so the operation owns the storage while suspended.
 
 ## External files
 

--- a/docs/guide/http.md
+++ b/docs/guide/http.md
@@ -1,0 +1,47 @@
+# HTTP Client
+
+HuxerUI provides `HttpClient` as a per-window root service backed by each platform's networking stack.
+Requests run through `Task`, and continuation resumes on the owning Runtime thread.
+
+## Requests and responses
+
+HTTP bodies use `Bytes` because their content is binary regardless of `Content-Type`.
+Headers, URLs, diagnostics, and other textual protocol values use UTF-8 strings.
+
+```cpp
+Bytes Utf8Bytes(std::string_view text) {
+  const auto bytes = std::as_bytes(std::span<const char>(text.data(), text.size()));
+  return Bytes(bytes.begin(), bytes.end());
+}
+
+Task<HttpResult> CreateItem(const std::shared_ptr<HttpClient>& http) {
+  co_return co_await http->Send({
+      .url = "https://api.example.com/items",
+      .method = HttpMethod::Post,
+      .headers = {{"Content-Type", "application/json; charset=utf-8"}},
+      .body = Utf8Bytes(R"({"name":"example"})"),
+  });
+}
+```
+
+The HTTP layer preserves empty bodies, embedded null bytes, and byte sequences that are not valid UTF-8.
+It does not infer an encoding, parse JSON, or decode response text.
+Applications that expect text select and validate an encoding from their API contract and `Content-Type`, then explicitly convert `HttpResponse::body`.
+
+## Results and errors
+
+`HttpResult::HasResponse()` distinguishes a received HTTP response from a transport error.
+Status codes such as 404 and 500 are responses and remain available through `Response()`.
+Timeouts, transport failures, and unsupported adapters produce `HttpError`.
+
+URLs must be absolute HTTP or HTTPS URLs.
+GET and HEAD reject nonempty bodies; header names and values reject invalid protocol characters; specified timeouts must be positive.
+Invalid request configuration throws `std::invalid_argument` synchronously from `Send()`.
+
+## Ownership and limits
+
+`Send()` takes ownership of its complete `HttpRequest`, including body storage, until the platform operation completes or is canceled.
+Responses are buffered completely into owned `Bytes` before the Task resumes.
+Streaming, progress, retries, WebSocket, and implicit file transfers are outside this API.
+
+See [HTTP Client Design](../design/http.md) for transport ownership, cancellation, and platform contracts.

--- a/examples/http/main.cpp
+++ b/examples/http/main.cpp
@@ -1,9 +1,14 @@
 #include <huxerui/huxerui.h>
 
+#include <cstddef>
+#include <span>
 #include <string>
-#include <utility>
 
 using namespace huxerui;
+
+std::string Utf8Text(std::span<const std::byte> bytes) {
+  return bytes.empty() ? std::string{} : std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+}
 
 struct LoadingState {
   bool loading {false};
@@ -35,7 +40,7 @@ View HttpContent() {
             HttpResponse& response = result.Response();
             loading = {
               false, "HTTP " + std::to_string(response.status_code) + " · " + response.url,
-              response.body.empty() ? "(empty response body)" : std::move(response.body)
+              response.body.empty() ? "(empty response body)" : Utf8Text(response.body)
             };
           } else {
             loading = {false, "Request failed", result.Error().message};

--- a/include/huxerui/android/jni.h
+++ b/include/huxerui/android/jni.h
@@ -6,7 +6,8 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
-#include <vector>
+
+#include <huxerui/data.h>
 
 #if defined(__ANDROID__)
 #include <jni.h>
@@ -86,6 +87,6 @@ private:
 [[nodiscard]] LocalRef<jstring> Utf8ToJavaString(JNIEnv* environment, std::string_view value);
 [[nodiscard]] std::string JavaStringToUtf8(JNIEnv* environment, jstring value);
 [[nodiscard]] LocalRef<jbyteArray> BytesToJavaByteArray(JNIEnv* environment, std::span<const std::byte> value);
-[[nodiscard]] std::vector<std::byte> JavaByteArrayToBytes(JNIEnv* environment, jbyteArray value);
+[[nodiscard]] Bytes JavaByteArrayToBytes(JNIEnv* environment, jbyteArray value);
 
 } // namespace huxerui::android

--- a/include/huxerui/data.h
+++ b/include/huxerui/data.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace huxerui {
+
+using Bytes = std::vector<std::byte>;
+
+} // namespace huxerui

--- a/include/huxerui/file.h
+++ b/include/huxerui/file.h
@@ -14,6 +14,7 @@
 #include <variant>
 #include <vector>
 
+#include <huxerui/data.h>
 #include <huxerui/task.h>
 
 namespace huxerui {
@@ -141,20 +142,20 @@ public:
   [[nodiscard]] FileResult<FileInfo> Stat() const;
   [[nodiscard]] Task<FileResult<FileInfo>> StatAsync() const;
 
-  [[nodiscard]] FileResult<std::vector<std::byte>> ReadBytes() const;
-  [[nodiscard]] Task<FileResult<std::vector<std::byte>>> ReadBytesAsync() const;
+  [[nodiscard]] FileResult<Bytes> ReadBytes() const;
+  [[nodiscard]] Task<FileResult<Bytes>> ReadBytesAsync() const;
 
   [[nodiscard]] FileResult<std::string> ReadString() const;
   [[nodiscard]] Task<FileResult<std::string>> ReadStringAsync() const;
 
   [[nodiscard]] bool WriteBytes(std::span<const std::byte> bytes) const;
-  [[nodiscard]] Task<bool> WriteBytesAsync(std::vector<std::byte> bytes) const;
+  [[nodiscard]] Task<bool> WriteBytesAsync(Bytes bytes) const;
 
   [[nodiscard]] bool WriteString(std::string_view value) const;
   [[nodiscard]] Task<bool> WriteStringAsync(std::string value) const;
 
   [[nodiscard]] bool AppendBytes(std::span<const std::byte> bytes) const;
-  [[nodiscard]] Task<bool> AppendBytesAsync(std::vector<std::byte> bytes) const;
+  [[nodiscard]] Task<bool> AppendBytesAsync(Bytes bytes) const;
 
   [[nodiscard]] bool AppendString(std::string_view value) const;
   [[nodiscard]] Task<bool> AppendStringAsync(std::string value) const;
@@ -197,7 +198,7 @@ public:
   [[nodiscard]] std::optional<std::string> ContentType() const;
   [[nodiscard]] bool CanWrite() const noexcept;
 
-  [[nodiscard]] Task<FileResult<std::vector<std::byte>>> ReadBytesAsync() const;
+  [[nodiscard]] Task<FileResult<Bytes>> ReadBytesAsync() const;
   [[nodiscard]] Task<FileResult<std::string>> ReadStringAsync() const;
   [[nodiscard]] Task<bool> ImportToAsync(File destination, bool overwrite = false) const;
   [[nodiscard]] Task<bool> ReplaceWithAsync(File source) const;

--- a/include/huxerui/http.h
+++ b/include/huxerui/http.h
@@ -7,6 +7,7 @@
 #include <variant>
 #include <vector>
 
+#include <huxerui/data.h>
 #include <huxerui/task.h>
 
 namespace huxerui {
@@ -36,7 +37,7 @@ struct HttpRequest {
   std::string url;
   HttpMethod method = HttpMethod::Get;
   std::vector<HttpHeader> headers;
-  std::string body;
+  Bytes body;
   std::optional<std::chrono::milliseconds> timeout = std::chrono::milliseconds{30000};
 };
 
@@ -44,7 +45,7 @@ struct HttpResponse {
   std::string url;
   int status_code = 0;
   std::vector<HttpHeader> headers;
-  std::string body;
+  Bytes body;
 
   bool operator==(const HttpResponse&) const = default;
 };

--- a/include/huxerui/huxerui.h
+++ b/include/huxerui/huxerui.h
@@ -4,6 +4,7 @@
 #include <huxerui/app.h>
 #include <huxerui/clipboard.h>
 #include <huxerui/color.h>
+#include <huxerui/data.h>
 #include <huxerui/environment.h>
 #include <huxerui/event.h>
 #include <huxerui/external_texture.h>

--- a/include/huxerui/platform_module.h
+++ b/include/huxerui/platform_module.h
@@ -18,6 +18,7 @@
 #include <variant>
 #include <vector>
 
+#include <huxerui/data.h>
 #include <huxerui/event.h>
 #include <huxerui/external_texture.h>
 
@@ -39,7 +40,6 @@ enum class PlatformPayloadKind {
 
 class PlatformPayload {
 public:
-  using Bytes = std::vector<std::byte>;
   using List = std::vector<PlatformPayload>;
   using Object = std::map<std::string, PlatformPayload, std::less<>>;
 

--- a/include/huxerui/resource.h
+++ b/include/huxerui/resource.h
@@ -13,6 +13,7 @@
 #include <variant>
 #include <vector>
 
+#include <huxerui/data.h>
 #include <huxerui/geometry.h>
 #include <huxerui/vector.h>
 
@@ -119,7 +120,7 @@ class RawAsset {
 public:
   RawAsset() = default;
 
-  static RawAsset FromBytes(std::vector<std::byte> bytes, std::string mime_type = {});
+  static RawAsset FromBytes(Bytes bytes, std::string mime_type = {});
   static RawAsset CopyBytes(std::span<const std::byte> bytes, std::string mime_type = {});
   static RawAsset FromSharedBytes(
       std::shared_ptr<const void> owner, const std::byte* data, std::size_t size, std::string mime_type = {}
@@ -158,7 +159,7 @@ public:
   ImageAsset() = default;
 
   static ImageAsset FromFile(const std::filesystem::path& path, float scale = 1.0F);
-  static ImageAsset FromEncoded(std::vector<std::byte> bytes, float scale = 1.0F);
+  static ImageAsset FromEncoded(Bytes bytes, float scale = 1.0F);
   static ImageAsset CopyEncoded(std::span<const std::byte> bytes, float scale = 1.0F);
 
   [[nodiscard]] std::span<const std::byte> EncodedBytes() const noexcept;

--- a/platform/android/huxerui/src/main/cpp/android_file_picker.cpp
+++ b/platform/android/huxerui/src/main/cpp/android_file_picker.cpp
@@ -156,15 +156,15 @@ public:
     if (bytes_completion) {
       try {
         if (static_cast<AndroidReferenceResult>(result) == AndroidReferenceResult::Bytes && bytes != nullptr) {
-          bytes_completion(FileResult<std::vector<std::byte>>(android::JavaByteArrayToBytes(environment, bytes)));
+          bytes_completion(FileResult<Bytes>(android::JavaByteArrayToBytes(environment, bytes)));
           return;
         }
-        bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+        bytes_completion(FileResult<Bytes>(FileError{
             ToFileErrorCode(error_code),
             JavaStringOrFallback(environment, message, "HuxerUI external file read failed"),
         }));
       } catch (...) {
-        bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+        bytes_completion(FileResult<Bytes>(FileError{
             FileErrorCode::Io,
             "HuxerUI external file result could not be decoded",
         }));
@@ -190,7 +190,7 @@ public:
       bool_completion = std::move(bool_completion_);
     }
     if (bytes_completion) {
-      bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+      bytes_completion(FileResult<Bytes>(FileError{
           FileErrorCode::Io,
           "HuxerUI Android external file operation could not be started",
       }));
@@ -415,7 +415,7 @@ private:
     JNIEnv* environment = attached.Get();
     if (environment == nullptr) {
       if constexpr (std::is_same_v<Completion, FileReferenceBytesCompletion>) {
-        completion(FileResult<std::vector<std::byte>>(FileError{
+        completion(FileResult<Bytes>(FileError{
             FileErrorCode::Io,
             "HuxerUI Android external file operation could not access JNI",
         }));

--- a/platform/android/huxerui/src/main/cpp/android_http.cpp
+++ b/platform/android/huxerui/src/main/cpp/android_http.cpp
@@ -291,11 +291,8 @@ public:
           MakeStringArray(environment, string_class.Get(), request.headers, true);
       android::LocalRef<jobjectArray> header_values =
           MakeStringArray(environment, string_class.Get(), request.headers, false);
-      const std::span<const std::byte> body(
-          reinterpret_cast<const std::byte*>(request.body.data()),
-          request.body.size()
-      );
-      android::LocalRef<jbyteArray> java_body = android::BytesToJavaByteArray(environment, body);
+      android::LocalRef<jbyteArray> java_body =
+          android::BytesToJavaByteArray(environment, std::span<const std::byte>(request.body));
       if (!url || !method || !java_body) {
         throw std::runtime_error("HuxerUI Android HTTP request values could not be allocated");
       }
@@ -406,10 +403,7 @@ HttpResult MakeAndroidHttpResult(
           android::JavaStringToUtf8(environment, value.Get()),
       });
     }
-    const std::vector<std::byte> bytes = android::JavaByteArrayToBytes(environment, body);
-    if (!bytes.empty()) {
-      response.body.assign(reinterpret_cast<const char*>(bytes.data()), bytes.size());
-    }
+    response.body = android::JavaByteArrayToBytes(environment, body);
     return HttpResult(std::move(response));
   }
   case AndroidHttpResult::Timeout:

--- a/platform/android/huxerui/src/main/cpp/android_jni.cpp
+++ b/platform/android/huxerui/src/main/cpp/android_jni.cpp
@@ -156,13 +156,13 @@ LocalRef<jbyteArray> BytesToJavaByteArray(JNIEnv* environment, std::span<const s
   return LocalRef<jbyteArray>(environment, result);
 }
 
-std::vector<std::byte> JavaByteArrayToBytes(JNIEnv* environment, jbyteArray value) {
+Bytes JavaByteArrayToBytes(JNIEnv* environment, jbyteArray value) {
   RequireEnvironment(environment);
   if (value == nullptr) {
     throw std::invalid_argument("HuxerUI Android Java byte array must not be null");
   }
   const jsize length = environment->GetArrayLength(value);
-  std::vector<std::byte> result(static_cast<std::size_t>(length));
+  Bytes result(static_cast<std::size_t>(length));
   if (length > 0) {
     environment->GetByteArrayRegion(value, 0, length, reinterpret_cast<jbyte*>(result.data()));
   }

--- a/platform/ios/ios_file_picker.mm
+++ b/platform/ios/ios_file_picker.mm
@@ -100,8 +100,8 @@ bool SameFileURL(NSURL* first, NSURL* second) {
   return first != nil && second != nil && [first.URLByStandardizingPath isEqual:second.URLByStandardizingPath];
 }
 
-FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
-  __block std::optional<FileResult<std::vector<std::byte>>> result;
+FileResult<Bytes> ReadFile(NSURL* url) {
+  __block std::optional<FileResult<Bytes>> result;
   NSFileCoordinator* coordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
   NSError* coordination_error = nil;
   [coordinator coordinateReadingItemAtURL:url
@@ -116,7 +116,7 @@ FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
                                    result.emplace(FileFailure(error, "HuxerUI external file read failed"));
                                    return;
                                  }
-                                 std::vector<std::byte> bytes(data.length);
+                                 Bytes bytes(data.length);
                                  if (data.length != 0) {
                                    std::memcpy(bytes.data(), data.bytes, data.length);
                                  }
@@ -125,8 +125,7 @@ FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
   if (result.has_value()) {
     return std::move(*result);
   }
-  return FileResult<std::vector<std::byte>>(FileFailure(coordination_error, "HuxerUI external file coordination failed")
-  );
+  return FileResult<Bytes>(FileFailure(coordination_error, "HuxerUI external file coordination failed"));
 }
 
 bool CopyFile(NSURL* source, NSURL* destination, bool overwrite) {
@@ -466,7 +465,7 @@ public:
         try {
           completion(ReadFile(self->url_));
         } catch (...) {
-          completion(FileResult<std::vector<std::byte>>(FileError{
+          completion(FileResult<Bytes>(FileError{
               FileErrorCode::Io,
               "HuxerUI external file read failed",
           }));

--- a/platform/ios/ios_http.mm
+++ b/platform/ios/ios_http.mm
@@ -191,7 +191,8 @@ private:
         });
       }
       if (data != nil && data.length != 0) {
-        result.body.assign(static_cast<const char*>(data.bytes), data.length);
+        const auto* bytes = static_cast<const std::byte*>(data.bytes);
+        result.body.assign(bytes, bytes + data.length);
       }
       Finish(HttpResult(std::move(result)), false);
     }

--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -544,11 +544,11 @@ public:
   std::function<void()> ReadBytes(FileReferenceBytesCompletion completion) override {
     const File file = file_;
     EnqueueFileOperation([file, completion = std::move(completion)]() mutable {
-      FileResult<std::vector<std::byte>> result = [&] {
+      FileResult<Bytes> result = [&] {
         try {
           return file.ReadBytes();
         } catch (...) {
-          return FileResult<std::vector<std::byte>>(FileError{
+          return FileResult<Bytes>(FileError{
               FileErrorCode::Io,
               "HuxerUI Linux external file read failed",
           });

--- a/platform/linux/linux_http.cpp
+++ b/platform/linux/linux_http.cpp
@@ -349,9 +349,9 @@ private:
       }
 
       gsize size = 0;
-      const auto* data = static_cast<const char*>(g_bytes_get_data(bytes, &size));
+      const auto* data = static_cast<const std::byte*>(g_bytes_get_data(bytes, &size));
       if (data != nullptr && size != 0) {
-        response.body.assign(data, size);
+        response.body.assign(data, data + size);
       }
       return HttpResult(std::move(response));
     } catch (...) {

--- a/platform/macos/macos_file_picker.mm
+++ b/platform/macos/macos_file_picker.mm
@@ -66,8 +66,8 @@ bool SameFileURL(NSURL* first, NSURL* second) {
   return first != nil && second != nil && [first.URLByStandardizingPath isEqual:second.URLByStandardizingPath];
 }
 
-FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
-  __block std::optional<FileResult<std::vector<std::byte>>> result;
+FileResult<Bytes> ReadFile(NSURL* url) {
+  __block std::optional<FileResult<Bytes>> result;
   NSFileCoordinator* coordinator = [[NSFileCoordinator alloc] initWithFilePresenter:nil];
   NSError* coordination_error = nil;
   [coordinator coordinateReadingItemAtURL:url
@@ -82,7 +82,7 @@ FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
                                    result.emplace(FileFailure(error, "HuxerUI external file read failed"));
                                    return;
                                  }
-                                 std::vector<std::byte> bytes(data.length);
+                                 Bytes bytes(data.length);
                                  if (data.length != 0) {
                                    std::memcpy(bytes.data(), data.bytes, data.length);
                                  }
@@ -91,8 +91,7 @@ FileResult<std::vector<std::byte>> ReadFile(NSURL* url) {
   if (result.has_value()) {
     return std::move(*result);
   }
-  return FileResult<std::vector<std::byte>>(FileFailure(coordination_error, "HuxerUI external file coordination failed")
-  );
+  return FileResult<Bytes>(FileFailure(coordination_error, "HuxerUI external file coordination failed"));
 }
 
 bool CopyFile(NSURL* source, NSURL* destination, bool overwrite) {
@@ -293,7 +292,7 @@ public:
         try {
           completion(ReadFile(self->url_));
         } catch (...) {
-          completion(FileResult<std::vector<std::byte>>(FileError{
+          completion(FileResult<Bytes>(FileError{
               FileErrorCode::Io,
               "HuxerUI external file read failed",
           }));

--- a/platform/macos/macos_http.mm
+++ b/platform/macos/macos_http.mm
@@ -191,7 +191,8 @@ private:
         });
       }
       if (data != nil && data.length != 0) {
-        result.body.assign(static_cast<const char*>(data.bytes), data.length);
+        const auto* bytes = static_cast<const std::byte*>(data.bytes);
+        result.body.assign(bytes, bytes + data.length);
       }
       Finish(HttpResult(std::move(result)), false);
     }

--- a/platform/web/web_file_picker.cpp
+++ b/platform/web/web_file_picker.cpp
@@ -594,7 +594,7 @@ public:
 
     if (canceled_) {
       if (bytes_completion) {
-        bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+        bytes_completion(FileResult<Bytes>(FileError{
             FileErrorCode::Io,
             "HuxerUI external file operation was canceled",
         }));
@@ -610,16 +610,16 @@ public:
         if (kind == web_file_result_bytes) {
           const val bytes = result["bytes"];
           const std::size_t size = bytes["byteLength"].as<std::size_t>();
-          std::vector<std::byte> value(size);
+          Bytes value(size);
           if (size != 0) {
             val(emscripten::typed_memory_view(size, reinterpret_cast<unsigned char*>(value.data())))
                 .call<void>("set", bytes);
           }
-          bytes_completion(FileResult<std::vector<std::byte>>(std::move(value)));
+          bytes_completion(FileResult<Bytes>(std::move(value)));
           return;
         }
         const int error_code = kind == web_file_result_error ? result["errorCode"].as<int>() : web_file_error_io;
-        bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+        bytes_completion(FileResult<Bytes>(FileError{
             ToFileErrorCode(error_code),
             ErrorMessage(result),
         }));
@@ -630,7 +630,7 @@ public:
       }
     } catch (...) {
       if (bytes_completion) {
-        bytes_completion(FileResult<std::vector<std::byte>>(FileError{
+        bytes_completion(FileResult<Bytes>(FileError{
             FileErrorCode::Io,
             "HuxerUI external file result is invalid",
         }));

--- a/platform/windows/win32_file_picker.cpp
+++ b/platform/windows/win32_file_picker.cpp
@@ -207,7 +207,7 @@ public:
     auto retained_completion = std::make_shared<FileReferenceBytesCompletion>(std::move(completion));
     try {
       EnqueueFileOperation([self, retained_completion] {
-        FileResult<std::vector<std::byte>> result(ReferenceReadFailure());
+        FileResult<Bytes> result(ReferenceReadFailure());
         try {
           result = self->file_.ReadBytes();
         } catch (...) {
@@ -215,7 +215,7 @@ public:
         (*retained_completion)(std::move(result));
       });
     } catch (...) {
-      (*retained_completion)(FileResult<std::vector<std::byte>>(ReferenceReadFailure()));
+      (*retained_completion)(FileResult<Bytes>(ReferenceReadFailure()));
     }
     return {};
   }

--- a/platform/windows/win32_http.cpp
+++ b/platform/windows/win32_http.cpp
@@ -659,7 +659,8 @@ private:
       if (finished_) {
         return;
       }
-      response_.body.append(static_cast<const char*>(bytes), byte_count);
+      const auto* body = static_cast<const std::byte*>(bytes);
+      response_.body.insert(response_.body.end(), body, body + byte_count);
     }
     ReadBody();
   }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -311,50 +311,50 @@ FileResult<FileInfo> Stat(std::string_view path) {
   return FileResult<FileInfo>(std::move(info));
 }
 
-FileResult<std::vector<std::byte>> ReadBytes(std::string_view path) {
+FileResult<Bytes> ReadBytes(std::string_view path) {
   const fs::path platform_path = PlatformPath(path);
   std::error_code error;
   const fs::file_status status = fs::status(platform_path, error);
   if (error) {
-    return Failure<std::vector<std::byte>>("read", error);
+    return Failure<Bytes>("read", error);
   }
   if (!fs::exists(status)) {
-    return Failure<std::vector<std::byte>>(FileErrorCode::NotFound, "HuxerUI file read found no file");
+    return Failure<Bytes>(FileErrorCode::NotFound, "HuxerUI file read found no file");
   }
   if (fs::is_directory(status)) {
-    return Failure<std::vector<std::byte>>(FileErrorCode::IsDirectory, "HuxerUI cannot read a directory as a file");
+    return Failure<Bytes>(FileErrorCode::IsDirectory, "HuxerUI cannot read a directory as a file");
   }
   if (!fs::is_regular_file(status)) {
-    return Failure<std::vector<std::byte>>(FileErrorCode::Unsupported, "HuxerUI cannot read this file type");
+    return Failure<Bytes>(FileErrorCode::Unsupported, "HuxerUI cannot read this file type");
   }
 
   const std::uintmax_t size = fs::file_size(platform_path, error);
   if (error) {
-    return Failure<std::vector<std::byte>>("size query", error);
+    return Failure<Bytes>("size query", error);
   }
-  if (size > static_cast<std::uintmax_t>(std::vector<std::byte>{}.max_size()) ||
+  if (size > static_cast<std::uintmax_t>(Bytes{}.max_size()) ||
       size > static_cast<std::uintmax_t>(std::numeric_limits<std::size_t>::max()) ||
       size > static_cast<std::uintmax_t>(std::numeric_limits<std::streamsize>::max())) {
-    return Failure<std::vector<std::byte>>(FileErrorCode::TooLarge, "HuxerUI file is too large to read into memory");
+    return Failure<Bytes>(FileErrorCode::TooLarge, "HuxerUI file is too large to read into memory");
   }
 
   errno = 0;
   std::ifstream stream(platform_path, std::ios::binary);
   if (!stream) {
-    return Failure<std::vector<std::byte>>("open for reading", StreamError());
+    return Failure<Bytes>("open for reading", StreamError());
   }
-  std::vector<std::byte> bytes(static_cast<std::size_t>(size));
+  Bytes bytes(static_cast<std::size_t>(size));
   if (!bytes.empty()) {
     stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
     if (stream.gcount() != static_cast<std::streamsize>(bytes.size())) {
-      return Failure<std::vector<std::byte>>(FileErrorCode::Io, "HuxerUI file changed while it was being read");
+      return Failure<Bytes>(FileErrorCode::Io, "HuxerUI file changed while it was being read");
     }
   }
   const std::ifstream::int_type trailing = stream.peek();
   if (stream.bad() || trailing != std::char_traits<char>::eof()) {
-    return Failure<std::vector<std::byte>>(FileErrorCode::Io, "HuxerUI file changed while it was being read");
+    return Failure<Bytes>(FileErrorCode::Io, "HuxerUI file changed while it was being read");
   }
-  return FileResult<std::vector<std::byte>>(std::move(bytes));
+  return FileResult<Bytes>(std::move(bytes));
 }
 
 bool WriteBytes(std::string_view path, std::span<const std::byte> bytes, bool append) {
@@ -792,11 +792,11 @@ void EnqueueFileOperation(std::function<void()> operation) {
 }
 #endif
 
-FileResult<std::string> DecodeFileUtf8(FileResult<std::vector<std::byte>> bytes) {
+FileResult<std::string> DecodeFileUtf8(FileResult<Bytes> bytes) {
   if (!bytes.Succeeded()) {
     return FileResult<std::string>(std::move(bytes).Error());
   }
-  std::vector<std::byte> value = std::move(bytes).Value();
+  Bytes value = std::move(bytes).Value();
   std::size_t offset = 0;
   if (value.size() >= 3 && value[0] == std::byte{0xEF} && value[1] == std::byte{0xBB} && value[2] == std::byte{0xBF}) {
     offset = 3;
@@ -916,12 +916,12 @@ Task<FileResult<FileInfo>> File::StatAsync() const {
   return detail::RunFileOperation<FileResult<FileInfo>>([file = *this] { return file.Stat(); });
 }
 
-FileResult<std::vector<std::byte>> File::ReadBytes() const {
+FileResult<Bytes> File::ReadBytes() const {
   return detail::ReadBytes(path_);
 }
 
-Task<FileResult<std::vector<std::byte>>> File::ReadBytesAsync() const {
-  return detail::RunFileOperation<FileResult<std::vector<std::byte>>>([file = *this] { return file.ReadBytes(); });
+Task<FileResult<Bytes>> File::ReadBytesAsync() const {
+  return detail::RunFileOperation<FileResult<Bytes>>([file = *this] { return file.ReadBytes(); });
 }
 
 FileResult<std::string> File::ReadString() const {
@@ -936,7 +936,7 @@ bool File::WriteBytes(std::span<const std::byte> bytes) const {
   return detail::WriteBytes(path_, bytes, false);
 }
 
-Task<bool> File::WriteBytesAsync(std::vector<std::byte> bytes) const {
+Task<bool> File::WriteBytesAsync(Bytes bytes) const {
   const bool persist = detail::RequiresPersistence(path_);
   return detail::RunFileOperation<bool>(
       [file = *this, bytes = std::move(bytes)] { return file.WriteBytes(std::span<const std::byte>(bytes)); },
@@ -962,7 +962,7 @@ bool File::AppendBytes(std::span<const std::byte> bytes) const {
   return detail::WriteBytes(path_, bytes, true);
 }
 
-Task<bool> File::AppendBytesAsync(std::vector<std::byte> bytes) const {
+Task<bool> File::AppendBytesAsync(Bytes bytes) const {
   const bool persist = detail::RequiresPersistence(path_);
   return detail::RunFileOperation<bool>(
       [file = *this, bytes = std::move(bytes)] { return file.AppendBytes(std::span<const std::byte>(bytes)); },

--- a/src/file_internal.h
+++ b/src/file_internal.h
@@ -18,7 +18,7 @@ struct FileReferenceMetadata {
   bool can_write = false;
 };
 
-using FileReferenceBytesCompletion = std::function<void(FileResult<std::vector<std::byte>>)>;
+using FileReferenceBytesCompletion = std::function<void(FileResult<Bytes>)>;
 using FileReferenceBoolCompletion = std::function<void(bool)>;
 
 class FileReferenceState {
@@ -54,7 +54,7 @@ struct FileSystemPaths {
 [[nodiscard]] std::shared_ptr<FileSystem> MakeFileSystem(FileSystemPaths paths);
 [[nodiscard]] FileReference
 MakeFileReference(FileReferenceMetadata metadata, std::shared_ptr<FileReferenceState> state);
-[[nodiscard]] FileResult<std::string> DecodeFileUtf8(FileResult<std::vector<std::byte>> bytes);
+[[nodiscard]] FileResult<std::string> DecodeFileUtf8(FileResult<Bytes> bytes);
 [[nodiscard]] bool IsValidFileUtf8(std::string_view text) noexcept;
 
 #if defined(__EMSCRIPTEN__)

--- a/src/file_picker.cpp
+++ b/src/file_picker.cpp
@@ -243,12 +243,12 @@ Task<Result> RunCallbackOperation(typename CallbackOperationState<Result>::Start
   co_return co_await CallbackOperationAwaiter<Result>(std::move(starter), std::move(failure));
 }
 
-Task<FileResult<std::vector<std::byte>>> ReadReferenceBytes(std::shared_ptr<FileReferenceState> state) {
-  co_return co_await RunCallbackOperation<FileResult<std::vector<std::byte>>>(
+Task<FileResult<Bytes>> ReadReferenceBytes(std::shared_ptr<FileReferenceState> state) {
+  co_return co_await RunCallbackOperation<FileResult<Bytes>>(
       [state = std::move(state)](FileReferenceBytesCompletion completion) {
         return state->ReadBytes(std::move(completion));
       },
-      FileResult<std::vector<std::byte>>(FileError{
+      FileResult<Bytes>(FileError{
           FileErrorCode::Io,
           "HuxerUI external file read failed",
       })
@@ -623,7 +623,7 @@ bool FileReference::CanWrite() const noexcept {
   return can_write_;
 }
 
-Task<FileResult<std::vector<std::byte>>> FileReference::ReadBytesAsync() const {
+Task<FileResult<Bytes>> FileReference::ReadBytesAsync() const {
   return detail::ReadReferenceBytes(state_);
 }
 

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -282,13 +282,13 @@ Locale Locale::Default() {
   return Locale("en");
 }
 
-RawAsset RawAsset::FromBytes(std::vector<std::byte> bytes, std::string mime_type) {
-  auto storage = std::make_shared<const std::vector<std::byte>>(std::move(bytes));
+RawAsset RawAsset::FromBytes(huxerui::Bytes bytes, std::string mime_type) {
+  auto storage = std::make_shared<const huxerui::Bytes>(std::move(bytes));
   return FromSharedBytes(storage, storage->data(), storage->size(), std::move(mime_type));
 }
 
 RawAsset RawAsset::CopyBytes(std::span<const std::byte> bytes, std::string mime_type) {
-  return FromBytes(std::vector<std::byte>(bytes.begin(), bytes.end()), std::move(mime_type));
+  return FromBytes(huxerui::Bytes(bytes.begin(), bytes.end()), std::move(mime_type));
 }
 
 RawAsset RawAsset::FromSharedBytes(
@@ -345,7 +345,7 @@ ImageAsset ImageAsset::FromFile(const std::filesystem::path& path, float scale) 
   return FromEncoded(std::move(bytes), scale);
 }
 
-ImageAsset ImageAsset::FromEncoded(std::vector<std::byte> bytes, float scale) {
+ImageAsset ImageAsset::FromEncoded(Bytes bytes, float scale) {
   return FromRawAsset(RawAsset::FromBytes(std::move(bytes)), scale);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(huxerui_tests
         unit/animation.cpp
         support/builtin_resources.cpp
         unit/application.cpp
+        unit/data.cpp
         unit/external_texture.cpp
         unit/file.cpp
         unit/geometry.cpp
@@ -161,6 +162,7 @@ set(HUXERUI_PUBLIC_HEADERS
         app.h
         clipboard.h
         color.h
+        data.h
         environment.h
         event.h
         external_texture.h

--- a/tests/cmake/installed_consumer.cmake
+++ b/tests/cmake/installed_consumer.cmake
@@ -61,7 +61,7 @@ foreach (CONSUMER_LINKAGE IN ITEMS shared static default both)
     set(CONSUMER_BUILD "${TEST_ROOT}/consumer-${CONSUMER_LINKAGE}-build")
     file(MAKE_DIRECTORY "${CONSUMER_SOURCE}")
     file(WRITE "${CONSUMER_SOURCE}/main.cpp"
-            "#include <huxerui/huxerui.h>\nint main() { huxerui::View view; return view ? 1 : 0; }\n")
+            "#include <huxerui/huxerui.h>\nint main() { huxerui::Bytes bytes{std::byte{1}}; huxerui::View view; return view ? static_cast<int>(bytes.size()) : 0; }\n")
     set(CONSUMER_COMPONENT)
     set(CONSUMER_CONFIGURE_ARGUMENTS)
     if (CONSUMER_LINKAGE STREQUAL "shared")

--- a/tests/cmake/sdk_archive.cmake
+++ b/tests/cmake/sdk_archive.cmake
@@ -57,6 +57,7 @@ file(TO_NATIVE_PATH "${SDK_ROOT}" SDK_ROOT_NATIVE)
 foreach (required_path IN ITEMS
         "LICENSE"
         "${INSTALL_BINDIR}/huxerui${CLI_SUFFIX}"
+        "include/huxerui/data.h"
         "include/huxerui/huxerui.h"
         "${INSTALL_LIBDIR}/cmake/HuxerUI/HuxerUIConfig.cmake"
         "${INSTALL_LIBDIR}/cmake/HuxerUI/HuxerUISharedTargets.cmake"
@@ -128,8 +129,10 @@ if (PLATFORM_ARTIFACTS_INCLUDED)
     if (HOST_SYSTEM STREQUAL "macos")
         foreach (required_path IN ITEMS
                 "share/huxerui/platform/ios/HuxerUI.xcframework/Info.plist"
+                "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64/Headers/huxerui/data.h"
                 "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64/Headers/huxerui/huxerui.h"
                 "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64/libhuxerui_static.a"
+                "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64_x86_64-simulator/Headers/huxerui/data.h"
                 "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64_x86_64-simulator/Headers/huxerui/huxerui.h"
                 "share/huxerui/platform/ios/HuxerUI.xcframework/ios-arm64_x86_64-simulator/libhuxerui_static.a"
         )

--- a/tests/platform/linux_http.cpp
+++ b/tests/platform/linux_http.cpp
@@ -34,6 +34,15 @@ namespace {
 
 using namespace std::chrono_literals;
 
+Bytes BytesFromString(std::string_view value) {
+  Bytes bytes;
+  bytes.reserve(value.size());
+  for (const char character : value) {
+    bytes.push_back(static_cast<std::byte>(character));
+  }
+  return bytes;
+}
+
 void CloseSocket(int socket) noexcept {
   if (socket >= 0) {
     close(socket);
@@ -267,7 +276,7 @@ std::string JoinedHeaderValues(const HttpResponse& response, std::string_view re
 } // namespace
 
 TEST_CASE("Linux HTTP transport preserves buffered requests and responses") {
-  const std::string response_body("reply\0bytes", 11);
+  const std::string response_body{'r', 'e', 'p', 'l', 'y', '\0', static_cast<char>(0xFF), 'b', 'y', 't', 'e', 's'};
   LoopbackHttpServer server({[&response_body](int socket, const std::string&) {
     SendResponse(socket, 201, "Created", {{"X-Repeat", "first"}, {"X-Repeat", "second"}}, response_body);
   }});
@@ -279,7 +288,7 @@ TEST_CASE("Linux HTTP transport preserves buffered requests and responses") {
           .url = server.Url("/items"),
           .method = HttpMethod::Post,
           .headers = {{"Content-Type", "application/octet-stream"}, {"X-Trace", "first"}, {"X-Trace", "second"}},
-          .body = request_body,
+          .body = BytesFromString(request_body),
           .timeout = 2s,
       }
   );
@@ -290,7 +299,7 @@ TEST_CASE("Linux HTTP transport preserves buffered requests and responses") {
   const HttpResponse& response = result.Response();
   REQUIRE(response.status_code == 201);
   REQUIRE(response.url == server.Url("/items"));
-  REQUIRE(response.body == response_body);
+  REQUIRE(response.body == BytesFromString(response_body));
   const std::string repeated_values = JoinedHeaderValues(response, "X-Repeat");
   REQUIRE(repeated_values.find("first") != std::string::npos);
   REQUIRE(repeated_values.find("second") != std::string::npos);
@@ -316,7 +325,7 @@ TEST_CASE("Linux HTTP transport follows redirects and returns HTTP error statuse
   REQUIRE(result.HasResponse());
   REQUIRE(result.Response().status_code == 404);
   REQUIRE(result.Response().url == server.Url("/missing"));
-  REQUIRE(result.Response().body == "missing");
+  REQUIRE(result.Response().body == BytesFromString("missing"));
   REQUIRE(server.WaitForRequests(2));
   REQUIRE(server.Request(0).starts_with("GET /redirect HTTP/1.1\r\n"));
   REQUIRE(server.Request(1).starts_with("GET /missing HTTP/1.1\r\n"));

--- a/tests/platform/windows_http.cpp
+++ b/tests/platform/windows_http.cpp
@@ -23,6 +23,15 @@
 namespace huxerui::test {
 namespace {
 
+Bytes BytesFromString(std::string_view value) {
+  Bytes bytes;
+  bytes.reserve(value.size());
+  for (const char character : value) {
+    bytes.push_back(static_cast<std::byte>(character));
+  }
+  return bytes;
+}
+
 class WinsockRuntime final {
 public:
   WinsockRuntime() {
@@ -225,7 +234,7 @@ TEST_CASE("WindowsHttpTransportPreservesRequestAndResponseData") {
           .url = server.Url("/items?source=test"),
           .method = HttpMethod::Post,
           .headers = {{"Content-Type", "application/octet-stream"}, {"X-Trace", "winhttp"}},
-          .body = request_body,
+          .body = BytesFromString(request_body),
           .timeout = std::chrono::seconds{5},
       },
       [&completion](HttpResult result) { completion.Complete(std::move(result)); }
@@ -244,7 +253,7 @@ TEST_CASE("WindowsHttpTransportPreservesRequestAndResponseData") {
   const HttpResponse& response = result.Response();
   REQUIRE(response.status_code == 201);
   REQUIRE(response.url == server.Url("/items?source=test"));
-  REQUIRE(response.body == response_body);
+  REQUIRE(response.body == BytesFromString(response_body));
   REQUIRE(std::count(response.headers.begin(), response.headers.end(), HttpHeader{"X-Test", "first"}) == 1);
   REQUIRE(std::count(response.headers.begin(), response.headers.end(), HttpHeader{"X-Test", "second"}) == 1);
 }

--- a/tests/runtime/file.cpp
+++ b/tests/runtime/file.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <filesystem>
@@ -117,6 +118,7 @@ private:
 std::shared_ptr<FileSystem> file_system;
 TaskScope file_tasks;
 std::string async_text;
+Bytes async_bytes;
 std::thread::id file_resume_thread;
 bool file_task_complete = false;
 bool canceled_file_task_continued = false;
@@ -131,6 +133,7 @@ void ResetFileState() {
   file_system.reset();
   file_tasks = {};
   async_text.clear();
+  async_bytes.clear();
   file_resume_thread = {};
   file_task_complete = false;
   canceled_file_task_continued = false;
@@ -168,6 +171,31 @@ TEST_CASE("RuntimeInstallsFileSystemAndFileAsyncOperationsResumeOnTheUIThread") 
   platform.RunUntil([] { return file_task_complete; });
   REQUIRE(async_text == "async value");
   REQUIRE(file_resume_thread == ui_thread);
+}
+
+TEST_CASE("FileAsyncByteOperationsRetainOwnedBinaryDataUntilCompletion") {
+  ResetFileState();
+  TemporaryDirectory temporary;
+  FileTestPlatform platform(temporary.Paths());
+  Runtime runtime(FileApp, platform);
+  runtime.BuildFrame();
+
+  File file = file_system->Directories().data_directory.Child("async.bin");
+  file_tasks.Launch([file]() -> Task<void> {
+    if (!co_await file.WriteBytesAsync(Bytes{std::byte{0}, std::byte{0xFF}}) ||
+        !co_await file.AppendBytesAsync(Bytes{std::byte{'a'}, std::byte{0}})) {
+      file_task_complete = true;
+      co_return;
+    }
+    FileResult<Bytes> result = co_await file.ReadBytesAsync();
+    if (result.Succeeded()) {
+      async_bytes = std::move(result).Value();
+    }
+    file_task_complete = true;
+  });
+
+  platform.RunUntil([] { return file_task_complete; });
+  REQUIRE((async_bytes == Bytes{std::byte{0}, std::byte{0xFF}, std::byte{'a'}, std::byte{0}}));
 }
 
 TEST_CASE("CancelingAFileTaskDropsItsContinuation") {

--- a/tests/runtime/file_picker.cpp
+++ b/tests/runtime/file_picker.cpp
@@ -17,8 +17,8 @@ namespace huxerui::test {
 
 namespace {
 
-std::vector<std::byte> Bytes(std::string_view value) {
-  std::vector<std::byte> bytes;
+Bytes BytesFromString(std::string_view value) {
+  Bytes bytes;
   bytes.reserve(value.size());
   for (const char character : value) {
     bytes.push_back(static_cast<std::byte>(character));
@@ -28,11 +28,11 @@ std::vector<std::byte> Bytes(std::string_view value) {
 
 class TestFileReferenceState final : public detail::FileReferenceState {
 public:
-  explicit TestFileReferenceState(std::vector<std::byte> bytes) : bytes(std::move(bytes)) {}
+  explicit TestFileReferenceState(Bytes bytes) : bytes(std::move(bytes)) {}
 
   std::function<void()> ReadBytes(detail::FileReferenceBytesCompletion completion) override {
     ++read_count;
-    completion(FileResult<std::vector<std::byte>>(bytes));
+    completion(FileResult<Bytes>(bytes));
     return {};
   }
 
@@ -50,7 +50,7 @@ public:
     return {};
   }
 
-  std::vector<std::byte> bytes;
+  Bytes bytes;
   int read_count = 0;
   std::optional<File> imported_to;
   bool imported_with_overwrite = false;
@@ -62,7 +62,7 @@ public:
 FileReference MakeReference(
     std::string name = "document.txt",
     bool can_write = true,
-    std::shared_ptr<TestFileReferenceState> state = std::make_shared<TestFileReferenceState>(Bytes("content"))
+    std::shared_ptr<TestFileReferenceState> state = std::make_shared<TestFileReferenceState>(BytesFromString("content"))
 ) {
   const std::size_t size = state->bytes.size();
   return detail::MakeFileReference(
@@ -198,7 +198,7 @@ TEST_CASE("FileReferenceRetainsItsGrantAndProvidesMetadataAndOperations") {
   Runtime runtime(FilePickerApp, platform);
   runtime.BuildFrame();
 
-  auto state = std::make_shared<TestFileReferenceState>(Bytes("\xEF\xBB\xBFhello"));
+  auto state = std::make_shared<TestFileReferenceState>(BytesFromString("\xEF\xBB\xBFhello"));
   std::weak_ptr<TestFileReferenceState> weak_state = state;
   FileReference reference = MakeReference("report.txt", true, state);
   FileReference copy = reference;
@@ -236,7 +236,7 @@ TEST_CASE("ReadOnlyFileReferenceRejectsReplacementWithoutCallingThePlatform") {
   Runtime runtime(FilePickerApp, platform);
   runtime.BuildFrame();
 
-  auto state = std::make_shared<TestFileReferenceState>(Bytes("read only"));
+  auto state = std::make_shared<TestFileReferenceState>(BytesFromString("read only"));
   FileReference reference = MakeReference("readonly.txt", false, state);
   file_picker_tasks.Launch([reference]() -> Task<void> {
     replaced_reference = co_await reference.ReplaceWithAsync(File("/tmp/replacement.txt"));
@@ -296,7 +296,7 @@ TEST_CASE("FilePickerValidatesPortableFiltersAndSuggestedNames") {
   REQUIRE_THROWS_AS(
       detail::MakeFileReference(
           {.name = "document.txt", .content_type = "text/*"},
-          std::make_shared<TestFileReferenceState>(Bytes("content"))
+          std::make_shared<TestFileReferenceState>(BytesFromString("content"))
       ),
       std::logic_error
   );

--- a/tests/runtime/http.cpp
+++ b/tests/runtime/http.cpp
@@ -2,10 +2,12 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -15,6 +17,15 @@
 namespace huxerui::test {
 
 namespace {
+
+Bytes BytesFromString(std::string_view value) {
+  Bytes bytes;
+  bytes.reserve(value.size());
+  for (const char character : value) {
+    bytes.push_back(static_cast<std::byte>(character));
+  }
+  return bytes;
+}
 
 class ManualHttpTransport final : public detail::HttpTransport {
 public:
@@ -163,6 +174,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
   Runtime runtime(HttpApp, platform);
   runtime.BuildFrame();
   const std::thread::id ui_thread = std::this_thread::get_id();
+  const Bytes request_body{std::byte{'{'}, std::byte{0}, std::byte{0xFF}, std::byte{'}'}};
 
   http_tasks.Launch(CaptureHttpResult(
       http_client,
@@ -175,7 +187,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
                   {"X-Trace", "first"},
                   {"X-Trace", "second"},
               },
-          .body = "{}",
+          .body = request_body,
           .timeout = std::chrono::milliseconds{5000},
       }
   ));
@@ -193,7 +205,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
            {"X-Trace", "second"},
        })
   );
-  REQUIRE(request.body == "{}");
+  REQUIRE(request.body == request_body);
   REQUIRE(request.timeout == std::chrono::milliseconds{5000});
 
   std::thread completion([&platform] {
@@ -203,7 +215,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
             .url = "https://example.test/items/42",
             .status_code = 201,
             .headers = {{"Content-Type", "application/json"}},
-            .body = "{\"id\":42}",
+            .body = Bytes{std::byte{'{'}, std::byte{0}, std::byte{0xFF}, std::byte{'}'}},
         })
     );
   });
@@ -213,7 +225,7 @@ TEST_CASE("HttpClientSendsTypedRequestsAndResumesWithResponsesOnTheUIThread") {
   platform.RunPlatformModuleTasks();
   REQUIRE(http_response.has_value());
   REQUIRE(http_response->status_code == 201);
-  REQUIRE(http_response->body == "{\"id\":42}");
+  REQUIRE((http_response->body == Bytes{std::byte{'{'}, std::byte{0}, std::byte{0xFF}, std::byte{'}'}}));
   REQUIRE(http_resume_thread == ui_thread);
 }
 
@@ -223,7 +235,7 @@ TEST_CASE("HttpClientHandlesImmediateTransportCompletion") {
   platform.transport->CompleteImmediately(HttpResult(HttpResponse{
       .url = "https://example.test/immediate",
       .status_code = 200,
-      .body = "immediate",
+      .body = BytesFromString("immediate"),
   }));
   Runtime runtime(HttpApp, platform);
   runtime.BuildFrame();
@@ -233,7 +245,7 @@ TEST_CASE("HttpClientHandlesImmediateTransportCompletion") {
 
   REQUIRE(http_completions == 1);
   REQUIRE(http_response.has_value());
-  REQUIRE(http_response->body == "immediate");
+  REQUIRE(http_response->body == BytesFromString("immediate"));
   REQUIRE_FALSE(platform.transport->Canceled(0));
 }
 
@@ -251,7 +263,7 @@ TEST_CASE("HttpClientAcceptsOnlyTheFirstTransportCompletion") {
       HttpResult(HttpResponse{
           .url = "https://example.test/duplicate",
           .status_code = 200,
-          .body = "first",
+          .body = BytesFromString("first"),
       })
   );
   platform.transport->Complete(
@@ -259,14 +271,14 @@ TEST_CASE("HttpClientAcceptsOnlyTheFirstTransportCompletion") {
       HttpResult(HttpResponse{
           .url = "https://example.test/duplicate",
           .status_code = 200,
-          .body = "second",
+          .body = BytesFromString("second"),
       })
   );
   platform.RunPlatformModuleTasks();
 
   REQUIRE(http_completions == 1);
   REQUIRE(http_response.has_value());
-  REQUIRE(http_response->body == "first");
+  REQUIRE(http_response->body == BytesFromString("first"));
 }
 
 TEST_CASE("HttpClientMapsTransportFailuresWithoutTreatingHttpStatusesAsErrors") {
@@ -300,7 +312,7 @@ TEST_CASE("HttpClientCancellationStopsThePlatformRequestAndDropsLateCompletion")
       HttpResult(HttpResponse{
           .url = "https://example.test/slow",
           .status_code = 200,
-          .body = "late",
+          .body = BytesFromString("late"),
       })
   );
   platform.RunPlatformModuleTasks();
@@ -317,7 +329,7 @@ TEST_CASE("HttpClientValidatesPortableRequestConfigurationBeforeLaunch") {
   REQUIRE_NOTHROW(static_cast<void>(http_client->Send({.url = "HTTPS://example.test"})));
   REQUIRE_THROWS_AS(static_cast<void>(http_client->Send({.url = "file:///tmp/value"})), std::invalid_argument);
   REQUIRE_THROWS_AS(
-      static_cast<void>(http_client->Send({.url = "https://example.test", .body = "body"})),
+      static_cast<void>(http_client->Send({.url = "https://example.test", .body = BytesFromString("body")})),
       std::invalid_argument
   );
   REQUIRE_THROWS_AS(

--- a/tests/unit/data.cpp
+++ b/tests/unit/data.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch_amalgamated.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+#include <huxerui/data.h>
+
+namespace huxerui::test {
+
+static_assert(std::is_same_v<Bytes, std::vector<std::byte>>);
+
+TEST_CASE("BytesOwnsMutableContiguousBinaryData") {
+  Bytes bytes{std::byte{0}, std::byte{0xFF}};
+  bytes.push_back(std::byte{'a'});
+
+  REQUIRE(bytes.size() == 3);
+  REQUIRE(bytes.data()[0] == std::byte{0});
+  REQUIRE(bytes.data()[1] == std::byte{0xFF});
+  REQUIRE(bytes.data()[2] == std::byte{'a'});
+}
+
+} // namespace huxerui::test

--- a/tests/unit/file.cpp
+++ b/tests/unit/file.cpp
@@ -129,8 +129,17 @@ TEST_CASE("FilePerformsSynchronousLocalFileAndDirectoryOperations") {
   REQUIRE(moved.Delete());
   REQUIRE(moved.Delete());
 
+  File binary = directory.Child("binary.bin");
+  const Bytes prefix{std::byte{0}, std::byte{0xFF}};
+  const Bytes suffix{std::byte{'a'}, std::byte{0}};
+  REQUIRE(binary.WriteBytes(prefix));
+  REQUIRE(binary.AppendBytes(suffix));
+  FileResult<Bytes> binary_result = binary.ReadBytes();
+  REQUIRE(binary_result.Succeeded());
+  REQUIRE((binary_result.Value() == Bytes{std::byte{0}, std::byte{0xFF}, std::byte{'a'}, std::byte{0}}));
+
   File bom = directory.Child("bom.txt");
-  const std::vector<std::byte> bom_bytes{
+  const Bytes bom_bytes{
       std::byte{0xEF},
       std::byte{0xBB},
       std::byte{0xBF},
@@ -141,7 +150,7 @@ TEST_CASE("FilePerformsSynchronousLocalFileAndDirectoryOperations") {
   REQUIRE(bom.ReadString().Value() == "ok");
 
   File invalid = directory.Child("invalid.txt");
-  const std::vector<std::byte> invalid_bytes{std::byte{0xFF}};
+  const Bytes invalid_bytes{std::byte{0xFF}};
   REQUIRE(invalid.WriteBytes(invalid_bytes));
   REQUIRE_FALSE(invalid.ReadString().Succeeded());
   REQUIRE(invalid.ReadString().Error().code == FileErrorCode::InvalidEncoding);

--- a/tests/unit/platform_payload.cpp
+++ b/tests/unit/platform_payload.cpp
@@ -22,7 +22,7 @@ TEST_CASE("PlatformPayloadPreservesSupportedKinds") {
       {"integer", std::int64_t{42}},
       {"double", 2.5},
       {"string", "value"},
-      {"bytes", PlatformPayload::Bytes{std::byte{1}, std::byte{2}}},
+      {"bytes", Bytes{std::byte{1}, std::byte{2}}},
       {"list", PlatformPayload::List{nullptr, false}},
   };
 


### PR DESCRIPTION
## Summary

- add the public huxerui::Bytes owned binary container in huxerui/data.h
- migrate file, resource, platform payload, Android JNI, and HTTP APIs and backends to Bytes
- preserve span-based borrowed inputs and add binary-focused tests, documentation, and SDK packaging checks

## Validation

- cmake --build build --parallel 4
- ctest --test-dir build --output-on-failure --parallel 4 (14/14 passed)
- independent clean configure and full build with tests, examples, and CLI enabled
- git diff --check

Closes #62