### PR TITLE
fix(tests): link linux runtime tests against GTK4

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,7 +148,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "${HUXERUI_PROJECT_DIR}/examples/platform_module"
             "$<TARGET_PROPERTY:huxerui_core_objects,INCLUDE_DIRECTORIES>"
     )
-    target_link_libraries(huxerui_tests PRIVATE PkgConfig::HUXERUI_GIO)
+    target_link_libraries(huxerui_tests PRIVATE
+            PkgConfig::HUXERUI_GTK4
+            PkgConfig::HUXERUI_GIO
+    )
 endif ()
 
 if (EMSCRIPTEN)


### PR DESCRIPTION
Link Linux runtime tests against GTK4 in addition to GIO so Cairo-dependent platform test sources resolve the required GTK, GDK, and Cairo symbols.

fix https://github.com/HuxerUI/HuxerUI/issues/98