### PR TITLE
feat(text): inherit locale for default shaping

### DIFF
--- a/docs/design/resources.md
+++ b/docs/design/resources.md
@@ -292,13 +292,14 @@ In particular, the Web entry integration loads the resource index and payload be
 Remote URLs remain application or library inputs and do not become package paths.
 
 When system locale or display scale changes, the platform integration calls `Runtime::UpdateResourceConfiguration()` with the new value.
-Runtime ignores an equal value; otherwise it updates AppResources and the inherited Locale, invalidates root composition, and requests a frame.
+Runtime ignores an equal value; otherwise it updates AppResources and the inherited Locale, notifies their recorded dependency readers, and requests a frame.
 `BuildFrame()` does not poll platform state.
-Resource configuration changes invalidate root composition, then normal reconciliation limits changed ImageAsset geometry and paint work to the affected nodes.
-Dependency-recorded resource reads and inherited Locale text shaping may later narrow the initial root invalidation without changing the public API.
+Normal reconciliation limits changed resource values, text layout, and paint work to affected scopes and nodes.
 
 An explicit Locale Environment value overrides the system locale for its subtree.
 Display scale remains a platform property.
+Mounted Text, built-in labels, TextField, and Canvas text use that effective Locale whenever their shaping locale is empty.
+Explicit non-empty shaping locales do not consult the Locale Environment, but localized StringVariant and ImageVariant resolution continues to use it independently.
 
 ## Resource variants
 
@@ -859,7 +860,7 @@ Resource reads participate in the existing dependency and invalidation model:
 - UseString, UseImage, and UseVectorImage resolve explicitly from the Runtime-owned service during composition without allocating state slots.
 - Text, controls, TextField, semantics, presentation values, VisualFill, and Image retain StringVariant or ImageVariant inputs until mounted reconciliation.
 - An Image constructed from ImageResource resolves that key to an immutable raster or vector asset before layout and paint.
-- ResourceConfiguration changes currently invalidate the root composition so locale and density variants are selected consistently.
+- Locale and display-scale readers subscribe only the composition scopes that resolve inherited shaping or resource variants from those values.
 - A visible selection overlay is repainted and remeasured when ResourceConfiguration changes because it is Runtime-owned rather than part of the application composition tree.
 - Reconciliation limits a changed image asset or intrinsic size to the affected node's measure, layout, and paint paths.
 - An unchanged image asset compares equal and preserves its recorded PaintSequence.
@@ -894,7 +895,6 @@ Resource compilation diagnostics are English and use the `hrc:` CLI prefix.
 ## Future work
 
 - Add localized image variants without introducing a second resource-selection mechanism.
-- Define inherited locale-aware shaping for ordinary text independently from localized string lookup.
 - Add explicit preload policy only for resources whose asynchronous platform preparation requires it.
 
 ## Validation

--- a/docs/design/text-input.md
+++ b/docs/design/text-input.md
@@ -750,7 +750,9 @@ Secure TextField creates grapheme boundaries from the platform text layout, then
 
 Editable `detail::TextLayout` remains internal to HuxerUI. Public Canvas and TextMeasurer expose immutable paragraph and run metrics plus paint commands, while hit testing, caret geometry, and range geometry remain owned by TextField and native editable layouts.
 
-The TextField caches layout by text, font, available width, multiline configuration, and relevant style values.
+The TextField caches layout by text, font, available width, multiline configuration, resolved shaping options, and relevant style values.
+An empty shaping locale resolves from the mounted TextField's effective inherited Locale, while `TextField::Shaping()` preserves a non-empty explicit locale.
+The resolved shaping value is shared by the controlled value, label, placeholder, validation message, grapheme boundaries, selection and caret geometry, measurement, and every DrawText command so platform layout and renderer replay cannot diverge.
 
 Editor components can use TextMeasurer for exact-run metrics while retaining their own line, selection, and document models. They do not reuse TextField's internal editable layout.
 

--- a/docs/design/text.md
+++ b/docs/design/text.md
@@ -1,7 +1,7 @@
 # Text and Font Design
 
 This document defines the shared text values, measurement boundary, paint commands, and platform resource ownership used by Text, TextField, Canvas, and text-oriented component libraries.
-Localized string resolution and the root Locale Environment are defined in [App Resources, Images, and Localization Design](resources.md); applying the inherited Locale automatically to otherwise-unspecified text shaping remains deferred.
+Localized string resolution and the root Locale Environment are defined in [App Resources, Images, and Localization Design](resources.md).
 
 ## Ownership
 
@@ -57,6 +57,16 @@ When the paragraph is taller than the rectangle, the remaining height is clamped
 
 `TextDirection::Auto` resolves from the first strong directional character and falls back to left-to-right when the text contains no strong character.
 Measurement and drawing use the same resolution rule on every platform.
+
+Mounted Text, built-in control labels, TextField, and Canvas text use the effective inherited `Locale` when their `TextShapingOptions::locale` is empty.
+`Text(...).Shaping(options)` and `TextField(...).Shaping(options)` provide complete component-local shaping overrides; a non-empty shaping locale wins without subscribing that declaration to the inherited Locale for shaping.
+TextField applies one resolved shaping value to its controlled value, label, placeholder, validation message, selection and caret geometry, secure grapheme processing, measurement, and retained drawing.
+The PaintContext passed to a Canvas fills an empty locale for `DrawText`, `DrawTextRun`, and each `DrawTextRuns` entry from that Canvas node while preserving every explicit run locale.
+An independently constructed PaintContext has no inherited Environment and therefore leaves empty shaping locales unchanged.
+
+Localized resource selection and text shaping remain separate concerns.
+An explicit shaping locale does not change which StringResource or ImageResource variant a declaration resolves, and a resource Locale change can still update resource-backed content whose shaping locale is explicit.
+TextMeasurer remains stateless and explicit: custom composition code reads `Locale` with `UseEnvironment<Locale>()` and passes its language tag when it wants inherited shaping.
 
 ## Measurement
 

--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -9,6 +9,16 @@ Use application state for authoritative values and let mounted behavior retain t
 Use `TextRole` for theme typography or provide an explicit `TextStyle`.
 Use `Align(TextAlign::...)` for horizontal paragraph alignment and `VerticalAlign(TextVerticalAlign::...)` when a framed Text should place its paragraph within extra height.
 Vertical alignment does not change intrinsic text measurement.
+Text, built-in labels, and TextField use the inherited `Locale` for shaping when no locale is supplied.
+Use `Shaping(TextShapingOptions{...})` on Text or TextField for a local direction or locale override without changing localized resource lookup:
+
+```cpp
+return Text("مرحبا")
+    .Shaping({.direction = TextDirection::RightToLeft, .locale = "ar"});
+```
+
+Canvas `DrawText`, `DrawTextRun`, and `DrawTextRuns` calls inherit the Canvas node Locale only for entries whose shaping locale is empty.
+TextMeasurer has no implicit Environment lookup; pass a locale explicitly when custom composition measurement needs it.
 
 `ImageVariant` covers `ImageResource`, `ImageAsset`, and `VectorAsset`.
 `Image` also accepts `std::shared_ptr<ExternalTexture>` through a separate overload because a live platform texture is not an application image value.

--- a/include/huxerui/paint.h
+++ b/include/huxerui/paint.h
@@ -21,10 +21,12 @@
 namespace huxerui {
 
 class PaintContext;
+struct RenderNode;
 
 namespace detail {
 struct FrozenScene;
 struct PlatformViewPaintAccess;
+void PaintNodeWithinClip(huxerui::MountedNode& node, const Rect& clip, const RenderNode* extra_child);
 } // namespace detail
 
 /// Selects how intrinsic image geometry maps into a destination rectangle.
@@ -654,6 +656,8 @@ public:
   void Finish();
 
 private:
+  PaintContext(PaintSequence& sequence, Rect bounds, std::string default_shaping_locale);
+
   enum class StackEntry {
     Clip,
     Transform,
@@ -665,6 +669,7 @@ private:
 
   PaintSequence& sequence_;
   Rect bounds_;
+  std::string default_shaping_locale_;
   Transform2D transform_;
   std::optional<Rect> clip_;
   std::vector<Transform2D> transform_stack_;
@@ -672,6 +677,7 @@ private:
   std::vector<StackEntry> command_stack_;
   bool finished_ = false;
 
+  friend void detail::PaintNodeWithinClip(huxerui::MountedNode&, const Rect&, const RenderNode*);
   friend struct detail::PlatformViewPaintAccess;
 };
 

--- a/include/huxerui/view.h
+++ b/include/huxerui/view.h
@@ -184,6 +184,7 @@ protected:
   void AddModifier(detail::ModifierSpec modifier);
   void SetModifier(detail::ModifierSpec modifier);
   void SetTextStyle(TextStyle style);
+  void SetTextShaping(TextShapingOptions shaping);
   void SetTextAlign(TextAlign align);
   void SetTextVerticalAlign(TextVerticalAlign align);
   void SetImageFit(ImageFit fit);
@@ -681,6 +682,8 @@ public:
 
   /// Replaces the resolved typography for this Text declaration.
   Text Style(TextStyle style) &&;
+  /// Configures text direction and an optional locale override for this Text declaration.
+  Text Shaping(TextShapingOptions shaping) &&;
   /// Sets horizontal paragraph alignment inside the measured text bounds.
   Text Align(TextAlign align) &&;
   /// Sets vertical paragraph alignment when the Text receives extra height.
@@ -1017,6 +1020,8 @@ public:
   TextField Variant(TextFieldVariant value) &&;
   /// Configures single-line behavior or intrinsic multiline height limits.
   TextField LineLimits(TextFieldLineLimits value) &&;
+  /// Configures text direction and an optional locale override for editable text and supporting labels.
+  TextField Shaping(TextShapingOptions value) &&;
   /// Sets horizontal paragraph alignment inside the editor viewport.
   TextField Align(TextAlign value) &&;
   /// Sets vertical paragraph alignment inside the editor viewport.
@@ -1051,6 +1056,7 @@ private:
   std::optional<TextFieldVariant> variant_;
   TextInputConfiguration configuration_;
   TextFieldLineLimits line_limits_ = TextFieldLineLimits::SingleLine();
+  TextShapingOptions text_shaping_;
   TextAlign text_align_ = TextAlign::Leading;
   std::optional<TextVerticalAlign> text_vertical_align_;
   std::optional<std::size_t> max_length_;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -365,8 +365,7 @@ Size MeasureVirtualItem(void* state, huxerui::MountedNode& item, Constraints con
 Size MeasureLabelContent(
     MountedNode& node,
     PlatformAdapter& platform,
-    const Constraints& constraints,
-    TextLayoutOptions text_options
+    const Constraints& constraints
 ) {
   const LabelContentMetrics metrics = node.LayoutValueOr<LabelContentMetrics>({});
   const Size icon_size{
@@ -380,7 +379,9 @@ Size MeasureLabelContent(
                                        : std::numeric_limits<float>::infinity();
   TextLayoutMetrics text;
   if (show_label) {
-    text = platform.MeasureText(node.text, node.properties.text_style, maximum_text_width, text_options);
+    text = platform.MeasureText(
+        node.text, node.properties.text_style, maximum_text_width, node.properties.text_layout_options
+    );
   }
   node.layout_cache.insert_or_assign(typeid(LabelLayoutCache), LabelLayoutCache{text});
   return {
@@ -531,8 +532,7 @@ Size MeasureNode(
       content_size = MeasureLabelContent(
           node,
           platform,
-          content_constraints,
-          TextLayoutOptions{.wrap = TextWrap::NoWrap}
+          content_constraints
       );
     } else {
       content_size = platform
@@ -551,7 +551,7 @@ Size MeasureNode(
                            node.text,
                            node.properties.text_style,
                            std::numeric_limits<float>::infinity(),
-                           TextLayoutOptions{.wrap = TextWrap::NoWrap}
+                           node.properties.text_layout_options
                        )
                        .size;
     break;
@@ -559,8 +559,7 @@ Size MeasureNode(
     content_size = MeasureLabelContent(
         node,
         platform,
-        content_constraints,
-        TextLayoutOptions{.wrap = TextWrap::NoWrap}
+        content_constraints
     );
     break;
   case NodeKind::Chip:
@@ -568,8 +567,7 @@ Size MeasureNode(
       content_size = MeasureLabelContent(
           node,
           platform,
-          content_constraints,
-          TextLayoutOptions{.wrap = TextWrap::NoWrap}
+          content_constraints
       );
     } else {
       content_size = platform
@@ -577,7 +575,7 @@ Size MeasureNode(
                              node.text,
                              node.properties.text_style,
                              std::numeric_limits<float>::infinity(),
-                             TextLayoutOptions{.wrap = TextWrap::NoWrap}
+                             node.properties.text_layout_options
                          )
                          .size;
     }

--- a/src/paint.cpp
+++ b/src/paint.cpp
@@ -164,6 +164,12 @@ void RequireGradientStops(const std::vector<GradientStop>& stops) {
 bool BrushUsesBounds(const Brush& brush) noexcept {
   return !std::holds_alternative<Color>(brush.Get());
 }
+
+void ApplyDefaultShapingLocale(TextShapingOptions& shaping, const std::string& default_locale) {
+  if (shaping.locale.empty()) {
+    shaping.locale = default_locale;
+  }
+}
 } // namespace
 
 void detail::ValidateColor(Color color, const char* message) {
@@ -256,7 +262,10 @@ Transform2D detail::ResolveGradientTransform(Rect rect, const RadialGradient& gr
   return ComposeTransform(destination, ComposeTransform(gradient.transform, ellipse));
 }
 
-PaintContext::PaintContext(PaintSequence& sequence, Rect bounds) : sequence_(sequence), bounds_(bounds) {
+PaintContext::PaintContext(PaintSequence& sequence, Rect bounds) : PaintContext(sequence, bounds, {}) {}
+
+PaintContext::PaintContext(PaintSequence& sequence, Rect bounds, std::string default_shaping_locale)
+    : sequence_(sequence), bounds_(bounds), default_shaping_locale_(std::move(default_shaping_locale)) {
   RequireRect(bounds);
   sequence_.commands_.clear();
   sequence_.bounds_ = {};
@@ -286,6 +295,7 @@ void PaintContext::DrawText(
   if (!IsFinite(paragraph_offset)) {
     throw std::invalid_argument("HuxerUI text paragraph offset must be finite");
   }
+  ApplyDefaultShapingLocale(options.shaping, default_shaping_locale_);
   sequence_.commands_.emplace_back(
       DrawTextCommand{rect, std::move(text), std::move(style), std::move(options), paragraph_offset}
   );
@@ -305,6 +315,7 @@ void PaintContext::DrawTextRun(
   if (text.empty() || bounds.IsEmpty()) {
     return;
   }
+  ApplyDefaultShapingLocale(shaping, default_shaping_locale_);
   TextRun run{bounds, baseline_origin, std::move(text), std::move(style), std::move(shaping)};
   if (!sequence_.commands_.empty()) {
     if (auto* command = std::get_if<DrawTextRunsCommand>(&sequence_.commands_.back())) {
@@ -329,6 +340,9 @@ void PaintContext::DrawTextRuns(std::vector<TextRun> runs) {
     }
     RequireTextStyle(run.style);
     RequireTextRun(run.text);
+  }
+  for (TextRun& run : runs) {
+    ApplyDefaultShapingLocale(run.shaping, default_shaping_locale_);
   }
   std::erase_if(runs, [](const TextRun& run) { return run.text.empty() || run.bounds.IsEmpty(); });
   if (runs.empty()) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -169,15 +169,11 @@ void PaintLabelContent(
   if (!show_label || text_width <= 0.0F) {
     return;
   }
-  TextLayoutOptions options = node.properties.text_layout_options;
-  options.align = TextAlign::Leading;
-  options.vertical_align = TextVerticalAlign::Center;
-  options.wrap = TextWrap::NoWrap;
   context.DrawText(
       {leading + icon_width + spacing, content.y, text_width, content.height},
       node.text,
       text_style,
-      options
+      node.properties.text_layout_options
   );
 }
 
@@ -601,7 +597,10 @@ void HideRenderTree(MountedNode& node) {
   node.render_structure_dirty = false;
 }
 
-void PaintNodeWithinClip(MountedNode& node, const Rect& clip, const RenderNode* extra_child = nullptr) {
+} // namespace
+
+void PaintNodeWithinClip(huxerui::MountedNode& mounted_node, const Rect& clip, const RenderNode* extra_child) {
+  auto& node = static_cast<detail::MountedNode&>(mounted_node);
   RenderNode& render_node = node.render_node;
   const Transform2D& local_transform = node.presentation.local_transform;
   const Transform2D children_transform = ResolveChildrenTransform(node);
@@ -625,7 +624,10 @@ void PaintNodeWithinClip(MountedNode& node, const Rect& clip, const RenderNode* 
                                          std::max(0.0F, bounds.height - node.resolved_padding.Vertical()),
                                      }
                                    : bounds;
-    PaintContext content{render_node.content, canvas_bounds};
+    PaintContext content =
+        node.kind == NodeKind::Canvas
+            ? PaintContext(render_node.content, canvas_bounds, node.properties.text_layout_options.shaping.locale)
+            : PaintContext{render_node.content, canvas_bounds};
     std::optional<VisualFill> background = node.properties.background;
     TextStyle text_style = node.properties.text_style;
     if (node.applies_disabled_appearance) {
@@ -667,12 +669,7 @@ void PaintNodeWithinClip(MountedNode& node, const Rect& clip, const RenderNode* 
           bounds,
           node.text,
           text_style,
-          TextLayoutOptions{
-              .shaping = {},
-              .align = TextAlign::Center,
-              .vertical_align = TextVerticalAlign::Center,
-              .wrap = TextWrap::NoWrap,
-          }
+          node.properties.text_layout_options
       );
     } else if ((node.kind == NodeKind::Checkbox || node.kind == NodeKind::RadioButton ||
                 node.kind == NodeKind::Switch) &&
@@ -721,7 +718,7 @@ void PaintNodeWithinClip(MountedNode& node, const Rect& clip, const RenderNode* 
   children.reserve(node.children.size());
   for (const auto& child : node.children) {
     if (child->participates_in_layout) {
-      PaintNodeWithinClip(*child, child_clip);
+      PaintNodeWithinClip(*child, child_clip, nullptr);
     } else {
       HideRenderTree(*child);
     }
@@ -771,8 +768,6 @@ void PaintNodeWithinClip(MountedNode& node, const Rect& clip, const RenderNode* 
   }
   node.render_structure_dirty = false;
 }
-
-} // namespace
 
 void PaintVisualFill(PaintContext& context, Rect bounds, const VisualFill& fill, CornerRadii corner_radii,
                      float opacity) {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -2717,6 +2717,8 @@ void Runtime::EnsureRootStructure() {
                        );
                      }
                    }).LayoutValue<WindowBackplaneValue>(true);
+  // The backplane records only system-bar rectangles and must not subscribe the application root to text Locale.
+  backplane.SetTextShaping({.locale = "und"});
   View application = ApplicationContentLayout{};
   if (state_->window_->content_mode == WindowContentMode::SafeArea) {
     application = std::move(application).With(SafeAreaPadding{});

--- a/src/text_field.cpp
+++ b/src/text_field.cpp
@@ -449,6 +449,8 @@ public:
         initialized_ && (configuration_.multiline != modifier.configuration.multiline ||
                          configuration_.secure != modifier.configuration.secure);
     const bool text_layout_options_changed = initialized_ && text_layout_options_ != modifier.text_layout_options;
+    const bool text_shaping_changed =
+        initialized_ && text_layout_options_.shaping != modifier.text_layout_options.shaping;
     const bool paragraph_layout_options_changed =
         initialized_ && !ParagraphLayoutOptionsEqual(text_layout_options_, modifier.text_layout_options);
     const bool authoritative_value_changed = initialized_ && modifier.value != authoritative_value_;
@@ -476,7 +478,8 @@ public:
     const TextFieldVariantStyle next_variant_style = detail::ResolveTextFieldVariantStyle(next_style, next_variant);
     next_style.text_style = node.properties.text_style;
     corner_radii_ = node.properties.corner_radii;
-    if (!initialized_ || text_layout_mode_changed || next_style.show_label != style_.show_label ||
+    if (!initialized_ || text_layout_mode_changed || text_shaping_changed ||
+        next_style.show_label != style_.show_label ||
         next_style.text_style.font != style_.text_style.font ||
         next_style.label_style.font != style_.label_style.font ||
         next_style.floating_label_style.font != style_.floating_label_style.font ||
@@ -747,7 +750,8 @@ public:
               size.height,
           },
           validation_.message,
-          std::move(validation_style)
+          std::move(validation_style),
+          TextLayoutOptions{.shaping = text_layout_options_.shaping, .wrap = TextWrap::Word}
       );
       context.PopClip();
     }
@@ -813,7 +817,12 @@ public:
           ResolveLabelColor(node, invalid, true),
           label_progress
       );
-      context.DrawText(AnimatedLabelBounds(node, label_progress), label_, std::move(animated_label_style));
+      context.DrawText(
+          AnimatedLabelBounds(node, label_progress),
+          label_,
+          std::move(animated_label_style),
+          TextLayoutOptions{.shaping = text_layout_options_.shaping, .wrap = TextWrap::NoWrap}
+      );
     }
   }
 
@@ -1348,7 +1357,7 @@ private:
       laid_out_label_.clear();
     } else if (!label_layout_ || !floating_label_layout_ || laid_out_label_ != label_) {
       const TextLayoutOptions label_options{
-          .shaping = {},
+          .shaping = text_layout_options_.shaping,
           .wrap = TextWrap::NoWrap,
       };
       label_layout_ = platform.CreateTextLayout(label_, style_.label_style, text_layout_width_, label_options);
@@ -1378,7 +1387,7 @@ private:
           validation_.message,
           style_.validation_text_style,
           validation_text_layout_width_,
-          TextLayoutOptions{.wrap = TextWrap::Word}
+          TextLayoutOptions{.shaping = text_layout_options_.shaping, .wrap = TextWrap::Word}
       );
       laid_out_validation_message_ = validation_.message;
       if (!validation_layout_) {
@@ -1692,7 +1701,7 @@ private:
         text,
         style_.text_style,
         std::numeric_limits<float>::infinity(),
-        TextLayoutOptions{.wrap = TextWrap::NoWrap}
+        TextLayoutOptions{.shaping = text_layout_options_.shaping, .wrap = TextWrap::NoWrap}
     );
     if (!layout) {
       throw std::logic_error("HuxerUI platform does not provide editable text layout");
@@ -2193,7 +2202,7 @@ private:
                     line,
                     style,
                     std::numeric_limits<float>::infinity(),
-                    TextLayoutOptions{.wrap = TextWrap::NoWrap}
+                    TextLayoutOptions{.shaping = text_layout_options_.shaping, .wrap = TextWrap::NoWrap}
                 )
                 .size.width
         );
@@ -2476,6 +2485,9 @@ TextFieldModifier CompileTextFieldModifier(
   };
   compiled.leading_icon = compile_icon(declaration.leading_icon);
   compiled.trailing_icon = compile_icon(declaration.trailing_icon);
+  if (compiled.text_layout_options.shaping.locale.empty()) {
+    compiled.text_layout_options.shaping.locale = resource_locale().LanguageTag();
+  }
   return compiled;
 }
 
@@ -2589,6 +2601,12 @@ TextField TextField::LineLimits(TextFieldLineLimits value) && {
   return std::move(*this);
 }
 
+TextField TextField::Shaping(TextShapingOptions value) && {
+  text_shaping_ = std::move(value);
+  UpdateModifier();
+  return std::move(*this);
+}
+
 TextField TextField::Align(TextAlign value) && {
   text_align_ = value;
   UpdateModifier();
@@ -2632,7 +2650,7 @@ TextField TextField::InputConfiguration(TextInputConfiguration configuration) &&
 
 void TextField::UpdateModifier() {
   const TextLayoutOptions text_layout_options{
-      .shaping = {},
+      .shaping = text_shaping_,
       .align = text_align_,
       .vertical_align = text_vertical_align_.value_or(
           line_limits_.IsMultiline() ? TextVerticalAlign::Top : TextVerticalAlign::Center

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -891,7 +891,7 @@ private:
     spec->properties.frame.min_height = std::max(0.0F, style.minimum_height);
     spec->properties.text_layout_options = {
         .shaping = {},
-        .align = TextAlign::Center,
+        .align = TextAlign::Leading,
         .vertical_align = TextVerticalAlign::Center,
         .wrap = TextWrap::NoWrap,
     };
@@ -1908,7 +1908,7 @@ private:
     spec->properties.frame.min_height = std::max(0.0F, style.minimum_height);
     spec->properties.text_layout_options = {
         .shaping = {},
-        .align = TextAlign::Center,
+        .align = TextAlign::Leading,
         .vertical_align = TextVerticalAlign::Center,
         .wrap = TextWrap::NoWrap,
     };
@@ -1994,6 +1994,9 @@ void ApplyButtonDefaults(detail::ViewSpec& spec, const std::shared_ptr<const Env
   spec.properties.background = style.background;
   spec.properties.disabled_background = style.disabled_background;
   spec.properties.text_style = style.label_style;
+  spec.properties.text_layout_options.align = TextAlign::Center;
+  spec.properties.text_layout_options.vertical_align = TextVerticalAlign::Center;
+  spec.properties.text_layout_options.wrap = TextWrap::NoWrap;
   spec.properties.disabled_foreground = style.disabled_label;
   spec.properties.corner_radii = style.corner_radius;
   spec.properties.frame.min_width = std::max(0.0F, style.minimum_width);
@@ -2012,6 +2015,9 @@ void ApplyIconButtonDefaults(detail::ViewSpec& spec, const std::shared_ptr<const
   const float state_layer_size = std::min(std::max(0.0F, style.state_layer_size), interactive_size);
   const float corner_radius = std::max(0.0F, style.corner_radius);
   spec.properties.text_style = TextStyle{Font::System(theme.typography.label_large), style.foreground};
+  spec.properties.text_layout_options.align = TextAlign::Leading;
+  spec.properties.text_layout_options.vertical_align = TextVerticalAlign::Center;
+  spec.properties.text_layout_options.wrap = TextWrap::NoWrap;
   spec.properties.disabled_foreground = style.disabled_foreground;
   spec.layout_values.insert_or_assign(
       typeid(detail::LabelContentMetrics),
@@ -2050,6 +2056,10 @@ void ApplyChipDefaults(detail::ViewSpec& spec, const std::shared_ptr<const Envir
   };
   spec.properties.text_style = style.label_style;
   spec.properties.text_style.foreground = selected ? style.selected_label : style.label_style.foreground;
+  spec.properties.text_layout_options.align =
+      spec.image_properties.HasValue() ? TextAlign::Leading : TextAlign::Center;
+  spec.properties.text_layout_options.vertical_align = TextVerticalAlign::Center;
+  spec.properties.text_layout_options.wrap = TextWrap::NoWrap;
   spec.properties.disabled_foreground = selected ? style.disabled_selected_label : style.disabled_label;
   if (spec.image_properties.HasValue()) {
     spec.layout_values.insert_or_assign(
@@ -3444,6 +3454,26 @@ const detail::ModifierDescriptor& Grow::Descriptor() {
 }
 
 namespace detail {
+namespace {
+
+bool NeedsDefaultShapingLocale(const ViewSpec& spec) {
+  if (spec.kind == NodeKind::Canvas) {
+    return true;
+  }
+  switch (spec.kind) {
+  case NodeKind::Text:
+  case NodeKind::Button:
+  case NodeKind::Chip:
+  case NodeKind::Checkbox:
+  case NodeKind::RadioButton:
+  case NodeKind::Switch:
+    return !StringLiteral(spec.text).empty();
+  default:
+    return false;
+  }
+}
+
+} // namespace
 
 ViewSpec CompileViewSpec(
     const ViewSpec& declaration,
@@ -3521,6 +3551,10 @@ ViewSpec CompileViewSpec(
   }
   if (compiled.properties.disabled_background.has_value()) {
     compiled.properties.disabled_background = compile_fill(*compiled.properties.disabled_background);
+  }
+  TextShapingOptions& shaping = compiled.properties.text_layout_options.shaping;
+  if (shaping.locale.empty() && NeedsDefaultShapingLocale(compiled)) {
+    shaping.locale = resource_locale().LanguageTag();
   }
 
   return compiled;
@@ -3674,6 +3708,11 @@ void View::SetTextStyle(TextStyle style) {
   AddModifier(detail::MakeModifierSpec(TextStyleProperty{std::move(style)}));
 }
 
+void View::SetTextShaping(TextShapingOptions shaping) {
+  EnsureUniqueSpec();
+  spec_->properties.text_layout_options.shaping = std::move(shaping);
+}
+
 void View::SetTextAlign(TextAlign align) {
   EnsureUniqueSpec();
   spec_->properties.text_layout_options.align = align;
@@ -3769,6 +3808,11 @@ Text::Text(StringVariant value, TextRole role) : View(MakeTextSpec(std::move(val
 
 Text Text::Style(TextStyle style) && {
   SetTextStyle(std::move(style));
+  return std::move(*this);
+}
+
+Text Text::Shaping(TextShapingOptions shaping) && {
+  SetTextShaping(std::move(shaping));
   return std::move(*this);
 }
 

--- a/tests/runtime/composition.cpp
+++ b/tests/runtime/composition.cpp
@@ -174,7 +174,7 @@ int locale_environment_compositions = 0;
 
 View ViewportEnvironmentContent() {
   ++viewport_environment_compositions;
-  return Text(std::to_string(static_cast<int>(UseViewportClass())));
+  return Text(std::to_string(static_cast<int>(UseViewportClass()))).Shaping({.locale = "en-US"});
 }
 
 View LocaleEnvironmentContent() {

--- a/tests/runtime/resources.cpp
+++ b/tests/runtime/resources.cpp
@@ -155,6 +155,104 @@ int literal_tooltip_compositions = 0;
 int resource_tooltip_compositions = 0;
 State<bool> missing_text_field_placeholder;
 ImageAsset direct_image_asset;
+State<bool> alternate_nested_shaping_locale;
+int inherited_shaping_compositions = 0;
+int explicit_shaping_compositions = 0;
+int resource_explicit_shaping_compositions = 0;
+int nested_inherited_shaping_compositions = 0;
+int nested_explicit_shaping_compositions = 0;
+int shaping_unrelated_compositions = 0;
+int text_measurer_shaping_compositions = 0;
+
+class ShapingRecordingPlatform final : public TestPlatform {
+public:
+  struct Measurement {
+    std::string text;
+    TextLayoutOptions options;
+  };
+
+  TextLayoutMetrics MeasureText(
+      std::string_view text, const TextStyle& style, float max_width, const TextLayoutOptions& options
+  ) override {
+    measurements.push_back({std::string(text), options});
+    return TestPlatform::MeasureText(text, style, max_width, options);
+  }
+
+  std::vector<Measurement> measurements;
+};
+
+View InheritedShapingContent() {
+  ++inherited_shaping_compositions;
+  return Column {
+    Text("root inherited"),
+    Text(StringResource("test", "strings/shaped")),
+    Button("button inherited"),
+    Chip("chip inherited"),
+    RadioButton("radio inherited", false),
+    Switch("switch inherited", false),
+    Canvas([](PaintContext& paint, Size) {
+      const TextStyle style = TextStyle::Default();
+      paint.DrawText({0.0F, 0.0F, 120.0F, 20.0F}, "canvas paragraph", style);
+      paint.DrawTextRun({0.0F, 20.0F, 70.0F, 20.0F}, {0.0F, 35.0F}, "canvas run", style);
+      paint.DrawTextRuns({
+          TextRun{{0.0F, 40.0F, 80.0F, 20.0F}, {0.0F, 55.0F}, "canvas batch", style, {}},
+          TextRun{
+              {0.0F, 60.0F, 90.0F, 20.0F},
+              {0.0F, 75.0F},
+              "canvas explicit",
+              style,
+              {.locale = "ko-KR"},
+          },
+      });
+    }).With(huxerui::Frame{120.0F, 80.0F}),
+  };
+}
+
+View ExplicitShapingContent() {
+  ++explicit_shaping_compositions;
+  return Text("root explicit").Shaping({.direction = TextDirection::RightToLeft, .locale = "fa-IR"});
+}
+
+View ResourceExplicitShapingContent() {
+  ++resource_explicit_shaping_compositions;
+  return Text(StringResource("test", "strings/explicit_shaped")).Shaping({.locale = "fa-IR"});
+}
+
+View NestedInheritedShapingContent() {
+  ++nested_inherited_shaping_compositions;
+  auto alternate_nested = UseState(false);
+  alternate_nested_shaping_locale = alternate_nested;
+  const Locale locale = Locale::FromLanguageTag(alternate_nested.Get() ? "de-DE" : "ar-EG");
+  return ProvideEnvironment(locale, Text("nested inherited"));
+}
+
+View NestedExplicitShapingContent() {
+  ++nested_explicit_shaping_compositions;
+  return Text("nested explicit").Shaping({.locale = "ja-JP"});
+}
+
+View ShapingUnrelatedContent() {
+  ++shaping_unrelated_compositions;
+  return Spacer();
+}
+
+View ExplicitTextMeasurerContent() {
+  ++text_measurer_shaping_compositions;
+  static_cast<void>(UseTextMeasurer().MeasureText("explicit measurer", TextStyle::Default()));
+  return Spacer();
+}
+
+View InheritedTextShapingApp() {
+  return Column {
+    Scope(InheritedShapingContent),
+    Scope(ExplicitShapingContent),
+    Scope(ResourceExplicitShapingContent),
+    Scope(NestedInheritedShapingContent),
+    ProvideEnvironment(Locale::FromLanguageTag("ar-EG"), Scope(NestedExplicitShapingContent)),
+    Scope(ShapingUnrelatedContent),
+    Scope(ExplicitTextMeasurerContent),
+  };
+}
 
 View ResourceMenuApp() {
   auto menu = UseMenu();
@@ -223,7 +321,7 @@ View DensityImageResourceContent() {
 
 View DensityUnrelatedResourceContent() {
   ++density_unrelated_compositions;
-  return Text("unrelated");
+  return Text("unrelated").Shaping({.locale = "en-US"});
 }
 
 View ResourceConfigurationDependencyApp() {
@@ -237,7 +335,7 @@ View DirectLiteralResourceHelperApp() {
   ++direct_literal_resource_compositions;
   const detail::ResolvedImageAsset resolved = detail::UseImageVariant(ImageVariant{direct_image_asset});
   REQUIRE(std::get<ImageAsset>(resolved) == direct_image_asset);
-  return Text(UseString(StringVariant{"literal"}));
+  return Text(UseString(StringVariant{"literal"})).Shaping({.locale = "en-US"});
 }
 
 View VirtualDensityResourceContent() {
@@ -265,7 +363,7 @@ View LiteralTextFieldResourceDependencyApp() {
 
 View LiteralSemanticsResourceContent() {
   ++literal_semantics_compositions;
-  return Text("semantic").With(Semantics{.label = "literal"});
+  return Text("semantic").Shaping({.locale = "en-US"}).With(Semantics{.label = "literal"});
 }
 
 View LiteralSemanticsResourceDependencyApp() {
@@ -283,7 +381,7 @@ View ResourceSemanticsDependencyApp() {
 
 View LiteralTooltipContent() {
   ++literal_tooltip_compositions;
-  return Text("tooltip target").With(Tooltip("literal hint"));
+  return Text("tooltip target").Shaping({.locale = "en-US"}).With(Tooltip("literal hint"));
 }
 
 View LiteralTooltipDependencyApp() {
@@ -436,6 +534,198 @@ TEST_CASE("DirectLiteralResourceHelpersDoNotObserveResourceConfiguration") {
   runtime.UpdateResourceConfiguration(resources.configuration);
   runtime.BuildFrame();
   REQUIRE(direct_literal_resource_compositions == 1);
+}
+
+TEST_CASE("MountedTextAndCanvasInheritLocaleWithoutSubscribingExplicitShaping") {
+  inherited_shaping_compositions = 0;
+  explicit_shaping_compositions = 0;
+  resource_explicit_shaping_compositions = 0;
+  nested_inherited_shaping_compositions = 0;
+  nested_explicit_shaping_compositions = 0;
+  shaping_unrelated_compositions = 0;
+  text_measurer_shaping_compositions = 0;
+  TestResources resources;
+  resources.assets.emplace(
+      detail::resource_index_path,
+      EncodeIndex({
+          {
+              .kind = detail::ResourceEntryKind::String,
+              .key = "strings/shaped",
+              .mime_type = "text/plain",
+              .value = "resource default",
+          },
+          {
+              .kind = detail::ResourceEntryKind::String,
+              .key = "strings/shaped",
+              .mime_type = "text/plain",
+              .locale = "zh",
+              .value = "resource inherited",
+          },
+          {
+              .kind = detail::ResourceEntryKind::String,
+              .key = "strings/explicit_shaped",
+              .mime_type = "text/plain",
+              .value = "explicit resource default",
+          },
+          {
+              .kind = detail::ResourceEntryKind::String,
+              .key = "strings/explicit_shaped",
+              .mime_type = "text/plain",
+              .locale = "zh",
+              .value = "explicit resource localized",
+          },
+      })
+  );
+  ShapingRecordingPlatform platform;
+  platform.platform_resources = &resources;
+  Runtime runtime{InheritedTextShapingApp, platform};
+  runtime.SetWindowMetrics({.viewport = {400.0F, 700.0F}});
+
+  const auto find_paragraph = [](const FlattenedScene& scene, std::string_view text) {
+    for (const PaintCommand& command : scene.Commands()) {
+      if (const auto* paragraph = std::get_if<DrawTextCommand>(&command);
+          paragraph != nullptr && paragraph->text == text) {
+        return paragraph;
+      }
+    }
+    return static_cast<const DrawTextCommand*>(nullptr);
+  };
+  const auto find_run = [](const FlattenedScene& scene, std::string_view text) {
+    for (const PaintCommand& command : scene.Commands()) {
+      if (const auto* batch = std::get_if<DrawTextRunsCommand>(&command)) {
+        const auto found = std::ranges::find(batch->runs, text, &TextRun::text);
+        if (found != batch->runs.end()) {
+          return &*found;
+        }
+      }
+    }
+    return static_cast<const TextRun*>(nullptr);
+  };
+  const auto last_measurement = [&platform](std::string_view text) {
+    const auto found = std::find_if(
+        platform.measurements.rbegin(),
+        platform.measurements.rend(),
+        [text](const ShapingRecordingPlatform::Measurement& measurement) {
+          return measurement.text == text;
+        }
+    );
+    return found == platform.measurements.rend() ? nullptr : &*found;
+  };
+  const auto require_measurement_matches = [&last_measurement](
+                                               std::string_view text,
+                                               const DrawTextCommand& command
+                                           ) {
+    const ShapingRecordingPlatform::Measurement* measurement = last_measurement(text);
+    REQUIRE(measurement != nullptr);
+    REQUIRE(measurement->options == command.options);
+  };
+
+  const FlattenedScene& initial = runtime.BuildFrame();
+  const DrawTextCommand* root_text = find_paragraph(initial, "root inherited");
+  const DrawTextCommand* resource_text = find_paragraph(initial, "resource inherited");
+  const DrawTextCommand* root_button = find_paragraph(initial, "button inherited");
+  const DrawTextCommand* root_chip = find_paragraph(initial, "chip inherited");
+  const DrawTextCommand* root_radio = find_paragraph(initial, "radio inherited");
+  const DrawTextCommand* root_switch = find_paragraph(initial, "switch inherited");
+  const DrawTextCommand* explicit_text = find_paragraph(initial, "root explicit");
+  const DrawTextCommand* explicit_resource_text = find_paragraph(initial, "explicit resource localized");
+  const DrawTextCommand* nested_text = find_paragraph(initial, "nested inherited");
+  const DrawTextCommand* nested_explicit = find_paragraph(initial, "nested explicit");
+  REQUIRE(root_text != nullptr);
+  REQUIRE(resource_text != nullptr);
+  REQUIRE(root_button != nullptr);
+  REQUIRE(root_chip != nullptr);
+  REQUIRE(root_radio != nullptr);
+  REQUIRE(root_switch != nullptr);
+  REQUIRE(explicit_text != nullptr);
+  REQUIRE(explicit_resource_text != nullptr);
+  REQUIRE(nested_text != nullptr);
+  REQUIRE(nested_explicit != nullptr);
+  const DrawTextCommand* canvas_paragraph = find_paragraph(initial, "canvas paragraph");
+  const TextRun* canvas_run = find_run(initial, "canvas run");
+  const TextRun* canvas_batch = find_run(initial, "canvas batch");
+  const TextRun* canvas_explicit = find_run(initial, "canvas explicit");
+  const ShapingRecordingPlatform::Measurement* root_measurement = last_measurement("root inherited");
+  const ShapingRecordingPlatform::Measurement* measurer_measurement = last_measurement("explicit measurer");
+  REQUIRE(canvas_paragraph != nullptr);
+  REQUIRE(canvas_run != nullptr);
+  REQUIRE(canvas_batch != nullptr);
+  REQUIRE(canvas_explicit != nullptr);
+  REQUIRE(root_measurement != nullptr);
+  REQUIRE(measurer_measurement != nullptr);
+  REQUIRE(root_text->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(resource_text->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(root_button->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(root_chip->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(root_radio->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(root_switch->options.shaping.locale == "zh-Hans-CN");
+  const TextShapingOptions explicit_options{.direction = TextDirection::RightToLeft, .locale = "fa-IR"};
+  REQUIRE(explicit_text->options.shaping == explicit_options);
+  REQUIRE(explicit_resource_text->options.shaping.locale == "fa-IR");
+  REQUIRE(nested_text->options.shaping.locale == "ar-EG");
+  REQUIRE(nested_explicit->options.shaping.locale == "ja-JP");
+  REQUIRE(canvas_paragraph->options.shaping.locale == "zh-Hans-CN");
+  REQUIRE(canvas_run->shaping.locale == "zh-Hans-CN");
+  REQUIRE(canvas_batch->shaping.locale == "zh-Hans-CN");
+  REQUIRE(canvas_explicit->shaping.locale == "ko-KR");
+  REQUIRE(root_measurement->options == root_text->options);
+  require_measurement_matches("button inherited", *root_button);
+  require_measurement_matches("chip inherited", *root_chip);
+  require_measurement_matches("radio inherited", *root_radio);
+  require_measurement_matches("switch inherited", *root_switch);
+  REQUIRE(measurer_measurement->options.shaping.locale.empty());
+  REQUIRE(inherited_shaping_compositions == 1);
+  REQUIRE(explicit_shaping_compositions == 1);
+  REQUIRE(resource_explicit_shaping_compositions == 1);
+  REQUIRE(nested_inherited_shaping_compositions == 1);
+  REQUIRE(nested_explicit_shaping_compositions == 1);
+  REQUIRE(shaping_unrelated_compositions == 1);
+  REQUIRE(text_measurer_shaping_compositions == 1);
+
+  resources.configuration.locale = Locale::FromLanguageTag("fr-FR");
+  runtime.UpdateResourceConfiguration(resources.configuration);
+  const FlattenedScene& root_updated = runtime.BuildFrame();
+  root_text = find_paragraph(root_updated, "root inherited");
+  resource_text = find_paragraph(root_updated, "resource default");
+  canvas_paragraph = find_paragraph(root_updated, "canvas paragraph");
+  explicit_text = find_paragraph(root_updated, "root explicit");
+  explicit_resource_text = find_paragraph(root_updated, "explicit resource default");
+  nested_text = find_paragraph(root_updated, "nested inherited");
+  REQUIRE(root_text != nullptr);
+  REQUIRE(resource_text != nullptr);
+  REQUIRE(canvas_paragraph != nullptr);
+  REQUIRE(explicit_text != nullptr);
+  REQUIRE(explicit_resource_text != nullptr);
+  REQUIRE(nested_text != nullptr);
+  REQUIRE(root_text->options.shaping.locale == "fr-FR");
+  REQUIRE(resource_text->options.shaping.locale == "fr-FR");
+  REQUIRE(canvas_paragraph->options.shaping.locale == "fr-FR");
+  REQUIRE(explicit_text->options.shaping.locale == "fa-IR");
+  REQUIRE(explicit_resource_text->options.shaping.locale == "fa-IR");
+  REQUIRE(nested_text->options.shaping.locale == "ar-EG");
+  REQUIRE(inherited_shaping_compositions == 2);
+  REQUIRE(explicit_shaping_compositions == 1);
+  REQUIRE(resource_explicit_shaping_compositions == 2);
+  REQUIRE(nested_inherited_shaping_compositions == 1);
+  REQUIRE(nested_explicit_shaping_compositions == 1);
+  REQUIRE(shaping_unrelated_compositions == 1);
+  REQUIRE(text_measurer_shaping_compositions == 1);
+
+  alternate_nested_shaping_locale = true;
+  const FlattenedScene& nested_updated = runtime.BuildFrame();
+  nested_text = find_paragraph(nested_updated, "nested inherited");
+  nested_explicit = find_paragraph(nested_updated, "nested explicit");
+  REQUIRE(nested_text != nullptr);
+  REQUIRE(nested_explicit != nullptr);
+  REQUIRE(nested_text->options.shaping.locale == "de-DE");
+  REQUIRE(nested_explicit->options.shaping.locale == "ja-JP");
+  REQUIRE(inherited_shaping_compositions == 2);
+  REQUIRE(explicit_shaping_compositions == 1);
+  REQUIRE(resource_explicit_shaping_compositions == 2);
+  REQUIRE(nested_inherited_shaping_compositions == 2);
+  REQUIRE(nested_explicit_shaping_compositions == 1);
+  REQUIRE(shaping_unrelated_compositions == 1);
+  REQUIRE(text_measurer_shaping_compositions == 1);
 }
 
 TEST_CASE("LiteralTextFieldsDoNotObserveResourceConfiguration") {

--- a/tests/runtime/text_field.cpp
+++ b/tests/runtime/text_field.cpp
@@ -19,6 +19,7 @@ State<TextEditingValue> single_line_scroll_value;
 State<int> text_field_recompose_trigger;
 State<bool> text_field_offset;
 State<bool> text_field_dark_theme;
+State<bool> text_field_shaping_locale;
 TextInputAction submission_action = TextInputAction::Default;
 int first_action_submissions = 0;
 int second_action_submissions = 0;
@@ -106,6 +107,23 @@ public:
   float centered_layout_width = std::numeric_limits<float>::infinity();
 };
 
+class ShapingTextLayoutPlatform final : public TestPlatform {
+public:
+  struct LayoutRequest {
+    std::string text;
+    TextLayoutOptions options;
+  };
+
+  std::unique_ptr<detail::TextLayout> CreateTextLayout(
+      std::string_view text, const TextStyle& style, float max_width, const TextLayoutOptions& options
+  ) override {
+    requests.push_back({std::string(text), options});
+    return TestPlatform::CreateTextLayout(text, style, max_width, options);
+  }
+
+  std::vector<LayoutRequest> requests;
+};
+
 View TextFieldApp() {
   auto value = UseState(
       TextEditingValue::FromText(
@@ -129,6 +147,35 @@ View TextFieldApp() {
 View EmptyTextFieldApp() {
   return Stack {
       TextField(TextEditingValue::FromText("")).Placeholder("Name").With(huxerui::Frame{160.0F, 40.0F}),
+  };
+}
+
+View TextFieldShapingApp() {
+  auto alternate_locale = UseState(false);
+  text_field_shaping_locale = alternate_locale;
+  const Locale inherited_locale = Locale::FromLanguageTag(alternate_locale.Get() ? "de-DE" : "zh-Hant-TW");
+  return Column {
+    ProvideEnvironment(
+        inherited_locale,
+        Column {
+          TextField(TextEditingValue::FromText("inherited value"))
+              .Label("inherited label")
+              .Placeholder("inherited placeholder")
+              .Validation(ValidationResult::Invalid("inherited validation"))
+              .With(huxerui::Frame{260.0F, 96.0F}),
+          TextField(TextEditingValue::FromText(""))
+              .Placeholder("inherited painted placeholder")
+              .With(huxerui::Frame{260.0F, 72.0F}),
+        }
+    ),
+    ProvideEnvironment(
+        Locale::FromLanguageTag("ar-EG"),
+        TextField(TextEditingValue::FromText(""))
+            .Placeholder("explicit placeholder")
+            .Validation(ValidationResult::Invalid("explicit validation"))
+            .Shaping({.direction = TextDirection::RightToLeft, .locale = "fa-IR"})
+            .With(huxerui::Frame{260.0F, 96.0F})
+    ),
   };
 }
 
@@ -595,6 +642,7 @@ void ResetTextFieldState() {
   text_field_recompose_trigger = State<int>{};
   text_field_offset = State<bool>{};
   text_field_dark_theme = State<bool>{};
+  text_field_shaping_locale = State<bool>{};
   submission_action = TextInputAction::Default;
   first_action_submissions = 0;
   second_action_submissions = 0;
@@ -762,6 +810,71 @@ TEST_CASE("TestTextFieldRendersPlaceholderAndThemeStyle") {
   REQUIRE(style.validation_border_width == 1.0F);
   REQUIRE(style.focused_validation_border_width == 2.0F);
   REQUIRE(style.filled.focused_border == material_theme.colors.primary);
+}
+
+TEST_CASE("TextFieldUsesOneInheritedOrExplicitShapingContractForEveryTextPath") {
+  ResetTextFieldState();
+  ShapingTextLayoutPlatform platform;
+  Runtime runtime{TextFieldShapingApp, platform};
+  runtime.SetWindowMetrics({.viewport = {300.0F, 340.0F}});
+  const FlattenedScene& scene = runtime.BuildFrame();
+
+  const auto last_request = [&platform](std::string_view text) {
+    const auto found = std::find_if(
+        platform.requests.rbegin(),
+        platform.requests.rend(),
+        [text](const ShapingTextLayoutPlatform::LayoutRequest& request) {
+          return request.text == text;
+        }
+    );
+    return found == platform.requests.rend() ? nullptr : &*found;
+  };
+  const auto require_request = [&last_request](std::string_view text, const TextShapingOptions& shaping) {
+    const ShapingTextLayoutPlatform::LayoutRequest* request = last_request(text);
+    REQUIRE(request != nullptr);
+    REQUIRE(request->options.shaping == shaping);
+  };
+
+  const TextShapingOptions inherited{.locale = "zh-Hant-TW"};
+  const TextShapingOptions explicit_shaping{
+      .direction = TextDirection::RightToLeft,
+      .locale = "fa-IR",
+  };
+  require_request("inherited value", inherited);
+  require_request("inherited label", inherited);
+  require_request("inherited placeholder", inherited);
+  require_request("inherited validation", inherited);
+  require_request("inherited painted placeholder", inherited);
+  require_request("explicit placeholder", explicit_shaping);
+  require_request("explicit validation", explicit_shaping);
+
+  const auto require_paint = [](const FlattenedScene& frame, std::string_view text, const TextShapingOptions& shaping) {
+    const DrawTextCommand* command = FindText(frame, text);
+    REQUIRE(command != nullptr);
+    REQUIRE(command->options.shaping == shaping);
+  };
+  require_paint(scene, "inherited value", inherited);
+  require_paint(scene, "inherited label", inherited);
+  require_paint(scene, "inherited validation", inherited);
+  require_paint(scene, "inherited painted placeholder", inherited);
+  require_paint(scene, "explicit placeholder", explicit_shaping);
+  require_paint(scene, "explicit validation", explicit_shaping);
+
+  platform.requests.clear();
+  text_field_shaping_locale = true;
+  const FlattenedScene& updated_scene = runtime.BuildFrame();
+  const TextShapingOptions updated_inherited{.locale = "de-DE"};
+  require_request("inherited value", updated_inherited);
+  require_request("inherited label", updated_inherited);
+  require_request("inherited placeholder", updated_inherited);
+  require_request("inherited validation", updated_inherited);
+  require_request("inherited painted placeholder", updated_inherited);
+  require_paint(updated_scene, "inherited value", updated_inherited);
+  require_paint(updated_scene, "inherited label", updated_inherited);
+  require_paint(updated_scene, "inherited validation", updated_inherited);
+  require_paint(updated_scene, "inherited painted placeholder", updated_inherited);
+  require_paint(updated_scene, "explicit placeholder", explicit_shaping);
+  require_paint(updated_scene, "explicit validation", explicit_shaping);
 }
 
 TEST_CASE("TextFieldAlignmentUsesOneLayoutContractForPlaceholderGeometry") {

--- a/tests/unit/paint.cpp
+++ b/tests/unit/paint.cpp
@@ -91,6 +91,24 @@ TEST_CASE("PaintContextKeepsTextParagraphOffsetsInsideFixedCommandBounds") {
   REQUIRE(sequence.Bounds() == bounds);
 }
 
+TEST_CASE("IndependentPaintContextLeavesDefaultTextShapingLocaleEmpty") {
+  PaintSequence sequence;
+  PaintContext context{sequence, Rect{0.0F, 0.0F, 100.0F, 80.0F}};
+  context.DrawText({0.0F, 0.0F, 80.0F, 20.0F}, "paragraph", TextStyle{});
+  context.DrawTextRun({0.0F, 20.0F, 40.0F, 20.0F}, {0.0F, 35.0F}, "run", TextStyle{});
+  context.DrawTextRuns({
+      TextRun{{0.0F, 40.0F, 40.0F, 20.0F}, {0.0F, 55.0F}, "batch", TextStyle{}, {}},
+  });
+  context.Finish();
+
+  REQUIRE(sequence.Commands().size() == 2);
+  REQUIRE(std::get<DrawTextCommand>(sequence.Commands()[0]).options.shaping.locale.empty());
+  const auto& runs = std::get<DrawTextRunsCommand>(sequence.Commands()[1]).runs;
+  REQUIRE(runs.size() == 2);
+  REQUIRE(runs[0].shaping.locale.empty());
+  REQUIRE(runs[1].shaping.locale.empty());
+}
+
 TEST_CASE("PaintContextNormalizesRoundedGeometryAgainstConcreteBounds") {
   const Rect pill{10.0F, 20.0F, 120.0F, 20.0F};
   const LinearGradient linear{


### PR DESCRIPTION
## Summary

- Resolve an empty `TextShapingOptions::locale` from the effective inherited `Locale` for mounted text, built-in control labels, TextField, and Canvas text.
- Add rvalue-qualified `Text::Shaping()` and `TextField::Shaping()` APIs for declaration-local overrides.
- Preserve explicit non-empty shaping locales without creating an inherited-Locale dependency.
- Keep localized resource selection independent from explicit shaping overrides.
- Integrate current `main` and keep the Linux test executable building and running after the upstream API changes.

## Behavior and ownership

Shared View compilation fills the shaping locale only for mounted nodes that actually render inherited text. Literal Text with an explicit locale remains clean after Locale updates, while resource-backed Text with explicit shaping still observes Locale only when localized resource selection requires it.

Button, Chip, Checkbox, RadioButton, and Switch measurement and paint paths forward the resolved `TextLayoutOptions`. Measurement and renderer replay therefore use the same shaping contract.

Canvas receives a node-local `PaintContext` seeded with the resolved inherited locale. `DrawText`, `DrawTextRun`, and each entry passed to `DrawTextRuns` fill only an empty run locale and preserve explicit run locales. Independently constructed `PaintContext` instances remain stateless and do not perform Environment lookup.

`TextMeasurer` also remains explicit and stateless. Composition code that needs inherited shaping must read Locale and pass its language tag through the existing shaping or layout options.

The Runtime-owned system-bar backplane Canvas declares the neutral `und` locale because it only records rectangles. This prevents that internal node from subscribing the application root to Locale and preserves precise scope invalidation.

## TextField

TextField resolves its shaping locale during modifier compilation and applies the same complete shaping value to:

- controlled value and placeholder layout;
- label and floating-label layout;
- validation message measurement and paint;
- secure grapheme-boundary layout;
- unbounded line measurement;
- caret, hit-test, selection, and retained drawing paths backed by the editable text layout.

A shaping change invalidates every affected retained TextField layout cache and participates in normal layout and paint reconciliation.

## Main integration and conflict resolution

The branch includes `origin/main` through `2659a55`.

Conflict resolutions preserve both sides of the evolving APIs:

- `src/paint.cpp` keeps the generic `Brush` drawing API from `main` together with inherited Canvas text-locale resolution from this branch.
- `include/huxerui/view.h` keeps the expanded public API documentation and new component declarations from `main` together with `Text::Shaping()` and `TextField::Shaping()`; the two shaping declarations now have matching public documentation.
- The Linux X11 `None` macro fix is now also present upstream as `dcd41c4` and reconciled cleanly with this branch.

With these conflicts resolved, `huxerui_tests` builds and links on Linux ARM64.

## Tests

Focused Runtime coverage verifies:

- root and nested Locale inheritance;
- literal and localized resource-backed Text;
- explicit Text shaping and resource lookup independence;
- Button, Chip, RadioButton, and Switch measurement/paint shaping agreement;
- Canvas paragraph, single-run, batch-run, and explicit-run behavior;
- precise recomposition of inherited, explicit, nested, unrelated, and TextMeasurer scopes;
- TextField value, label, placeholder, validation, layout, and paint shaping agreement.

Existing resource-dependency tests give intentionally unrelated literal Text an explicit locale, so they continue to test only the Environment entry named by each case.

## Documentation

Updated the text, resource, and text-input design contracts plus the component guide to document inherited defaults, explicit overrides, Canvas behavior, resource-selection separation, and the explicit TextMeasurer boundary.

## Validation

- [x] `cmake --build build --target huxerui_tests -j8`
- [x] Complete suite excluding the known nondeterministic Linux HTTP race test — all 925 test cases passed with 8,065 assertions.
- [x] `Linux HTTP transport resolves cancellation and completion races once` run in isolation — 40 assertions passed.
- [x] `cmake --build build --target huxerui_header_checks -j8`
- [x] `git diff --check`

Together, the complete-suite run and isolated HTTP run cover all 926 current test cases. Running every case in one process can still hit the pre-existing Linux HTTP cancellation/completion memory race; this PR does not modify HTTP behavior.

The checked-in Linux ARM64 prebuilt `hrc` does not yet contain the newest resource wire-format changes from `main`. For local validation only, the current resource-compiler source was built in a temporary directory and used to refresh generated files under `build/`; no generated resource or prebuilt binary is included in this PR.

The requested conflict-resolution outcome is confirmed: the test target builds, links, and runs.

Closes #29