### PR TITLE
refactor(core): replace magic numbers with named constants

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -8,6 +8,7 @@
 #include <huxerui/theme.h>
 
 #include "internal.h"
+#include "numeric_constants.h"
 
 namespace huxerui {
 
@@ -24,10 +25,10 @@ double EvaluateCubicBezier(const CubicBezierCurve& curve, double progress) {
   };
 
   double parameter = progress;
-  for (int iteration = 0; iteration < 8; ++iteration) {
+  for (int iteration = 0; iteration < detail::newton_max_iterations; ++iteration) {
     const double error = coordinate(parameter, curve.X1(), curve.X2()) - progress;
     const double slope = derivative(parameter, curve.X1(), curve.X2());
-    if (std::abs(error) < 1.0e-7 || std::abs(slope) < 1.0e-7) {
+    if (std::abs(error) < detail::bezier_convergence_epsilon || std::abs(slope) < detail::bezier_convergence_epsilon) {
       break;
     }
     parameter = std::clamp(parameter - error / slope, 0.0, 1.0);
@@ -35,9 +36,9 @@ double EvaluateCubicBezier(const CubicBezierCurve& curve, double progress) {
 
   double low = 0.0;
   double high = 1.0;
-  for (int iteration = 0; iteration < 12; ++iteration) {
+  for (int iteration = 0; iteration < detail::bisection_max_iterations; ++iteration) {
     const double x = coordinate(parameter, curve.X1(), curve.X2());
-    if (std::abs(x - progress) < 1.0e-7) {
+    if (std::abs(x - progress) < detail::bezier_convergence_epsilon) {
       break;
     }
     if (x < progress) {
@@ -156,7 +157,7 @@ EvaluateSpring(const SpringSpec& spring, float start, float target, float start_
   double resolved_displacement = displacement;
   double resolved_velocity = velocity;
 
-  if (damping_ratio < 1.0 - 1.0e-5) {
+  if (damping_ratio < 1.0 - detail::critical_damping_epsilon) {
     const double damped_frequency = angular_frequency * std::sqrt(1.0 - damping_ratio * damping_ratio);
     const double a = displacement;
     const double b = (velocity + damping_ratio * angular_frequency * displacement) / damped_frequency;
@@ -166,7 +167,7 @@ EvaluateSpring(const SpringSpec& spring, float start, float target, float start_
     resolved_displacement = exponential * (a * cosine + b * sine);
     resolved_velocity = exponential * (-damping_ratio * angular_frequency * (a * cosine + b * sine) -
                                        a * damped_frequency * sine + b * damped_frequency * cosine);
-  } else if (damping_ratio <= 1.0 + 1.0e-5) {
+  } else if (damping_ratio <= 1.0 + detail::critical_damping_epsilon) {
     const double a = displacement;
     const double b = velocity + angular_frequency * displacement;
     const double exponential = std::exp(-angular_frequency * elapsed);
@@ -367,8 +368,7 @@ public:
   NodeExtension::FrameResult OnFrame(MountedNode& node, const FrameInfo& frame) override {
     auto& mounted = static_cast<detail::MountedNode&>(node);
     const MotionAdvanceResult result = degrees_.Advance(frame);
-    constexpr float degrees_to_radians = 3.14159265358979323846F / 180.0F;
-    const float radians = degrees_.Value() * degrees_to_radians;
+    const float radians = degrees_.Value() * detail::degrees_to_radians_factor;
     const float cosine = std::cos(radians);
     const float sine = std::sin(radians);
     const Transform2D rotation{
@@ -555,7 +555,7 @@ MotionAdvanceResult MotionController::Advance(const FrameInfo& frame) noexcept {
     const auto [resolved_value, resolved_velocity] = EvaluateSpring(*spring, start_, target_, start_velocity_, elapsed);
     value_ = resolved_value;
     velocity_ = resolved_velocity;
-    if (std::abs(target_ - value_) < 0.001F && std::abs(velocity_) < 0.001F) {
+    if (std::abs(target_ - value_) < detail::progress_epsilon && std::abs(velocity_) < detail::progress_epsilon) {
       Finish(target_);
     }
     return {value_ != previous_value, running_, std::nullopt};

--- a/src/geometry_internal.h
+++ b/src/geometry_internal.h
@@ -6,6 +6,8 @@
 
 #include <huxerui/geometry.h>
 
+#include "numeric_constants.h"
+
 namespace huxerui::detail {
 
 inline Transform2D ComposeTransform(const Transform2D& outer, const Transform2D& inner) noexcept {
@@ -32,7 +34,7 @@ inline Transform2D TranslationTransform(Point offset) noexcept {
 
 inline std::optional<Transform2D> InverseTransform(const Transform2D& transform) noexcept {
   const float determinant = transform.m11 * transform.m22 - transform.m12 * transform.m21;
-  if (!std::isfinite(determinant) || std::abs(determinant) <= 0.000001F) {
+  if (!std::isfinite(determinant) || std::abs(determinant) <= transform_epsilon) {
     return std::nullopt;
   }
   const float inverse_m11 = transform.m22 / determinant;

--- a/src/gesture.cpp
+++ b/src/gesture.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "internal.h"
+#include "numeric_constants.h"
 
 namespace huxerui {
 namespace {
@@ -81,8 +82,8 @@ public:
 
 private:
   std::uint32_t count_ = 2;
-  double maximum_interval_ = 0.3;
-  float maximum_movement_ = 18.0F;
+  double maximum_interval_ = detail::long_press_minimum_interval;
+  float maximum_movement_ = detail::multi_tap_movement_slop;
 };
 
 class MultiTapExtension final : public NodeExtension {
@@ -224,7 +225,7 @@ public:
 
 private:
   Point origin_;
-  float maximum_movement_ = 6.0F;
+  float maximum_movement_ = detail::touch_gesture_slop;
   std::optional<double> deadline_;
   bool accepted_ = false;
 };
@@ -417,7 +418,7 @@ private:
   }
 
   Point Velocity(double timestamp) const {
-    constexpr double maximum_age = 0.1;
+    constexpr double maximum_age = detail::velocity_sample_max_age;
     if (sample_count_ < 2 || !std::isfinite(timestamp)) {
       return {};
     }
@@ -452,8 +453,8 @@ private:
   }
 
   std::optional<Axis> axis_;
-  float minimum_distance_ = 6.0F;
-  float delayed_tolerance_ = 6.0F;
+  float minimum_distance_ = detail::touch_gesture_slop;
+  float delayed_tolerance_ = detail::touch_gesture_slop;
   Point down_origin_;
   Point origin_;
   Point previous_;
@@ -661,10 +662,10 @@ private:
       dot += from.x * to.x + from.y * to.y;
       cross += from.x * to.y - from.y * to.x;
     }
-    const float scale = previous.mean_square_radius > 0.000001F
+    const float scale = previous.mean_square_radius > detail::transform_epsilon
                             ? std::sqrt(current.mean_square_radius / previous.mean_square_radius)
                             : 1.0F;
-    const float rotation = std::abs(dot) > 0.000001F || std::abs(cross) > 0.000001F
+    const float rotation = std::abs(dot) > detail::transform_epsilon || std::abs(cross) > detail::transform_epsilon
                                ? std::atan2(cross, dot)
                                : 0.0F;
     const Point previous_local = Local(previous.centroid);

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "numeric_constants.h"
 
 #include <algorithm>
 #include <cmath>
@@ -987,7 +988,7 @@ ScrollMotionFrameResult ScrollMotion::Advance(MountedNode& node, const FrameInfo
     Stop();
     return {};
   }
-  const float stop_velocity = physics.minimum_fling_velocity * 0.3F;
+  const float stop_velocity = physics.minimum_fling_velocity * fling_stop_velocity_fraction;
   if (!node.interaction.enabled || !IsScrollContainer(node)) {
     Stop();
     return {};
@@ -1000,7 +1001,7 @@ ScrollMotionFrameResult ScrollMotion::Advance(MountedNode& node, const FrameInfo
     };
   }
 
-  const double elapsed = std::clamp(frame.timestamp - *previous_timestamp_, 0.0, 0.25);
+  const double elapsed = std::clamp(frame.timestamp - *previous_timestamp_, 0.0, fling_frame_clamp);
   previous_timestamp_ = frame.timestamp;
   if (elapsed <= 0.0) {
     return {
@@ -1020,7 +1021,7 @@ ScrollMotionFrameResult ScrollMotion::Advance(MountedNode& node, const FrameInfo
       }
     }
   }
-  if (std::abs(consumed - delta) > 0.001F) {
+  if (std::abs(consumed - delta) > scroll_delta_epsilon) {
     const float transfer_velocity = velocity_ - physics.deceleration_rate * consumed;
     Stop();
     if (std::abs(transfer_velocity) >= stop_velocity) {
@@ -1105,7 +1106,7 @@ ScrollEventResult ApplyScrollEvent(MountedNode& node, const ScrollEvent& event) 
       continue;
     }
     result.scroll_chain.push_back(*candidate);
-    if (std::abs(remaining) < 0.001F) {
+    if (std::abs(remaining) < scroll_delta_epsilon) {
       continue;
     }
     const float consumed = ScrollNodeBy(**candidate, remaining);

--- a/src/modifier.cpp
+++ b/src/modifier.cpp
@@ -11,6 +11,11 @@ namespace huxerui {
 
 namespace {
 
+// Scroll bar surface alphas are a scroll bar implementation detail.
+constexpr float scrollbar_track_alpha = 0.08F;
+constexpr float scrollbar_thumb_alpha = 0.55F;
+constexpr float scrollbar_hit_opacity = 0.01F;
+
 ScrollBarStyle ResolveScrollBarStyle(
     const std::shared_ptr<const Environment>& environment, const std::optional<ScrollBarStyle>& explicit_style
 ) {
@@ -28,9 +33,9 @@ ScrollBarStyle ResolveScrollBarStyle(
   style.fade_in_duration = theme.motion.reduced_motion ? 0.0F : static_cast<float>(theme.motion.fast);
   style.fade_out_duration = theme.motion.reduced_motion ? 0.0F : static_cast<float>(theme.motion.normal);
   style.track_color = theme.colors.on_surface;
-  style.track_color.alpha *= 0.08F;
+  style.track_color.alpha *= scrollbar_track_alpha;
   style.thumb_color = theme.colors.on_surface;
-  style.thumb_color.alpha *= 0.55F;
+  style.thumb_color.alpha *= scrollbar_thumb_alpha;
   return style;
 }
 
@@ -126,7 +131,8 @@ public:
 
   bool HitTest(MountedNode& node, Point position) const override {
     const auto geometry = ResolveLocalScrollBarGeometry(node);
-    return node.IsEnabled() && geometry.has_value() && opacity_.Value() > 0.01F && geometry->track.Contains(position);
+    return node.IsEnabled() && geometry.has_value() && opacity_.Value() > scrollbar_hit_opacity &&
+           geometry->track.Contains(position);
   }
 
   bool HoverHitTest(MountedNode& node, Point position) const override {
@@ -156,7 +162,8 @@ public:
     }
     if (event.type == PointerEventType::Down) {
       const auto geometry = ResolveLocalScrollBarGeometry(node);
-      if (!geometry.has_value() || opacity_.Value() <= 0.01F || !geometry->track.Contains(event.position)) {
+      if (!geometry.has_value() || opacity_.Value() <= scrollbar_hit_opacity ||
+          !geometry->track.Contains(event.position)) {
         return NodeExtension::PointerResult::Ignored;
       }
 

--- a/src/navigation_ui.cpp
+++ b/src/navigation_ui.cpp
@@ -13,6 +13,7 @@
 #include <huxerui/theme.h>
 
 #include "internal.h"
+#include "numeric_constants.h"
 #include "resource_internal.h"
 
 namespace huxerui::detail {
@@ -861,7 +862,7 @@ public:
     static_cast<detail::MountedNode&>(node.ChildAt(1)).local_enabled = configuration->presentation->target_visible;
     static_cast<detail::MountedNode&>(node).trap_focus =
         !inline_placement &&
-        (configuration->presentation->target_visible || configuration->presentation->progress > 0.001F);
+        (configuration->presentation->target_visible || configuration->presentation->progress > detail::progress_epsilon);
     return result.SetSize(size);
   }
 };
@@ -921,7 +922,7 @@ public:
       configuration_.presentation->progress = progress_.Value();
     }
     auto& mounted = static_cast<detail::MountedNode&>(node);
-    const bool trap_focus = target_visible || progress_.Value() > 0.001F;
+    const bool trap_focus = target_visible || progress_.Value() > detail::progress_epsilon;
     const bool focus_changed = mounted.trap_focus != trap_focus;
     mounted.trap_focus = trap_focus;
     return {result.needs_frame || focus_changed, result.wake_after};
@@ -931,7 +932,7 @@ public:
     if (!IsModal() || !node.IsEnabled() || !node.Bounds().Contains(position)) {
       return false;
     }
-    if (progress_.Value() > 0.001F || TargetVisible()) {
+    if (progress_.Value() > detail::progress_epsilon || TargetVisible()) {
       return true;
     }
     if (!configuration_.presentation || !configuration_.presentation->allow_open_gesture) {
@@ -951,12 +952,12 @@ public:
       drag_origin_ = event.position.x;
       drag_origin_progress_ = progress_.Value();
       const Rect panel = PresentedPanelBounds(node);
-      outside_press_ = progress_.Value() > 0.001F && !panel.Contains(event.position);
+      outside_press_ = progress_.Value() > detail::progress_epsilon && !panel.Contains(event.position);
       const float handle = std::max(0.0F, configuration_.edge_drag_width);
       const bool close_handle = configuration_.side == DrawerSide::Start
                                     ? std::abs(event.position.x - (panel.x + panel.width)) <= handle
                                     : std::abs(event.position.x - panel.x) <= handle;
-      dragging_ = !outside_press_ && (progress_.Value() <= 0.001F || close_handle);
+      dragging_ = !outside_press_ && (progress_.Value() <= detail::progress_epsilon || close_handle);
       return outside_press_ || dragging_ ? PointerResult::Capture : PointerResult::Ignored;
     }
     if (!pointer_id_.has_value() || *pointer_id_ != event.pointer_id) {
@@ -997,7 +998,7 @@ public:
       return false;
     }
     if (!TargetVisible() && !interactive_) {
-      return progress_.Value() > 0.001F;
+      return progress_.Value() > detail::progress_epsilon;
     }
     switch (event.phase) {
     case BackPhase::Begin:

--- a/src/numeric_constants.h
+++ b/src/numeric_constants.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace huxerui::detail {
+
+// Shared numeric tolerances. File-local constants live next to their only use site.
+inline constexpr float transform_epsilon = 0.000001F;   // Inverse-matrix determinant singularity
+inline constexpr float extrema_epsilon = 0.000001F;     // Bezier extrema root singularity
+inline constexpr float scroll_delta_epsilon = 0.001F;   // Scroll delta consumed/comparison epsilon
+inline constexpr float progress_epsilon = 0.001F;       // Progress/opacity zero-test epsilon
+
+// Curve approximation constants.
+inline constexpr float cubic_circle_kappa = 0.5522847498F;  // Bezier control for a quarter circle
+inline constexpr float square_cap_scale = 0.70710678118F;   // sqrt(0.5), square stroke cap outset
+inline constexpr float square_cap_outset = 1.41421356237F;  // sqrt(2), square stroke cap corner
+inline constexpr float degrees_to_radians_factor = 3.14159265358979323846F / 180.0F;
+inline constexpr float two_pi = 6.28318530717958647692F;
+
+// Root-finding iteration bounds.
+inline constexpr int newton_max_iterations = 8;         // Cubic bezier Newton solve (double precision)
+inline constexpr int bezier_bisection_iterations = 16;  // Cubic bezier bisection solve (float precision)
+inline constexpr int bisection_max_iterations = 12;     // Cubic bezier bisection refine (double precision)
+inline constexpr double bezier_convergence_epsilon = 1.0e-7;
+inline constexpr double critical_damping_epsilon = 1.0e-5;  // Damping-ratio neighborhood of 1.0
+
+// Gesture and animation timing defaults.
+inline constexpr double double_tap_interval = 0.4;          // Text double-tap window
+inline constexpr double long_press_delay = 0.5;             // Text long-press delay
+inline constexpr double long_press_minimum_interval = 0.3;  // Multi-tap fallback interval
+inline constexpr float multi_tap_movement_slop = 18.0F;     // Multi-tap movement tolerance
+inline constexpr float velocity_sample_max_age = 0.1F;      // Scroll velocity sampling window
+inline constexpr float fling_stop_velocity_fraction = 0.3F; // Stop velocity = min fling * fraction
+inline constexpr double fling_frame_clamp = 0.25;           // Single-frame time clamp
+inline constexpr double maximum_extrapolation_ratio = 2.0;  // Velocity extrapolation ratio cap
+
+// Visual thresholds.
+inline constexpr float luminance_threshold = 0.45F;         // System bar brightness boundary
+inline constexpr float tick_max_interval_count = 512.0F;    // Slider tick interval cap
+inline constexpr float tick_min_spacing_scale = 1.5F;        // Slider tick minimum spacing
+
+} // namespace huxerui::detail

--- a/src/paint.cpp
+++ b/src/paint.cpp
@@ -9,6 +9,7 @@
 #include <huxerui/vector.h>
 
 #include "geometry_internal.h"
+#include "numeric_constants.h"
 #include "shadow_internal.h"
 #include "vector_internal.h"
 
@@ -410,7 +411,7 @@ void PaintContext::DrawArc(
       }
   );
   const float cap_outset =
-      cap == StrokeCap::Square ? std::max(0.0F, width) * 0.70710678118F : std::max(0.0F, width) * 0.5F;
+      cap == StrokeCap::Square ? std::max(0.0F, width) * detail::square_cap_scale : std::max(0.0F, width) * 0.5F;
   const float extent = std::max(0.0F, radius) + cap_outset;
   Include({
       center.x - extent,
@@ -526,7 +527,7 @@ void PaintContext::StrokePath(Path path, Color color, float width, StrokeCap cap
     outset_multiplier = std::max(outset_multiplier, miter_limit);
   }
   if (cap == StrokeCap::Square) {
-    outset_multiplier = std::max(outset_multiplier, 1.41421356237F);
+    outset_multiplier = std::max(outset_multiplier, detail::square_cap_outset);
   }
   const float outset = width * 0.5F * outset_multiplier;
   Include({

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "geometry_internal.h"
+#include "numeric_constants.h"
 #include "path_internal.h"
 
 namespace huxerui {
@@ -38,7 +39,7 @@ float CubicValue(float start, float first_control, float second_control, float e
 
 template <class Include> void IncludeQuadraticExtrema(float start, float control, float end, Include&& include) {
   const float denominator = start - 2.0F * control + end;
-  if (std::abs(denominator) <= 0.000001F) {
+  if (std::abs(denominator) <= detail::extrema_epsilon) {
     return;
   }
   const float time = (start - control) / denominator;
@@ -52,8 +53,8 @@ void IncludeCubicExtrema(float start, float first_control, float second_control,
   const float a = -start + 3.0F * first_control - 3.0F * second_control + end;
   const float b = 2.0F * (start - 2.0F * first_control + second_control);
   const float c = first_control - start;
-  if (std::abs(a) <= 0.000001F) {
-    if (std::abs(b) > 0.000001F) {
+  if (std::abs(a) <= detail::extrema_epsilon) {
+    if (std::abs(b) > detail::extrema_epsilon) {
       const float time = -c / b;
       if (time > 0.0F && time < 1.0F) {
         include(time);
@@ -220,7 +221,7 @@ Path Path::RoundedRect(Rect rect, CornerRadii corner_radii) {
 
   const float right = rect.x + rect.width;
   const float bottom = rect.y + rect.height;
-  constexpr float cubic_circle = 0.5522847498F;
+  constexpr float cubic_circle = detail::cubic_circle_kappa;
   Path path;
   path.MoveTo({rect.x + corner_radii.top_left, rect.y})
       .LineTo({right - corner_radii.top_right, rect.y})

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "numeric_constants.h"
 #include "application_internal.h"
 #include "external_texture_internal.h"
 #include "resource_internal.h"
@@ -16,6 +17,16 @@
 namespace huxerui::detail {
 
 namespace {
+
+// sRGB transfer function and relative luminance coefficients for system bar contrast.
+constexpr float srgb_linear_threshold = 0.04045F;
+constexpr float srgb_linear_divisor = 12.92F;
+constexpr float srgb_offset = 0.055F;
+constexpr float srgb_offset_denominator = 1.055F;
+constexpr float srgb_gamma = 2.4F;
+constexpr float relative_luminance_red = 0.2126F;
+constexpr float relative_luminance_green = 0.7152F;
+constexpr float relative_luminance_blue = 0.0722F;
 
 int LayerLevelRank(LayerLevel level) noexcept {
   switch (level) {
@@ -216,17 +227,18 @@ Color CompositeOver(Color foreground, Color background) noexcept {
 
 float LinearColorChannel(float value) noexcept {
   value = std::clamp(value, 0.0F, 1.0F);
-  return value <= 0.04045F ? value / 12.92F : std::pow((value + 0.055F) / 1.055F, 2.4F);
+  return value <= srgb_linear_threshold ? value / srgb_linear_divisor
+                                        : std::pow((value + srgb_offset) / srgb_offset_denominator, srgb_gamma);
 }
 
 SystemBarContentBrightness ResolveBrightness(SystemBarContentBrightness configured, Color background) noexcept {
   if (configured != SystemBarContentBrightness::Automatic) {
     return configured;
   }
-  const float luminance = 0.2126F * LinearColorChannel(background.red) +
-                          0.7152F * LinearColorChannel(background.green) +
-                          0.0722F * LinearColorChannel(background.blue);
-  return luminance > 0.45F ? SystemBarContentBrightness::Dark : SystemBarContentBrightness::Light;
+  const float luminance = relative_luminance_red * LinearColorChannel(background.red) +
+                          relative_luminance_green * LinearColorChannel(background.green) +
+                          relative_luminance_blue * LinearColorChannel(background.blue);
+  return luminance > luminance_threshold ? SystemBarContentBrightness::Dark : SystemBarContentBrightness::Light;
 }
 
 Color ResolveCaptionForeground(Color background) noexcept {
@@ -247,7 +259,7 @@ void CollectWindowDragRegionBackground(
       background = CompositeOver(*color, inherited_background);
     }
   }
-  if (node.properties.window_drag_region && node.presentation.resolved_opacity > 0.001F) {
+  if (node.properties.window_drag_region && node.presentation.resolved_opacity > progress_epsilon) {
     const Rect bounds = TransformBounds(node.presentation.resolved_transform, node.bounds);
     if (bounds.y < title_bar_height && bounds.y + bounds.height > 0.0F) {
       candidate = background;
@@ -309,7 +321,7 @@ void CollectSystemBarCandidates(
   if (!node.participates_in_layout) {
     return;
   }
-  if (node.presentation.resolved_opacity > 0.001F && node.properties.system_bars_appearance.has_value()) {
+  if (node.presentation.resolved_opacity > progress_epsilon && node.properties.system_bars_appearance.has_value()) {
     const Rect bounds = TransformBounds(node.presentation.resolved_transform, node.bounds);
     const SystemBarsAppearance& appearance = *node.properties.system_bars_appearance;
     if (appearance.status_bar_background.alpha > 0.0F && bounds.y <= status_boundary + 0.5F &&

--- a/src/runtime_pointer_interaction.cpp
+++ b/src/runtime_pointer_interaction.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "numeric_constants.h"
 
 #include <algorithm>
 #include <cmath>
@@ -49,7 +50,7 @@ void RecordScrollVelocitySample(PointerSession& session, Point position, double 
 }
 
 std::optional<float> EstimateScrollVelocity(const PointerSession& session, Axis axis, double release_timestamp) {
-  constexpr double maximum_sample_age = 0.1;
+  constexpr double maximum_sample_age = velocity_sample_max_age;
   if (session.scroll_velocity_sample_count < 2 || !std::isfinite(release_timestamp)) {
     return std::nullopt;
   }
@@ -149,7 +150,7 @@ std::optional<float> EstimateScrollVelocity(const PointerSession& session, Axis 
                : std::nullopt;
   }
 
-  constexpr double maximum_extrapolation_ratio = 2.0;
+  constexpr double maximum_extrapolation_ratio = detail::maximum_extrapolation_ratio;
   const double maximum_velocity = std::abs(trend_velocity) * maximum_extrapolation_ratio;
   return static_cast<float>(std::clamp(velocity, -maximum_velocity, maximum_velocity));
 }
@@ -647,7 +648,7 @@ void Runtime::AdvanceDragDropSession(std::int64_t pointer_id, const FrameInfo& f
       NotifyScrollActivity(*node, ScrollActivitySource::External);
       RequestFrame();
     }
-    if (std::abs(consumed - delta) < 0.001F) {
+    if (std::abs(consumed - delta) < scroll_delta_epsilon) {
       break;
     }
   }
@@ -1183,7 +1184,7 @@ std::vector<detail::MountedNode*> Runtime::ApplyDragScroll(const PointerSession&
       changed.push_back(candidate);
       remaining -= consumed;
     }
-    if (std::abs(remaining) < 0.001F) {
+    if (std::abs(remaining) < scroll_delta_epsilon) {
       break;
     }
   }

--- a/src/runtime_text_selection_gesture.cpp
+++ b/src/runtime_text_selection_gesture.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "numeric_constants.h"
 
 #include <algorithm>
 #include <cmath>
@@ -65,26 +66,23 @@ bool Runtime::TrackTouchTextSelectionGesture(const PointerEvent& event) {
     recognition->long_press_pending = false;
     recognition->tap_pending = false;
     recognition->double_tap_pending = false;
-    constexpr double double_tap_interval = 0.4;
-    constexpr float double_tap_slop = 18.0F;
     const double now = state_->platform_->Now();
     if (gesture.previous_tap_time.has_value() &&
         gesture.previous_tap_node == std::optional{recognition->node_identity} &&
-        now - *gesture.previous_tap_time >= 0.0 && now - *gesture.previous_tap_time <= double_tap_interval &&
+        now - *gesture.previous_tap_time >= 0.0 && now - *gesture.previous_tap_time <= detail::double_tap_interval &&
         std::hypot(event.position.x - gesture.previous_tap_position.x,
-                   event.position.y - gesture.previous_tap_position.y) <= double_tap_slop) {
+                   event.position.y - gesture.previous_tap_position.y) <= detail::multi_tap_movement_slop) {
       gesture.previous_tap_time.reset();
       gesture.previous_tap_node.reset();
       recognition->double_tap_pending = true;
       recognition->tap_position = event.position;
       return false;
     }
-    constexpr double delay = 0.5;
     recognition->long_press_pending = true;
-    recognition->long_press_deadline = now + delay;
+    recognition->long_press_deadline = now + detail::long_press_delay;
     recognition->tap_pending = true;
     recognition->tap_position = event.position;
-    RequestFrameAfter(delay);
+    RequestFrameAfter(detail::long_press_delay);
     return false;
   }
   if (event.type == PointerEventType::Move) {
@@ -93,7 +91,7 @@ bool Runtime::TrackTouchTextSelectionGesture(const PointerEvent& event) {
     if (recognition->long_press_pending && distance >= detail::touch_gesture_slop) {
       recognition->long_press_pending = false;
     }
-    if (recognition->tap_pending && distance >= 18.0F) {
+    if (recognition->tap_pending && distance >= detail::multi_tap_movement_slop) {
       recognition->tap_pending = false;
     }
     if (recognition->double_tap_pending && distance >= detail::touch_gesture_slop) {

--- a/src/scene_transition.cpp
+++ b/src/scene_transition.cpp
@@ -11,6 +11,7 @@
 #include <huxerui/theme.h>
 
 #include "internal.h"
+#include "numeric_constants.h"
 #include "window_internal.h"
 
 namespace huxerui::detail {
@@ -18,7 +19,7 @@ namespace huxerui::detail {
 namespace {
 
 Path CircularClip(Point center, float radius) {
-  constexpr float cubic_circle = 0.5522847498F;
+  constexpr float cubic_circle = cubic_circle_kappa;
   const float control = radius * cubic_circle;
   Path path;
   path.MoveTo({center.x + radius, center.y})

--- a/src/text_field.cpp
+++ b/src/text_field.cpp
@@ -1,5 +1,6 @@
 #include "internal.h"
 #include "geometry_internal.h"
+#include "numeric_constants.h"
 #include "resource_internal.h"
 #include "text_field_internal.h"
 #include "text_input_internal.h"
@@ -18,6 +19,9 @@
 
 namespace huxerui {
 namespace {
+
+// Minimum caret blink wake-up interval in seconds.
+constexpr double caret_wake_minimum = 0.001;
 
 bool IsSingleUtf8CodePoint(std::string_view text) noexcept {
   if (text.empty()) {
@@ -239,7 +243,7 @@ Path OutlinedBorderPath(Rect frame, float width, CornerRadii corner_radii, float
     return Path::RoundedRect(centerline, corner_radii);
   }
 
-  constexpr float cubic_circle = 0.5522847498F;
+  constexpr float cubic_circle = detail::cubic_circle_kappa;
   Path path;
   path.MoveTo({end, centerline.y})
       .LineTo({right - corner_radii.top_right, centerline.y})
@@ -826,7 +830,7 @@ public:
     const double phase = std::fmod(elapsed, interval);
     caret_visible_ = static_cast<std::uint64_t>(elapsed / interval) % 2 == 0;
     return finish({
-        .wake_after = std::max(0.001, interval - phase),
+        .wake_after = std::max(caret_wake_minimum, interval - phase),
     });
   }
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -14,6 +14,18 @@ namespace {
 
 constexpr float material_shadow_blur_per_elevation = 4.0F;
 
+// Alpha coefficients that shape Material design surfaces and their disabled states.
+constexpr float state_layer_alpha = 0.12F;              // Hover/ripple/disabled container/separator
+constexpr float disabled_content_alpha = 0.38F;         // Disabled foreground content
+constexpr float disabled_filled_background_alpha = 0.04F;
+constexpr float hover_state_alpha = 0.08F;              // Indication hover layer
+constexpr float scrim_shadow_alpha = 0.24F;             // Dialog/card shadow
+constexpr float elevated_shadow_alpha = 0.22F;
+constexpr float menu_shadow_alpha = 0.2F;
+constexpr float inverse_surface_alpha = 0.94F;          // Toast/tooltip background
+constexpr float selection_alpha = 0.22F;                // Text selection highlight
+constexpr float slider_track_alpha = 0.2F;
+
 AnimationSpec InteractionTween(double duration) {
   return TweenSpec{.duration = duration, .easing = Easing::EaseOut};
 }
@@ -39,8 +51,8 @@ Indication FlatIndication(Color color, const ThemeSpec& theme, float hover_opaci
 
 Indication MaterialIndication(Color color, const ThemeSpec& theme) {
   Color hover = color;
-  color.alpha *= 0.12F;
-  hover.alpha *= 0.08F;
+  color.alpha *= state_layer_alpha;
+  hover.alpha *= hover_state_alpha;
   return {
       .hover = IndicationLayer{
           .fill = hover,
@@ -67,12 +79,12 @@ Shadow MaterialShadow(Color color, float elevation) {
 
 ToastStyle FlatToastStyle(const ThemeSpec& theme) {
   Color background = theme.colors.inverse_surface;
-  background.alpha *= 0.94F;
+  background.alpha *= inverse_surface_alpha;
   return {
       .background = background,
       .text_style = TextStyle{Font::System(theme.typography.body_medium), theme.colors.inverse_on_surface},
       .padding = EdgeInsets::Symmetric(theme.spacing.medium, theme.spacing.small + theme.spacing.extra_small),
-      .shadow = Shadow{Color::Rgb(0, 0, 0, 0.24F), {}, theme.elevation.medium, 0.0F},
+      .shadow = Shadow{Color::Rgb(0, 0, 0, scrim_shadow_alpha), {}, theme.elevation.medium, 0.0F},
       .corner_radius = theme.shapes.small,
       .maximum_width = 480.0F,
       .viewport_padding = EdgeInsets{16.0F, 16.0F, 24.0F, 16.0F},
@@ -83,7 +95,7 @@ ToastStyle FlatToastStyle(const ThemeSpec& theme) {
 
 TooltipStyle FlatTooltipStyle(const ThemeSpec& theme) {
   Color background = theme.colors.inverse_surface;
-  background.alpha *= 0.94F;
+  background.alpha *= inverse_surface_alpha;
   return {
       .background = background,
       .text_style = TextStyle{Font::System(theme.typography.body_small), theme.colors.inverse_on_surface},
@@ -104,11 +116,11 @@ TooltipStyle FlatTooltipStyle(const ThemeSpec& theme) {
 
 DialogStyle FlatDialogStyle(const ThemeSpec& theme) {
   Color separator = theme.colors.on_surface;
-  separator.alpha *= 0.12F;
+  separator.alpha *= state_layer_alpha;
   return {
       .scrim = theme.colors.scrim,
       .background = theme.colors.surface,
-      .shadow = Shadow{Color::Rgb(0, 0, 0, 0.24F), {}, theme.elevation.high, 0.0F},
+      .shadow = Shadow{Color::Rgb(0, 0, 0, scrim_shadow_alpha), {}, theme.elevation.high, 0.0F},
       .title_style =
           TextStyle{Font::System(theme.typography.title_large).WithWeight(FontWeight::Bold), theme.colors.on_surface},
       .message_style = TextStyle{Font::System(theme.typography.body_medium), theme.colors.on_surface},
@@ -145,7 +157,7 @@ BottomSheetStyle FlatBottomSheetStyle(const ThemeSpec& theme) {
   return {
       .scrim = theme.colors.scrim,
       .background = theme.colors.surface,
-      .shadow = Shadow{Color::Rgb(0, 0, 0, 0.22F), {}, theme.elevation.high, 0.0F},
+      .shadow = Shadow{Color::Rgb(0, 0, 0, elevated_shadow_alpha), {}, theme.elevation.high, 0.0F},
       .corner_radii = CornerRadii::Top(theme.shapes.large),
       .drag_handle = Color::Transparent(),
       .drag_handle_size = {},
@@ -158,7 +170,7 @@ BottomSheetStyle FlatBottomSheetStyle(const ThemeSpec& theme) {
 
 MenuStyle FlatMenuStyle(const ThemeSpec& theme) {
   Color separator = theme.colors.on_surface;
-  separator.alpha *= 0.12F;
+  separator.alpha *= state_layer_alpha;
   return {
       .background = theme.colors.surface,
       .foreground = theme.colors.on_surface,
@@ -172,7 +184,7 @@ MenuStyle FlatMenuStyle(const ThemeSpec& theme) {
       .item_padding = EdgeInsets::Symmetric(theme.spacing.small + theme.spacing.extra_small, theme.spacing.small),
       .item_content_spacing = theme.spacing.small,
       .icon_size = 18.0F,
-      .shadow = Shadow{Color::Rgb(0, 0, 0, 0.2F), {}, theme.elevation.medium, 0.0F},
+      .shadow = Shadow{Color::Rgb(0, 0, 0, menu_shadow_alpha), {}, theme.elevation.medium, 0.0F},
       .corner_radius = theme.shapes.small,
       .minimum_width = 180.0F,
       .minimum_item_height = 36.0F,
@@ -253,7 +265,7 @@ DrawerStyle FlatDrawerStyle(const ThemeSpec& theme) {
   return {
       .background = theme.colors.surface,
       .scrim = theme.colors.scrim,
-      .shadow = Shadow{Color::Rgb(0, 0, 0, 0.22F), {}, theme.elevation.medium, 0.0F},
+      .shadow = Shadow{Color::Rgb(0, 0, 0, elevated_shadow_alpha), {}, theme.elevation.medium, 0.0F},
       .preferred_width = 320.0F,
       .minimum_width = 240.0F,
       .minimum_content_width = 360.0F,
@@ -291,9 +303,9 @@ ThemeDefinition FlatDefinition(ThemeSpec theme) {
 
 ButtonStyle MaterialButtonStyle(const ThemeSpec& theme) {
   Color disabled_background = theme.colors.on_surface;
-  disabled_background.alpha *= 0.12F;
+  disabled_background.alpha *= state_layer_alpha;
   Color disabled_label = theme.colors.on_surface;
-  disabled_label.alpha *= 0.38F;
+  disabled_label.alpha *= disabled_content_alpha;
   return {
       .background = theme.colors.primary,
       .label_style =
@@ -310,7 +322,7 @@ ButtonStyle MaterialButtonStyle(const ThemeSpec& theme) {
 
 IconButtonStyle MaterialIconButtonStyle(const ThemeSpec& theme) {
   Color disabled_foreground = theme.colors.on_surface;
-  disabled_foreground.alpha *= 0.38F;
+  disabled_foreground.alpha *= disabled_content_alpha;
   return {
       .foreground = theme.colors.on_surface_variant,
       .disabled_foreground = disabled_foreground,
@@ -324,11 +336,11 @@ IconButtonStyle MaterialIconButtonStyle(const ThemeSpec& theme) {
 
 ChipStyle MaterialChipStyle(const ThemeSpec& theme) {
   Color disabled_container = theme.colors.on_surface;
-  disabled_container.alpha *= 0.12F;
+  disabled_container.alpha *= state_layer_alpha;
   Color disabled_content = theme.colors.on_surface;
-  disabled_content.alpha *= 0.38F;
+  disabled_content.alpha *= disabled_content_alpha;
   Color disabled_border = theme.colors.on_surface;
-  disabled_border.alpha *= 0.12F;
+  disabled_border.alpha *= state_layer_alpha;
   return {
       .background = Color::Transparent(),
       .selected_background = theme.colors.secondary_container,
@@ -375,7 +387,7 @@ SegmentedButtonStyle MaterialSegmentedButtonStyle(const ThemeSpec& theme) {
 
 TabsStyle MaterialTabsStyle(const ThemeSpec& theme) {
   Color disabled_label = theme.colors.on_surface;
-  disabled_label.alpha *= 0.38F;
+  disabled_label.alpha *= disabled_content_alpha;
   Color divider_color = theme.colors.outline;
   divider_color.alpha *= 0.4F;
   return {
@@ -415,13 +427,13 @@ DividerStyle MaterialDividerStyle(const ThemeSpec& theme) {
 
 TextFieldStyle MaterialTextFieldStyle(const ThemeSpec& theme) {
   Color disabled_content = theme.colors.on_surface;
-  disabled_content.alpha *= 0.38F;
+  disabled_content.alpha *= disabled_content_alpha;
   Color disabled_indicator = theme.colors.on_surface;
-  disabled_indicator.alpha *= 0.38F;
+  disabled_indicator.alpha *= disabled_content_alpha;
   Color disabled_outline = theme.colors.on_surface;
-  disabled_outline.alpha *= 0.12F;
+  disabled_outline.alpha *= state_layer_alpha;
   Color disabled_container = theme.colors.on_surface;
-  disabled_container.alpha *= 0.04F;
+  disabled_container.alpha *= disabled_filled_background_alpha;
   return {
       .variant = TextFieldVariant::Filled,
       .show_label = true,
@@ -503,7 +515,7 @@ TextFieldStyle MaterialTextFieldStyle(const ThemeSpec& theme) {
 
 CheckboxStyle MaterialCheckboxStyle(const ThemeSpec& theme) {
   Color disabled = theme.colors.on_surface;
-  disabled.alpha *= 0.38F;
+  disabled.alpha *= disabled_content_alpha;
   return {
       .size = 18.0F,
       .minimum_interactive_size = 48.0F,
@@ -521,7 +533,7 @@ CheckboxStyle MaterialCheckboxStyle(const ThemeSpec& theme) {
 
 RadioButtonStyle MaterialRadioButtonStyle(const ThemeSpec& theme) {
   Color disabled = theme.colors.on_surface;
-  disabled.alpha *= 0.38F;
+  disabled.alpha *= disabled_content_alpha;
   return {
       .size = 20.0F,
       .minimum_interactive_size = 48.0F,
@@ -538,9 +550,9 @@ RadioButtonStyle MaterialRadioButtonStyle(const ThemeSpec& theme) {
 
 SwitchStyle MaterialSwitchStyle(const ThemeSpec& theme) {
   Color disabled_track = theme.colors.on_surface;
-  disabled_track.alpha *= 0.12F;
+  disabled_track.alpha *= state_layer_alpha;
   Color disabled_thumb = theme.colors.on_surface;
-  disabled_thumb.alpha *= 0.38F;
+  disabled_thumb.alpha *= disabled_content_alpha;
   return {
       .width = 52.0F,
       .height = 32.0F,
@@ -598,9 +610,9 @@ ProgressBarStyle MaterialProgressBarStyle(const ThemeSpec& theme) {
 
 SliderStyle MaterialSliderStyle(const ThemeSpec& theme) {
   Color disabled_active = theme.colors.on_surface;
-  disabled_active.alpha *= 0.38F;
+  disabled_active.alpha *= disabled_content_alpha;
   Color disabled_inactive = theme.colors.on_surface;
-  disabled_inactive.alpha *= 0.12F;
+  disabled_inactive.alpha *= state_layer_alpha;
   return {
       .width = 160.0F,
       .height = 48.0F,
@@ -634,7 +646,7 @@ SliderStyle MaterialSliderStyle(const ThemeSpec& theme) {
 
 ScrollBarStyle MaterialScrollBarStyle(const ThemeSpec& theme) {
   Color thumb = theme.colors.on_surface;
-  thumb.alpha *= 0.38F;
+  thumb.alpha *= disabled_content_alpha;
   return {
       .thickness = 4.0F,
       .minimum_thumb_extent = 24.0F,
@@ -743,7 +755,7 @@ BottomSheetStyle MaterialBottomSheetStyle(const ThemeSpec& theme) {
 
 MenuStyle MaterialMenuStyle(const ThemeSpec& theme) {
   Color separator = theme.colors.on_surface;
-  separator.alpha *= 0.12F;
+  separator.alpha *= state_layer_alpha;
   return {
       .background = theme.colors.surface_container,
       .foreground = theme.colors.on_surface,
@@ -1004,7 +1016,7 @@ IconButtonStyle DefaultIconButtonStyle(const ThemeSpec& theme) {
 
 ChipStyle DefaultChipStyle(const ThemeSpec& theme) {
   Color border = theme.colors.on_surface;
-  border.alpha *= 0.24F;
+  border.alpha *= scrim_shadow_alpha;
   Color disabled_background = theme.colors.surface;
   disabled_background.alpha *= theme.interactions.disabled_opacity;
   Color disabled_selected_background = theme.colors.primary;
@@ -1041,7 +1053,7 @@ ChipStyle DefaultChipStyle(const ThemeSpec& theme) {
 
 SegmentedButtonStyle DefaultSegmentedButtonStyle(const ThemeSpec& theme) {
   Color border = theme.colors.on_surface;
-  border.alpha *= 0.24F;
+  border.alpha *= scrim_shadow_alpha;
   return {
       .background = theme.colors.surface,
       .selected_background = theme.colors.primary,
@@ -1089,7 +1101,7 @@ TabsStyle DefaultTabsStyle(const ThemeSpec& theme) {
 
 DividerStyle DefaultDividerStyle(const ThemeSpec& theme) {
   Color color = theme.colors.on_surface;
-  color.alpha *= 0.12F;
+  color.alpha *= state_layer_alpha;
   return {
       .color = color,
       .thickness = 1.0F,
@@ -1160,7 +1172,7 @@ TextFieldStyle DefaultTextFieldStyle(const ThemeSpec& theme) {
               theme.colors.primary.red,
               theme.colors.primary.green,
               theme.colors.primary.blue,
-              0.22F,
+              selection_alpha,
           },
       .caret = theme.colors.primary,
       .error_caret = theme.colors.error,
@@ -1228,7 +1240,7 @@ SwitchStyle DefaultSwitchStyle(const ThemeSpec& theme) {
   Color track = theme.colors.on_surface;
   track.alpha *= 0.28F;
   Color disabled_track = theme.colors.on_surface;
-  disabled_track.alpha *= 0.12F;
+  disabled_track.alpha *= state_layer_alpha;
   Color disabled_thumb = theme.colors.on_surface;
   disabled_thumb.alpha *= theme.interactions.disabled_opacity;
   return {
@@ -1292,11 +1304,11 @@ ProgressBarStyle DefaultProgressBarStyle(const ThemeSpec& theme) {
 
 SliderStyle DefaultSliderStyle(const ThemeSpec& theme) {
   Color inactive_track = theme.colors.on_surface;
-  inactive_track.alpha *= 0.2F;
+  inactive_track.alpha *= slider_track_alpha;
   Color disabled_active = theme.colors.on_surface;
-  disabled_active.alpha *= 0.38F;
+  disabled_active.alpha *= disabled_content_alpha;
   Color disabled_inactive = theme.colors.on_surface;
-  disabled_inactive.alpha *= 0.12F;
+  disabled_inactive.alpha *= state_layer_alpha;
   return {
       .width = 160.0F,
       .height = 32.0F,

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -9,6 +9,7 @@
 
 #include "huxerui_builtin_resources.h"
 #include "internal.h"
+#include "numeric_constants.h"
 #include "resource_internal.h"
 #include "indication_internal.h"
 #include "text_field_internal.h"
@@ -451,7 +452,7 @@ float CubicBezierProgress(float progress, float x1, float y1, float x2, float y2
   }
   float lower = 0.0F;
   float upper = 1.0F;
-  for (int iteration = 0; iteration < 16; ++iteration) {
+  for (int iteration = 0; iteration < detail::bezier_bisection_iterations; ++iteration) {
     const float parameter = (lower + upper) * 0.5F;
     if (CubicBezierCoordinate(parameter, x1, x2) < target) {
       lower = parameter;
@@ -637,7 +638,7 @@ private:
   }
 
   void PaintRadioButton(const MountedNode& node, PaintContext& context) const {
-    constexpr float full_circle = 6.28318530717958647692F;
+    constexpr float full_circle = detail::two_pi;
     const Rect frame = detail::ResolveToggleControlBounds(static_cast<const detail::MountedNode&>(node));
     const float progress = progress_.Value();
     const bool disabled = UsesDisabledVisualState(node);
@@ -1713,8 +1714,8 @@ private:
       return;
     }
     const double interval_count = std::ceil(static_cast<double>(maximum_ - minimum_) / *step_);
-    if (!std::isfinite(interval_count) || interval_count <= 1.0 || interval_count > 512.0 ||
-        track.width / static_cast<float>(interval_count) < tick_size * 1.5F) {
+    if (!std::isfinite(interval_count) || interval_count <= 1.0 || interval_count > detail::tick_max_interval_count ||
+        track.width / static_cast<float>(interval_count) < tick_size * detail::tick_min_spacing_scale) {
       return;
     }
     const float radius = tick_size * 0.5F;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -15,6 +15,11 @@ namespace huxerui {
 
 namespace detail {
 
+// Window control glyphs and their interaction surface alphas.
+constexpr float window_close_hover_alpha = 0.9F;
+constexpr float window_control_hover_alpha = 0.08F;
+constexpr float window_control_press_alpha = 0.16F;
+
 class WindowControlsLayout final : public huxerui::Layout<WindowControlsLayout> {
 public:
   using Layout::Layout;
@@ -118,8 +123,10 @@ View WindowControl(
     context.StrokePath(std::move(path), window->caption_foreground, 1.0F);
   });
   const bool close = command == WindowCommand::Close;
-  const Color hover = close ? Color::Rgb(196, 43, 28, 0.9F) : Color::Rgb(0, 0, 0, 0.08F);
-  const Color press = close ? Color::Rgb(196, 43, 28, 0.9F) : Color::Rgb(0, 0, 0, 0.16F);
+  const Color hover =
+      close ? Color::Rgb(196, 43, 28, window_close_hover_alpha) : Color::Rgb(0, 0, 0, window_control_hover_alpha);
+  const Color press =
+      close ? Color::Rgb(196, 43, 28, window_close_hover_alpha) : Color::Rgb(0, 0, 0, window_control_press_alpha);
   View interaction_surface = Stack {}.With(
       Indication{
           .hover = IndicationLayer{.fill = hover},


### PR DESCRIPTION
## Summary

Replace scattered magic numbers across the core library with named constants:

- New `src/numeric_constants.h` centralizes shared tolerances, curve-approximation factors, root-finding iteration bounds, gesture timing defaults, and visual thresholds in `huxerui::detail`.
- File-local constants (sRGB transfer and luminance coefficients, theme alpha values, scrollbar and window-control opacities) stay next to their only use site instead of polluting the shared header.
- Public API headers (`include/huxerui/*.h`) are untouched; every replacement is value-preserving, so there is no behavior change.

Notable deduplication:
- `cubic_circle_kappa` previously defined in three files (path, scene transition, text field) is now shared.
- Text double-tap / long-press / multi-tap slop duplicated between `gesture.cpp` and `runtime_text_selection_gesture.cpp` now reference one set of constants aligned with `GestureSettings` defaults.
- `0.001F` scroll/progress epsilon, `0.000001F` geometry epsilon, and bezier root-finding bounds are consolidated.

## Test plan

- `cmake --build build --parallel` succeeds.
- `ctest --test-dir build --output-on-failure` passes all 14 tests.