### PR TITLE
feat(window): add minimum size constraints

### DIFF
--- a/docs/design/window-chrome.md
+++ b/docs/design/window-chrome.md
@@ -100,6 +100,7 @@ struct WindowMetrics {
 struct WindowOptions {
   std::string title = "HuxerUI";
   Size initial_size = {520.0F, 360.0F};
+  std::optional<Size> minimum_size;
   WindowContentMode content_mode = WindowContentMode::SafeArea;
   WindowChromeMode chrome_mode = WindowChromeMode::System;
   float title_bar_height = 40.0F;
@@ -111,6 +112,11 @@ struct AppOptions {
   // Application-wide fields...
 };
 ```
+
+`initial_size` and `minimum_size` describe the logical HuxerUI content surface in device-independent units.
+When `minimum_size` is present, both sizes must be finite and positive and the initial size must not be smaller in either dimension.
+Resizable top-level desktop adapters preserve larger platform minimums and convert the requested content minimum through their native frame and scale boundary.
+Fixed and embedded hosts, including the current mobile and Web integrations, validate the shared configuration but cannot enforce a top-level window constraint.
 
 `WindowOptions::title_bar_height` is the application's preferred logical height for Custom chrome.
 It drives both `WindowTitleBar` layout and framework caption-control geometry, so applications do not configure those heights independently.

--- a/docs/guide/platforms.md
+++ b/docs/guide/platforms.md
@@ -17,6 +17,13 @@ Each backend uses platform lifecycle, input, text, accessibility, file, network,
 Capabilities not listed as implemented are not implied by the shared API.
 OHOS does not currently have a repository-owned backend.
 
+## Window sizing
+
+`WindowOptions::initial_size` requests the initial logical content size.
+An optional `minimum_size` constrains resizable Windows, macOS, and Linux top-level windows in the same device-independent units while preserving any larger native minimum.
+Both sizes must be finite and positive, and the initial size must not be smaller than the requested minimum in either dimension.
+Mobile and Web hosts still validate these values but do not control an independently resizable top-level window, so their native shell or embedding page remains authoritative for host sizing.
+
 ## Windows
 
 The default backend targets Windows 10 or later and uses Win32, D3D11, Direct2D, DirectWrite, DXGI, and IMM32.

--- a/examples/window_chrome/main.cpp
+++ b/examples/window_chrome/main.cpp
@@ -148,6 +148,7 @@ const Application application{
         .window = {
             .title = "HuxerUI Window Chrome",
             .initial_size = {760.0F, 480.0F},
+            .minimum_size = Size{480.0F, 320.0F},
             .chrome_mode = WindowChromeMode::Custom,
             .title_bar_height = 48.0F,
         },

--- a/include/huxerui/window.h
+++ b/include/huxerui/window.h
@@ -69,6 +69,8 @@ struct WindowCaptionLabels {
 struct WindowOptions {
   std::string title = "HuxerUI";
   Size initial_size = {520.0F, 360.0F};
+  // Resizable top-level hosts enforce this logical content size; fixed or embedded hosts may not support it.
+  std::optional<Size> minimum_size;
   // Root geometry remains stable for one Runtime; pages may still override SystemBarsAppearance independently.
   WindowContentMode content_mode = WindowContentMode::SafeArea;
   // System window chrome ownership remains stable for one Runtime.

--- a/platform/linux/linux_adapter.cpp
+++ b/platform/linux/linux_adapter.cpp
@@ -503,6 +503,13 @@ private:
     gtk_window_set_decorated(window_, !custom_chrome_);
 
     drawing_area_ = GTK_DRAWING_AREA(gtk_drawing_area_new());
+    if (options.minimum_size.has_value()) {
+      gtk_widget_set_size_request(
+          GTK_WIDGET(drawing_area_),
+          std::max(1, static_cast<int>(std::ceil(options.minimum_size->width))),
+          std::max(1, static_cast<int>(std::ceil(options.minimum_size->height)))
+      );
+    }
     gtk_widget_set_focusable(GTK_WIDGET(drawing_area_), TRUE);
     gtk_drawing_area_set_draw_func(drawing_area_, Draw, this, nullptr);
     gtk_window_set_child(window_, GTK_WIDGET(drawing_area_));

--- a/platform/macos/appkit_adapter.mm
+++ b/platform/macos/appkit_adapter.mm
@@ -218,6 +218,9 @@ public:
                                                  styleMask:style
                                                    backing:NSBackingStoreBuffered
                                                      defer:NO];
+      if (options.minimum_size.has_value()) {
+        window_.contentMinSize = NSMakeSize(options.minimum_size->width, options.minimum_size->height);
+      }
       window_->huxeruiAdapter = this;
       window_.title = [NSString stringWithUTF8String:options.title.c_str()];
       window_.acceptsMouseMovedEvents = YES;

--- a/platform/windows/win32_adapter.cpp
+++ b/platform/windows/win32_adapter.cpp
@@ -608,6 +608,7 @@ private:
     const float scale = DpiScale();
     custom_chrome_ = options.chrome_mode == WindowChromeMode::Custom;
     custom_title_bar_height_ = options.title_bar_height;
+    minimum_size_ = options.minimum_size;
     RECT frame{
         0,
         0,
@@ -1064,6 +1065,27 @@ private:
       return *handled;
     }
     switch (message) {
+    case WM_GETMINMAXINFO:
+      if (minimum_size_.has_value() && l_param != 0) {
+        const LRESULT result = DefWindowProcW(window, message, w_param, l_param);
+        const float scale = DpiScale();
+        RECT minimum_frame{
+            0,
+            0,
+            std::max(1L, static_cast<LONG>(std::ceil(minimum_size_->width * scale))),
+            std::max(1L, static_cast<LONG>(std::ceil(minimum_size_->height * scale))),
+        };
+        if (!custom_chrome_ &&
+            !win32_api_.AdjustWindowRectForDpi(
+                &minimum_frame, WS_OVERLAPPEDWINDOW, FALSE, 0, static_cast<UINT>(std::max(dpi_, 1.0F))
+            )) {
+          throw std::runtime_error("HuxerUI could not calculate the Windows minimum window size");
+        }
+        auto* constraints = reinterpret_cast<MINMAXINFO*>(l_param);
+        constraints->ptMinTrackSize = ResolveWin32MinimumTrackSize(constraints->ptMinTrackSize, minimum_frame);
+        return result;
+      }
+      break;
     case WM_NCHITTEST:
       if (custom_chrome_) {
         if (const std::optional<LRESULT> caption_control = CaptionControlHitTest(l_param)) {
@@ -1358,6 +1380,7 @@ private:
   Win32Accessibility accessibility_;
   Win32TextInput text_input_;
   std::exception_ptr failure_;
+  std::optional<Size> minimum_size_;
   std::optional<double> timer_deadline_;
   const RenderFrame* committed_frame_ = nullptr;
   Win32UIThreadDispatcher& ui_dispatcher_;

--- a/platform/windows/win32_internal.h
+++ b/platform/windows/win32_internal.h
@@ -109,6 +109,13 @@ inline RECT InsetWin32MaximizedClientRect(RECT proposed_window, LONG horizontal_
   return proposed_window;
 }
 
+inline POINT ResolveWin32MinimumTrackSize(POINT platform_minimum, const RECT& requested_frame) noexcept {
+  return {
+      std::max(platform_minimum.x, std::max(0L, requested_frame.right - requested_frame.left)),
+      std::max(platform_minimum.y, std::max(0L, requested_frame.bottom - requested_frame.top)),
+  };
+}
+
 inline float ResolveWin32CaptionButtonWidth(float system_width) noexcept {
   constexpr float modern_caption_button_width = 46.0F;
   return std::max(modern_caption_button_width, system_width);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -1046,6 +1046,17 @@ Runtime::Runtime(const Application& application, PlatformAdapter& platform, Appl
       !std::isfinite(window_options.initial_size.height) || window_options.initial_size.height <= 0.0F) {
     throw std::invalid_argument("HuxerUI initial window size must be finite and positive");
   }
+  if (window_options.minimum_size.has_value()) {
+    const Size minimum_size = *window_options.minimum_size;
+    if (!std::isfinite(minimum_size.width) || minimum_size.width <= 0.0F ||
+        !std::isfinite(minimum_size.height) || minimum_size.height <= 0.0F) {
+      throw std::invalid_argument("HuxerUI minimum window size must be finite and positive");
+    }
+    if (window_options.initial_size.width < minimum_size.width ||
+        window_options.initial_size.height < minimum_size.height) {
+      throw std::invalid_argument("HuxerUI initial window size must not be smaller than the minimum window size");
+    }
+  }
   if (window_options.content_mode != WindowContentMode::SafeArea &&
       window_options.content_mode != WindowContentMode::EdgeToEdge) {
     throw std::invalid_argument("HuxerUI window content mode is invalid");

--- a/tests/platform/windows_window_chrome.cpp
+++ b/tests/platform/windows_window_chrome.cpp
@@ -13,6 +13,12 @@ TEST_CASE("Win32MaximizedClientRectStaysInsideTheWorkArea") {
   REQUIRE(client.bottom == 1040);
 }
 
+TEST_CASE("Win32MinimumTrackSizePreservesLargerPlatformLimits") {
+  const POINT minimum = detail::ResolveWin32MinimumTrackSize(POINT{400, 300}, RECT{-8, -31, 328, 511});
+  REQUIRE(minimum.x == 400);
+  REQUIRE(minimum.y == 542);
+}
+
 TEST_CASE("Win32CaptionButtonsUseTheModernMinimumWidth") {
   REQUIRE(detail::ResolveWin32CaptionButtonWidth(36.0F) == 46.0F);
   REQUIRE(detail::ResolveWin32CaptionButtonWidth(52.0F) == 52.0F);

--- a/tests/runtime/window.cpp
+++ b/tests/runtime/window.cpp
@@ -277,6 +277,15 @@ TEST_CASE("WindowMetricsRejectInvalidValues") {
   REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
   invalid_options.window.initial_size = {520.0F, std::numeric_limits<float>::infinity()};
   REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
+  invalid_options.window.initial_size = {520.0F, 360.0F};
+  invalid_options.window.minimum_size = Size{0.0F, 240.0F};
+  REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
+  invalid_options.window.minimum_size = Size{320.0F, std::numeric_limits<float>::infinity()};
+  REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
+  invalid_options.window.minimum_size = Size{521.0F, 360.0F};
+  REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
+  invalid_options.window.minimum_size = Size{520.0F, 361.0F};
+  REQUIRE_THROWS_AS(Runtime(WindowContentApp, platform, invalid_options), std::invalid_argument);
   TestPlatform invalid_appearance_platform;
   Runtime invalid_appearance{
       +[]() -> View {
@@ -288,6 +297,14 @@ TEST_CASE("WindowMetricsRejectInvalidValues") {
   };
   invalid_appearance.SetWindowMetrics({.viewport = {100.0F, 100.0F}});
   REQUIRE_THROWS_AS(invalid_appearance.BuildFrame(), std::invalid_argument);
+}
+
+TEST_CASE("WindowOptionsAcceptAValidMinimumSize") {
+  TestPlatform platform;
+  AppOptions options;
+  options.show_debug_overlay = false;
+  options.window.minimum_size = Size{320.0F, 240.0F};
+  REQUIRE_NOTHROW(Runtime(WindowContentApp, platform, options));
 }
 
 TEST_CASE("WindowHandleForwardsCommandsToThePlatform") {


### PR DESCRIPTION
## Summary

- Add an optional `WindowOptions::minimum_size` for constraining resizable top-level windows.
- Define the minimum in the same logical device-independent content units as `initial_size`.
- Validate the shared configuration before creating a native window.
- Enforce the constraint in the Win32, AppKit, and current GTK desktop adapters.
- Document the behavior of fixed and embedded mobile and Web hosts.
- Extend the window-chrome example and focused tests.

Closes #68

## Public API

Applications can request a minimum logical content size alongside the initial size:

```cpp
const Application application{
    App,
    {
        .window = {
            .title = "HuxerUI Window Chrome",
            .initial_size = {760.0F, 480.0F},
            .minimum_size = Size{480.0F, 320.0F},
        },
    }
};
```

Leaving `minimum_size` unset preserves the existing platform-default resizing behavior.

When it is set:

- Width and height must both be finite and positive.
- `initial_size` must not be smaller than `minimum_size` in either dimension.
- Invalid configuration throws `std::invalid_argument` before a platform window is created.
- A larger native platform minimum remains authoritative.

## Platform behavior

### Windows

The Win32 adapter handles `WM_GETMINMAXINFO`, converts the logical content minimum with the current window DPI, and adjusts system-chrome windows through the existing DPI-aware frame calculation. The resolved track size preserves any larger minimum supplied by User32.

Custom-chrome windows use their client-owned frame geometry directly, consistent with their existing initial-size path.

### macOS

The AppKit adapter assigns the logical minimum through `NSWindow::contentMinSize`, keeping the contract expressed in content coordinates for both system and custom chrome.

### Linux

The GTK adapter applies the minimum request to the drawing-area content widget. Fractional logical values round upward so the native integer request cannot undershoot the public minimum.

### Mobile and Web

Android, iOS, and Web still receive shared validation, but their native shell or embedding page owns the top-level surface size. They do not claim to enforce a resizable application-window minimum.

## Tests and validation

Passed on the current Linux host:

- `cmake --build build --target huxerui_tests huxerui_header_checks example_window_chrome -j4`
- `build/bin/huxerui_tests "Window*"` — 12 test cases and 70 assertions passed.
- `ctest --test-dir build -R '^HuxerUITests$' --output-on-failure`
- `ctest --test-dir build -R '^HuxerUICodegenRuntimeTests$' --output-on-failure`
- `cmake --build build -j4`
- `git diff --check`
- Manual Linux GTK window-resize validation, including the configured minimum size.

The first full common-test run encountered a GLib crash in the unrelated Linux HTTP cancellation/completion race test. That test passed independently with 40 assertions, and the complete common suite passed on the immediate rerun.

## Validation not performed

- Windows build and Win32 runtime validation were not performed.
- macOS build and AppKit runtime validation were not performed.

