### PR TITLE
feat(animation): add circular conceal scene transitions

### DIFF
--- a/docs/design/animation.md
+++ b/docs/design/animation.md
@@ -113,6 +113,8 @@ return Button("Dark theme")
 
 `RunAt()` accepts a window-local logical point for callers that already own pointer geometry.
 `Run()` with a circular reveal uses the final bounds of the retained anchor, while Fade does not require an anchor.
+`CircularConcealSceneTransition` uses the same origin and timing contract while contracting the frozen old scene over
+the live scene. It is an explicit one-shot transition, not reverse playback of a circular reveal.
 
 `RunFromCurrentInteraction()` resolves a circular reveal from the Runtime's current synchronous interaction origin:
 
@@ -147,7 +149,11 @@ The new tree becomes authoritative immediately for input, focus, text input, tex
 
 Starting a transition while another one is active freezes the currently committed composite and replaces the prior snapshot. Transitions do not queue or create nested snapshots. Reduced motion runs the mutation without freezing or scheduling animation. A viewport change that invalidates the frozen logical coordinate space ends the transition.
 
-Whole-scene transitions are one-shot. Their public descriptions expose an optional delay but do not expose repetition or reverse playback because either policy would retain obsolete full-scene visual data indefinitely. They reject undamped springs for the same ownership reason: an undamped spring never settles. Repetition and undamped springs remain available to ordinary `MotionController` animation.
+Whole-scene transitions are one-shot. Their public descriptions expose an optional delay but do not expose repetition or
+reverse playback controls because either policy would retain obsolete full-scene visual data indefinitely. A caller that
+needs the opposite visual composition chooses the explicit one-shot `CircularConcealSceneTransition` instead. They
+reject undamped springs for the same ownership reason: an undamped spring never settles. Repetition and undamped
+springs remain available to ordinary `MotionController` animation.
 
 ### FrozenScene
 
@@ -161,7 +167,7 @@ The existing damage snapshot is renamed `RenderDamageSnapshot`. It remains light
 
 SceneTransitionService owns the active snapshot, motion controller, and synthetic render wrappers as one optional active transition, without a separate implementation-state allocation. It reads the committed render frame and window through the shared Runtime::State context. Runtime advances the service at the scene-composition boundary and combines its scheduling result with the rest of the frame. Disconnecting the service clears its context pointer, releases active transition data, and rejects subsequent requests from retained handles.
 
-A fade scene transition without a PlatformView uses two synthetic render wrappers: old opacity is `1 - progress`, new opacity is `progress`. A circular reveal draws the old frozen composite normally and places the live composite beneath one circular child clip on an otherwise empty wrapper. It does not require a separate whole-subtree clip primitive or inverse and even-odd clipping.
+A fade scene transition without a PlatformView uses two synthetic render wrappers: old opacity is `1 - progress`, new opacity is `progress`. A circular reveal draws the old frozen composite normally and places the live composite beneath one circular child clip on an otherwise empty wrapper. A circular conceal reverses the visual ordering: the live composite is drawn first and the old frozen composite is placed above it with a shrinking circular child clip. Neither transition requires a separate whole-subtree clip primitive or inverse and even-odd clipping.
 
 An active scene transition reports full damage because the visible composite changes across the reveal or cross-fade. Normal incremental damage resumes after completion.
 

--- a/docs/guide/themes-and-presentation.md
+++ b/docs/guide/themes-and-presentation.md
@@ -74,6 +74,15 @@ Button("Next").OnClick([transition, page] {
 });
 ```
 
+Use `CircularConcealSceneTransition` when the old scene should contract toward the interaction origin while the mutated
+scene remains underneath it:
+
+```cpp
+Button("Close").OnClick([transition, page] {
+  transition.RunFromCurrentInteraction(CircularConcealSceneTransition{}, [page] { page += 1; });
+});
+```
+
 The implicit origin exists only for the duration of the interaction callback.
 Use `RunAt` with retained geometry for asynchronous work, and use `Anchor` plus `Run` when the reveal belongs to stable View geometry rather than the triggering interaction.
 When reduced motion is enabled, the runtime selects the documented reduced or immediate path rather than leaving each component to interpret the system setting independently.

--- a/include/huxerui/animation.h
+++ b/include/huxerui/animation.h
@@ -468,6 +468,21 @@ struct CircularRevealSceneTransition {
   bool operator==(const CircularRevealSceneTransition&) const = default;
 };
 
+/// Conceals the previously committed scene through a shrinking circular clip.
+///
+/// The scene produced by the synchronous mutation is composed underneath the frozen old scene. The old scene
+/// starts fully visible and contracts toward the supplied origin until the mutated scene is fully visible. This is a
+/// one-shot scene transition, not reverse playback of a CircularRevealSceneTransition.
+struct CircularConcealSceneTransition {
+  /// Motion used to advance normalized transition progress.
+  AnimationSpec animation = TweenSpec{0.36, Easing::EaseInOut};
+  /// Non-negative delay in seconds before the transition begins.
+  double delay = 0.0;
+
+  /// Compares motion and delay.
+  bool operator==(const CircularConcealSceneTransition&) const = default;
+};
+
 /// Retained modifier that supplies stable presentation geometry to a circular scene transition.
 ///
 /// One anchor returned by SceneTransitionHandle::Anchor() may be mounted on only one View at a time.
@@ -517,11 +532,17 @@ public:
   /// Throws `std::logic_error` when no anchor is mounted.
   void Run(CircularRevealSceneTransition transition, std::function<void()> mutation) const;
 
+  /// Conceals the previously committed scene toward the center of the mounted Anchor().
+  void Run(CircularConcealSceneTransition transition, std::function<void()> mutation) const;
+
   /// Reveals the mutated scene from a finite window-local logical point.
   ///
   /// RunAt() is appropriate when the caller already owns stable geometry or resumes asynchronous work after an input
   /// callback has returned.
   void RunAt(Point origin, CircularRevealSceneTransition transition, std::function<void()> mutation) const;
+
+  /// Conceals the previously committed scene toward a finite window-local logical point.
+  void RunAt(Point origin, CircularConcealSceneTransition transition, std::function<void()> mutation) const;
 
   /// Runs a circular reveal from the current synchronous pointer, keyboard, or semantic interaction.
   ///
@@ -534,6 +555,10 @@ public:
   /// });
   /// @endcode
   void RunFromCurrentInteraction(CircularRevealSceneTransition transition, std::function<void()> mutation) const;
+
+  /// Runs a circular conceal from the current synchronous pointer, keyboard, or semantic interaction.
+  void RunFromCurrentInteraction(CircularConcealSceneTransition transition,
+                                 std::function<void()> mutation) const;
 
 private:
   SceneTransitionHandle(std::shared_ptr<detail::SceneTransitionService> service,

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -230,6 +230,7 @@ struct LayerEntry {
 enum class SceneTransitionKind {
   Fade,
   CircularReveal,
+  CircularConceal,
 };
 
 struct SceneTransitionRequest {

--- a/src/runtime/scene_transition.cpp
+++ b/src/runtime/scene_transition.cpp
@@ -95,12 +95,22 @@ const RenderNode* SceneTransitionService::Compose(const RenderNode* live_root) {
     return &transition.composite;
   }
 
-  const float radius = CircularRevealRadius(transition.request.origin, transition.viewport) * progress;
-  transition.new_wrapper.child_clips.push_back(PushPathClipCommand{
-      CircularClip(transition.request.origin, radius),
-      PathFillRule::NonZero,
-  });
-  transition.composite.children = {transition.frozen->root, &transition.new_wrapper};
+  const float maximum_radius = CircularRevealRadius(transition.request.origin, transition.viewport);
+  if (transition.request.kind == SceneTransitionKind::CircularConceal) {
+    const float radius = maximum_radius * (1.0F - progress);
+    transition.old_wrapper.child_clips.push_back(PushPathClipCommand{
+        CircularClip(transition.request.origin, radius),
+        PathFillRule::NonZero,
+    });
+    transition.composite.children = {&transition.new_wrapper, &transition.old_wrapper};
+  } else {
+    const float radius = maximum_radius * progress;
+    transition.new_wrapper.child_clips.push_back(PushPathClipCommand{
+        CircularClip(transition.request.origin, radius),
+        PathFillRule::NonZero,
+    });
+    transition.composite.children = {transition.frozen->root, &transition.new_wrapper};
+  }
   return &transition.composite;
 }
 
@@ -261,6 +271,14 @@ void SceneTransitionHandle::Run(CircularRevealSceneTransition transition, std::f
   RunAt(*origin, std::move(transition), std::move(mutation));
 }
 
+void SceneTransitionHandle::Run(CircularConcealSceneTransition transition, std::function<void()> mutation) const {
+  const std::optional<Point> origin = anchor_ ? anchor_->Center() : std::nullopt;
+  if (!origin.has_value()) {
+    throw std::logic_error("HuxerUI circular scene transition requires a mounted anchor");
+  }
+  RunAt(*origin, std::move(transition), std::move(mutation));
+}
+
 void SceneTransitionHandle::RunAt(
     Point origin, CircularRevealSceneTransition transition, std::function<void()> mutation
 ) const {
@@ -279,8 +297,36 @@ void SceneTransitionHandle::RunAt(
   );
 }
 
+void SceneTransitionHandle::RunAt(
+    Point origin, CircularConcealSceneTransition transition, std::function<void()> mutation
+) const {
+  if (!std::isfinite(origin.x) || !std::isfinite(origin.y)) {
+    throw std::invalid_argument("HuxerUI scene transition origin must be finite");
+  }
+  service_->Run(
+      detail::SceneTransitionRequest{
+          .kind = detail::SceneTransitionKind::CircularConceal,
+          .animation = std::move(transition.animation),
+          .delay = transition.delay,
+          .origin = origin,
+      },
+      std::move(mutation),
+      reduced_motion_
+  );
+}
+
 void SceneTransitionHandle::RunFromCurrentInteraction(
     CircularRevealSceneTransition transition, std::function<void()> mutation
+) const {
+  const std::optional<Point> origin = service_->CurrentInteractionOrigin();
+  if (!origin.has_value()) {
+    throw std::logic_error("HuxerUI scene transition requires a current interaction origin");
+  }
+  RunAt(*origin, std::move(transition), std::move(mutation));
+}
+
+void SceneTransitionHandle::RunFromCurrentInteraction(
+    CircularConcealSceneTransition transition, std::function<void()> mutation
 ) const {
   const std::optional<Point> origin = service_->CurrentInteractionOrigin();
   if (!origin.has_value()) {

--- a/tests/runtime/animation.cpp
+++ b/tests/runtime/animation.cpp
@@ -6,10 +6,12 @@ namespace huxerui::test {
 namespace {
 
 State<bool> scene_transition_changed;
+State<bool> scene_conceal_transition_changed;
 State<bool> scene_transition_anchor_visible;
 State<bool> platform_scene_transition_changed;
 State<bool> synchronized_transition_selected;
 std::optional<SceneTransitionHandle> interaction_scene_transition;
+std::optional<SceneTransitionHandle> interaction_scene_conceal_transition;
 
 View SynchronizedTransitionApp() {
   auto selected = UseState(false);
@@ -31,6 +33,22 @@ View SceneTransitionApp() {
     Button("Change")
         .OnClick([transition, changed] {
           transition.RunFromCurrentInteraction(CircularRevealSceneTransition{}, [changed] { changed = true; });
+        })
+        .With(Frame{80.0F, 40.0F}),
+    Text(changed ? "new" : "old"),
+  };
+}
+
+View SceneConcealTransitionApp() {
+  auto changed = UseState(false);
+  scene_conceal_transition_changed = changed;
+  auto transition = UseSceneTransition();
+  interaction_scene_conceal_transition = transition;
+  return Column {
+    Button("Change")
+        .OnClick([transition, changed] {
+          transition.RunFromCurrentInteraction(
+              CircularConcealSceneTransition{}, [changed] { changed = true; });
         })
         .With(Frame{80.0F, 40.0F}),
     Text(changed ? "new" : "old"),
@@ -118,6 +136,38 @@ TEST_CASE("SceneTransitionPublishesFrozenAndLiveSceneComposition") {
       std::get_if<PushPathClipCommand>(&transition.scene.root->children[1]->child_clips.front());
   REQUIRE(reveal != nullptr);
   REQUIRE(reveal->path.Bounds() == Rect{20.0F, 20.0F, 0.0F, 0.0F});
+
+  platform.AdvanceTime(0.5);
+  const RenderFrame& completed = runtime.BuildRenderFrame();
+  REQUIRE(completed.damage.full);
+  REQUIRE(completed.scene.root != nullptr);
+  REQUIRE(completed.scene.root->id == live_root_identity);
+}
+
+TEST_CASE("CircularConcealTransitionShrinksFrozenSceneOverLiveScene") {
+  TestPlatform platform;
+  Runtime runtime{SceneConcealTransitionApp, platform};
+  runtime.SetWindowMetrics({.viewport = {240.0F, 160.0F}});
+  const RenderFrame& initial = runtime.BuildRenderFrame();
+  REQUIRE(initial.scene.root != nullptr);
+  const std::uint64_t live_root_identity = initial.scene.root->id;
+
+  ClickAt(runtime, {20.0F, 20.0F});
+  REQUIRE(scene_conceal_transition_changed.Get());
+  const RenderFrame& transition = runtime.BuildRenderFrame();
+  REQUIRE(transition.damage.full);
+  REQUIRE(transition.scene.root != nullptr);
+  REQUIRE(transition.scene.root->id == std::numeric_limits<std::uint64_t>::max());
+  REQUIRE(transition.scene.root->children.size() == 2);
+  REQUIRE(transition.scene.root->children[0]->id == std::numeric_limits<std::uint64_t>::max() - 2);
+  REQUIRE(transition.scene.root->children[0]->children.size() == 1);
+  REQUIRE(transition.scene.root->children[0]->children[0]->id == live_root_identity);
+  REQUIRE(transition.scene.root->children[1]->id == std::numeric_limits<std::uint64_t>::max() - 1);
+  REQUIRE(transition.scene.root->children[1]->child_clips.size() == 1);
+  const auto* conceal =
+      std::get_if<PushPathClipCommand>(&transition.scene.root->children[1]->child_clips.front());
+  REQUIRE(conceal != nullptr);
+  REQUIRE(conceal->path.Bounds().width > 500.0F);
 
   platform.AdvanceTime(0.5);
   const RenderFrame& completed = runtime.BuildRenderFrame();


### PR DESCRIPTION
## Summary

- add `CircularConcealSceneTransition` for one-shot circular contraction of the frozen old scene
- keep the mutated live scene underneath the shrinking old-scene clip
- support anchor, explicit-point, and current-interaction origins with the existing reduced-motion and PlatformView policies
- add runtime coverage and document the composition and ownership contract

This is intentionally a distinct one-shot transition rather than reverse playback of `CircularRevealSceneTransition`. It keeps scene progress normalized from 0 to 1 and avoids adding repetition or reverse controls that would extend frozen-scene ownership.

## Validation

- `huxerui_tests "SceneTransition*"`
- UBSan-only build of `huxerui_tests`
- UBSan-only `HuxerUIProfilingBuildTests`

The full local `HuxerUITests` suite also has an unrelated existing Linux bidi caret test failure in this environment; the scene-transition filter passes all 9 cases and 35 assertions.
