### PR TITLE
fix(linux): make portal shutdown callback-safe

### DIFF
--- a/platform/linux/linux_file_picker.cpp
+++ b/platform/linux/linux_file_picker.cpp
@@ -253,13 +253,23 @@ public:
 
   void Stop() noexcept {
     std::thread thread;
+    bool stop_on_portal_thread = false;
     {
       std::scoped_lock lock(mutex_);
       if (!thread_.joinable()) {
         return;
       }
       stopping_ = true;
-      thread = std::move(thread_);
+      if (thread_.get_id() == std::this_thread::get_id()) {
+        thread_.detach();
+        stop_on_portal_thread = true;
+      } else {
+        thread = std::move(thread_);
+      }
+    }
+    if (stop_on_portal_thread) {
+      RequestStop();
+      return;
     }
     g_main_context_invoke_full(
         context_,
@@ -296,7 +306,10 @@ private:
   }
 
   bool Start() {
-    thread_ = std::thread([this] { Run(); });
+    // A portal completion can release the last transport on this thread. Retain the connection
+    // until Run() has left the GLib context so same-thread shutdown cannot destroy live GLib state.
+    const std::shared_ptr<PortalConnection> self = shared_from_this();
+    thread_ = std::thread([self] { self->Run(); });
     std::unique_lock lock(mutex_);
     ready_condition_.wait(lock, [this] { return ready_; });
     if (Available()) {

--- a/tests/platform/linux_file_picker.cpp
+++ b/tests/platform/linux_file_picker.cpp
@@ -865,6 +865,32 @@ TEST_CASE("LinuxFilePickerCompletesAnActiveRequestWhenThePortalDisappears") {
   cancel();
 }
 
+TEST_CASE("LinuxFilePickerCanReleaseItsTransportFromAPortalCompletion") {
+  FakePortal portal;
+  portal.SetScenario({.response = 1});
+  std::shared_ptr<detail::FilePickerTransport> transport =
+      detail::CreateLinuxFilePickerTransport([] { return 0UL; }, portal.Address());
+  REQUIRE(transport);
+
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool completed = false;
+  std::function<void()> cancel = transport->OpenFiles({}, false, [&](std::vector<FileReference> references) {
+    transport.reset();
+    {
+      std::scoped_lock lock(mutex);
+      completed = references.empty();
+    }
+    condition.notify_all();
+  });
+  {
+    std::unique_lock lock(mutex);
+    REQUIRE(condition.wait_for(lock, std::chrono::seconds(5), [&] { return completed; }));
+  }
+  REQUIRE_FALSE(transport);
+  cancel();
+}
+
 TEST_CASE("LinuxFilePickerHandlesEmptyFiltersPortalFailuresAndInvalidUris") {
   FakePortal portal;
   TemporaryDirectory temporary;

--- a/tests/platform/linux_http.cpp
+++ b/tests/platform/linux_http.cpp
@@ -159,11 +159,11 @@ public:
     stopping_ = true;
     if (listen_socket_ >= 0) {
       shutdown(listen_socket_, SHUT_RDWR);
-      CloseSocket(std::exchange(listen_socket_, -1));
     }
     if (thread_.joinable()) {
       thread_.join();
     }
+    CloseSocket(std::exchange(listen_socket_, -1));
   }
 
   [[nodiscard]] std::string Url(std::string_view path) const {

--- a/tests/runtime/presentation.cpp
+++ b/tests/runtime/presentation.cpp
@@ -3160,7 +3160,8 @@ TEST_CASE("TestFocusTraversalKeyboardAndThemeVisuals") {
   });
   REQUIRE(third_keyboard_clicks == 0);
   const FlattenedScene& space_down = runtime.BuildFrame();
-  const Color* keyboard_press = LayerFillColor(huxerui::FlatLightThemeSpec().interactions.indication.press);
+  const ThemeSpec light_theme = huxerui::FlatLightThemeSpec();
+  const Color* keyboard_press = LayerFillColor(light_theme.interactions.indication.press);
   REQUIRE(keyboard_press != nullptr);
   REQUIRE(FindRectWithColor(space_down, *keyboard_press) != nullptr);
 


### PR DESCRIPTION
# Summary

Fix a Linux file-picker shutdown crash that occurs when a portal completion releases the final picker transport on the portal thread.

Also remove the two sanitizer blockers exposed while verifying that lifecycle path: a loopback HTTP test-server descriptor race under TSan and a presentation-test pointer into a temporary theme under ASan.

No public API, FilePicker result semantics, HTTP transport behavior, GTK requirement, or non-Linux backend changes.

## Root causes

### File picker

`LinuxFilePickerTransport::~LinuxFilePickerTransport()` stops its `PortalConnection`. A completion runs on the dedicated GLib portal thread, so a completion that releases the final transport could call `PortalConnection::Stop()` from that same thread. The previous implementation moved the worker `std::thread` and unconditionally joined it, causing `std::system_error` inside a destructor and process termination.

The connection thread also captured a raw `this`. Simply detaching the current thread would therefore allow the connection and its `GMainContext`/`GMainLoop` to be destroyed while `Run()` was still unwinding.

### HTTP test server

`LoopbackHttpServer` closed and replaced `listen_socket_` before its accept thread joined. The accept thread concurrently read the same plain integer, which TSan reported as a data race. Closing before join also allowed the descriptor number to be reused while the old accept loop was still active.

### Presentation test

The keyboard-focus test passed a nested member of a temporary `ThemeSpec` to `LayerFillColor()` and retained the returned pointer past the end of the full expression, producing an ASan stack-use-after-scope.

## Changes

- Retain `PortalConnection` from the worker thread until `Run()` has fully left the GLib context.
- Detect portal-thread shutdown, request loop termination, and detach instead of joining the current thread.
- Add a regression that releases the last file-picker transport directly from a portal completion.
- Wake the loopback HTTP accept thread with `shutdown()`, join it, and only then close/reset the listening descriptor.
- Keep the test theme in a local value for as long as the borrowed color pointer is used.

## Concurrency and ownership

External shutdown remains synchronous: it posts the stop request and joins the portal thread. Same-thread shutdown cannot synchronously join itself, so the worker-held `shared_ptr` becomes the lifetime barrier; GLib objects are released only after `Run()` finishes cleanup and pops its thread-default context.

The HTTP change is deliberately limited to the test fixture. No libsoup request, cancellation, timeout, or response code changes were required by the reproduced TSan report.

## Validation

All builds used `-j8`.

- Incremental Linux test build: passed.
- Focused file-picker tests: 11 test cases, 131 assertions passed.
- Existing runtime-destruction picker test: 1 test case, 2 assertions passed.
- Focused HTTP tests: 22 test cases, 147 assertions passed.
- Focused presentation regression: 1 test case, 22 assertions passed.
- Full ordinary test binary: 989 test cases, 24,521 assertions passed.
- Full CTest suite: 17/17 passed.
- Full ASan+UBSan test binary: 989 test cases, 24,521 assertions passed with no sanitizer report (`detect_leaks=0` for uninstrumented GLib-owned process state).
- Full TSan test binary: 989 test cases, 24,520 assertions passed with suppressions limited to uninstrumented GLib/GIO/GObject/Fontconfig/D-Bus internals.
- `git diff --check`: passed.
