### PR TITLE
feat(android): load named fonts from application assets

### DIFF
--- a/platform/android/huxerui/src/main/java/org/huxerui/HuxerUIView.java
+++ b/platform/android/huxerui/src/main/java/org/huxerui/HuxerUIView.java
@@ -2226,6 +2226,17 @@ public final class HuxerUIView extends ViewGroup {
         }
     }
 
+    private Typeface resolveNamedTypeface(String familyName) {
+        // Named families resolve against bundled assets first (fonts/<family>.ttf)
+        // and fall back to the system family table, so applications can ship
+        // custom fonts without platform integration.
+        try {
+            return Typeface.createFromAsset(getContext().getAssets(), "fonts/" + familyName + ".ttf");
+        } catch (Exception ignored) {
+            return Typeface.create(familyName, Typeface.NORMAL);
+        }
+    }
+
     private Typeface resolveTypeface(int familyKind, String familyName, int weight, int slant) {
         FontKey key = new FontKey(familyKind, familyName, weight, slant);
         Typeface typeface = fontCache.get(key);
@@ -2234,7 +2245,7 @@ public final class HuxerUIView extends ViewGroup {
             if (familyKind == FONT_FAMILY_MONOSPACE) {
                 base = Typeface.MONOSPACE;
             } else if (familyKind == FONT_FAMILY_NAMED) {
-                base = Typeface.create(familyName, Typeface.NORMAL);
+                base = resolveNamedTypeface(familyName);
             } else {
                 base = Typeface.DEFAULT;
             }


### PR DESCRIPTION
## Motivation

Named font families (`Font::Named`) resolve through `Typeface.create(familyName, ...)`, which consults only the system family table. Applications that ship a custom font in their assets (`fonts/<family>.ttf`) silently fall back to the default font.

## Behavior

`resolveTypeface(FONT_FAMILY_NAMED, ...)` now resolves named families against `fonts/<family>.ttf` in the application assets first and falls back to the system family table when the asset is absent. Resolved typefaces still feed the per-key font cache and the weight and slant synthesis path. Measurement and painting resolve through the same function, so both stay consistent.

## Validation

- Built the Android platform through a real application project (Gradle `assembleDebug`, arm64-v8a) whose APK packages `assets/fonts/MapleMono.ttf` and `assets/fonts/MapleMonoNL.ttf`; the editor renders with the bundled font.
- No C++ or JNI signature changes. The change is contained to `HuxerUIView#resolveTypeface` and a new private helper.