### PR TITLE
feat(cli): add mcpp build frontend

### DIFF
--- a/docs/design/sdk-cli.md
+++ b/docs/design/sdk-cli.md
@@ -229,6 +229,7 @@ huxerui doctor [platform-list]
 huxerui setup <platform-list> [--yes]
 huxerui devices [platform]
 huxerui build [platform-list] [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
+huxerui mcpp build [--source <path>] [--release] [--locked] [--offline] [--verbose]
 huxerui run <platform> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui package <platform-list> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui open ios [--source <path>]
@@ -241,6 +242,8 @@ The accepted identifiers are `codex`, `claude`, `antigravity`, `opencode`, `comm
 `codex`, `antigravity`, `opencode`, `command-code`, `omp`, and `dsh` map to `.agents/skills`; `claude` maps to `.claude/skills`; and `zcode` maps to `.zcode/skills`.
 The default is `codex`; `all` selects the three distinct directories, and `none` disables Skill creation.
 An explicit list replaces the default, and aliases that share a directory are deduplicated.
+
+`huxerui mcpp build` is an independent generic mcpp frontend. It requires `mcpp.toml` in the selected source directory and invokes the `mcpp` executable directly. It does not participate in HuxerUI project discovery, alter the existing CMake and platform-driver paths, or provide HuxerUI package integration; the mcpp project owns those details.
 
 ### Create and platform add
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -65,6 +65,14 @@ The source override applies only to that CLI process and its build children; it 
 
 Direct CMake builds of generated projects use `-DHUXERUI_HOME=<path>`. CMake loads the source checkout or installed package at that location. Use a separate build directory for each framework location; the CLI does this automatically.
 
+The SDK CLI also provides an independent mcpp frontend for projects that own an `mcpp.toml` manifest:
+
+```bash
+huxerui mcpp build --source ../my-mcpp-project
+```
+
+This command invokes mcpp directly and does not change the existing HuxerUI CMake build or platform commands. It is a generic mcpp entry point; the mcpp project remains responsible for its own sources, dependencies, and framework integration.
+
 The CLI passes the selected framework home through its process environment and build arguments without writing it into platform configuration files. Direct Android Studio builds require `HUXERUI_HOME` in the IDE's environment; direct Xcode builds require it in the IDE's environment or explicit build settings, such as `Config/Local.xcconfig`. An already running IDE does not inherit the CLI's temporary environment or remember its last `--source` selection.
 
 Android and iOS accept a device selected from:
@@ -172,6 +180,7 @@ huxerui doctor [platform-list]
 huxerui setup <platform-list> [--yes]
 huxerui devices [platform]
 huxerui build [platform-list] [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
+huxerui mcpp build [--source <path>] [--release] [--locked] [--offline] [--verbose]
 huxerui run <platform> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui package <platform-list> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui open ios [--source <path>]

--- a/examples/mcpp_demo/.gitignore
+++ b/examples/mcpp_demo/.gitignore
@@ -1,0 +1,2 @@
+target/
+compile_commands.json

--- a/examples/mcpp_demo/README.md
+++ b/examples/mcpp_demo/README.md
@@ -1,0 +1,33 @@
+# HuxerUI mcpp demo
+
+This directory is intentionally outside the CMake example list. It demonstrates the independent `huxerui mcpp build` frontend by compiling a small HuxerUI desktop page from an `mcpp.toml` manifest.
+
+Build the HuxerUI static library first from the repository root:
+
+```bash
+cmake -S . -B build -G Ninja \
+  -DHUXERUI_BUILD_EXAMPLES=OFF \
+  -DHUXERUI_BUILD_TESTS=OFF \
+  -DHUXERUI_BUILD_CLI=ON \
+  -DHUXERUI_ENABLE_PROFILING=OFF
+cmake --build build --target huxerui_static --parallel
+```
+
+Then build this demo through the SDK CLI:
+
+```bash
+build/bin/huxerui mcpp build --source examples/mcpp_demo
+```
+
+The generated executable is placed in mcpp's `target/` directory. Run it with mcpp from this directory:
+
+```bash
+cd examples/mcpp_demo
+mcpp run
+```
+
+The manifest links the locally built Linux HuxerUI static library and its GTK dependencies. This is a host-specific proof of the build delegation path; packaging and cross-platform integration are not part of this demo.
+
+The demo currently requests C++26 through mcpp and uses the GCC 16.1.0 toolchain. The same page was also verified with `standard = "c++23"`; both standards compile successfully.
+
+The page intentionally uses stateless public components only, so it does not require HuxerUI's `hcg` code generator or `hrc` resource compiler. Stateful composables and packaged resources need an additional mcpp integration layer.

--- a/examples/mcpp_demo/mcpp.toml
+++ b/examples/mcpp_demo/mcpp.toml
@@ -1,0 +1,44 @@
+[package]
+name = "huxerui-mcpp-demo"
+version = "0.1.0"
+standard = "c++26"
+description = "A small HuxerUI page built through the mcpp CLI frontend"
+
+[toolchain]
+default = "gcc@16.1.0"
+
+[targets.huxerui_mcpp_demo]
+kind = "bin"
+main = "src/main.cpp"
+
+[build]
+include_dirs = ["../../include"]
+cxxflags = ["-pthread"]
+static_stdlib = false
+ldflags = [
+    "-L../../build/lib",
+    "-lhuxerui_static",
+    "-Wl,--no-as-needed",
+    "/lib64/libgtk-4.so",
+    "/lib64/libpangocairo-1.0.so",
+    "/lib64/libpango-1.0.so",
+    "/lib64/libgdk_pixbuf-2.0.so",
+    "/lib64/libcairo-gobject.so",
+    "/lib64/libcairo.so",
+    "/lib64/libharfbuzz.so",
+    "/lib64/libvulkan.so",
+    "/lib64/libgraphene-1.0.so",
+    "/lib64/libepoxy.so",
+    "/lib64/libsoup-3.0.so",
+    "/lib64/libgio-2.0.so",
+    "/lib64/libgobject-2.0.so",
+    "/lib64/libgmodule-2.0.so",
+    "/lib64/libglib-2.0.so",
+    "/lib64/libpcre2-8.so",
+    "/lib64/libfontconfig.so",
+    "-pthread",
+    "-Wl,--as-needed",
+]
+
+[runtime]
+library_dirs = ["/lib64"]

--- a/examples/mcpp_demo/src/main.cpp
+++ b/examples/mcpp_demo/src/main.cpp
@@ -1,0 +1,36 @@
+#include <huxerui/huxerui.h>
+
+#include <cstdio>
+
+using namespace huxerui;
+
+View App() {
+  return Column {
+    Text("mcpp + HuxerUI", TextRole::Title),
+    Text("This small page is compiled by mcpp and linked directly to the HuxerUI static library."),
+    Divider(),
+    Text("The SDK CLI does not need to know what the application is. It only delegates the build to mcpp."),
+    Row {
+      Button("Say hello").OnClick([] { std::puts("Hello from the HuxerUI mcpp demo."); }),
+    }.With(Spacing(12.0F)),
+  }.With(
+      Padding(32.0F),
+      Spacing(16.0F),
+      CrossAlign(CrossAxisAlignment::Stretch),
+      Background(Color::Rgb(248, 249, 252))
+  );
+}
+
+const Application application{
+    App,
+    {
+        .window = {
+            .title = "mcpp HuxerUI Demo",
+            .initial_size = {640.0F, 420.0F},
+        },
+    },
+};
+
+int main() {
+  return RunApplication();
+}

--- a/skills/huxerui-app-development/references/project-workflow.md
+++ b/skills/huxerui-app-development/references/project-workflow.md
@@ -23,6 +23,7 @@ huxerui doctor [platform-list]
 huxerui setup <platform-list> [--yes]
 huxerui devices [platform]
 huxerui build [platform-list] [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
+huxerui mcpp build [--source <path>] [--release] [--locked] [--offline] [--verbose]
 huxerui run <platform> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui package <platform-list> [--device <id>] [--profile debug|release] [--generator <name>] [--source <path>] [--java-home <path>]
 huxerui open ios [--source <path>]
@@ -155,6 +156,8 @@ TAG accepts a plain Git tag name rather than a branch or a `refs/tags/` value.
 Do not add a second dependency manifest or invoke FetchContent separately for a library already owned by this helper.
 
 ## Build and run without changing toolchains
+
+For an independent project that uses mcpp, run `huxerui mcpp build`. The selected directory must contain `mcpp.toml`; this frontend invokes mcpp directly and does not change the CMake-based HuxerUI project workflow below.
 
 - Reuse the project's compatible build directory and generator.
 - On Windows, keep the existing MSVC generator; do not switch to MinGW or pin a Visual Studio release without a project requirement.

--- a/tests/cli/commands.cpp
+++ b/tests/cli/commands.cpp
@@ -1,5 +1,7 @@
 #include "support.h"
 
+#include "mcpp/mcpp.h"
+
 using namespace huxerui::cli::test;
 
 TEST_CASE("HuxerUICliHelpListsSupportedAgents") {
@@ -26,6 +28,34 @@ TEST_CASE("HuxerUICliHelpListsSupportedAgents") {
   REQUIRE(invocation.output.find("--source <path>") != std::string::npos);
   REQUIRE(invocation.output.find("--java-home <path>") != std::string::npos);
   REQUIRE(invocation.output.find("a common library's Preview enable all platforms") != std::string::npos);
+  REQUIRE(invocation.output.find("huxerui mcpp build") != std::string::npos);
+}
+
+TEST_CASE("HuxerUICliCreatesMcppBuildCommands") {
+  TemporaryDirectory temporary;
+  const huxerui::cli::mcpp::BuildOptions options{
+      temporary.Path() / "mcpp-project",
+      true,
+      true,
+      true,
+      true,
+  };
+  const std::vector<huxerui::cli::ProcessCommand> commands = huxerui::cli::mcpp::BuildCommands(options);
+
+  REQUIRE(commands.size() == 1);
+  REQUIRE(commands[0].executable == "mcpp");
+  REQUIRE(
+      commands[0].arguments == std::vector<std::string>{"build", "--release", "--locked", "--offline", "--verbose"}
+  );
+  REQUIRE(commands[0].working_directory == options.project_root);
+}
+
+TEST_CASE("HuxerUICliMcppRequiresAManifest") {
+  TemporaryDirectory temporary;
+  const Invocation invocation = Invoke(temporary.Path(), {"mcpp", "build"});
+
+  REQUIRE(invocation.result == 1);
+  REQUIRE(invocation.error.find("mcpp.toml") != std::string::npos);
 }
 
 TEST_CASE("HuxerUICliRejectsInvalidSourceBuildOptions") {

--- a/tools/huxerui_cli/CMakeLists.txt
+++ b/tools/huxerui_cli/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(huxerui_cli_core STATIC
         platform/macos.cpp
         platform/web.cpp
         platform/windows.cpp
+        mcpp/mcpp.cpp
         process_runner.cpp
         project.cpp
         sdk.cpp

--- a/tools/huxerui_cli/cli.cpp
+++ b/tools/huxerui_cli/cli.cpp
@@ -17,6 +17,7 @@
 #include "platform.h"
 #include "process_runner.h"
 #include "project.h"
+#include "mcpp/mcpp.h"
 
 namespace huxerui::cli {
 namespace {
@@ -58,6 +59,7 @@ void PrintHelp(std::ostream& output) {
          << "  huxerui devices [platform]\n"
          << "  huxerui build [platform-list] [--device <id>] [--profile debug|release] [--generator <name>] "
             "[--source <path>] [--java-home <path>]\n"
+         << "  huxerui mcpp build [--source <path>] [--release] [--locked] [--offline] [--verbose]\n"
          << "  huxerui run <platform> [--device <id>] [--profile debug|release] [--generator <name>] "
             "[--source <path>] [--java-home <path>]\n"
          << "  huxerui package <platform-list> [--device <id>] [--profile debug|release] [--generator <name>] "
@@ -1123,6 +1125,9 @@ int Run(std::span<const std::string_view> arguments, const std::filesystem::path
     }
     if (arguments[0] == "devices") {
       return RunDevices(arguments, output);
+    }
+    if (arguments[0] == "mcpp") {
+      return mcpp::Run(arguments.subspan(1), working_directory, output, error);
     }
     if (arguments[0] == "build") {
       return RunBuild(arguments, working_directory, sdk.home, output);

--- a/tools/huxerui_cli/mcpp/mcpp.cpp
+++ b/tools/huxerui_cli/mcpp/mcpp.cpp
@@ -1,0 +1,147 @@
+#include "mcpp.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace huxerui::cli::mcpp {
+namespace {
+
+class UsageError final : public std::invalid_argument {
+public:
+  using std::invalid_argument::invalid_argument;
+};
+
+void PrintHelp(std::ostream& output) {
+  output << "HuxerUI standalone mcpp build frontend\n\n"
+         << "Usage:\n"
+         << "  huxerui mcpp build [--source <path>] [--release] [--locked] [--offline] [--verbose]\n\n"
+         << "The source directory must contain mcpp.toml.\n";
+}
+
+void RequireOnce(bool& selected, std::string_view option) {
+  if (selected) {
+    throw UsageError(std::string(option) + " may be specified only once");
+  }
+  selected = true;
+}
+
+std::filesystem::path ResolveProjectRoot(const std::filesystem::path& working_directory,
+                                         const std::filesystem::path& source) {
+  const std::filesystem::path candidate = source.is_absolute() ? source : working_directory / source;
+  const std::filesystem::path project_root = std::filesystem::absolute(candidate).lexically_normal();
+  if (!std::filesystem::is_directory(project_root)) {
+    throw std::runtime_error("mcpp source directory does not exist: " + project_root.string());
+  }
+  if (!std::filesystem::is_regular_file(project_root / "mcpp.toml")) {
+    throw std::runtime_error("mcpp project is missing mcpp.toml: " + project_root.string());
+  }
+  return project_root;
+}
+
+BuildOptions ParseBuildOptions(std::span<const std::string_view> arguments,
+                               const std::filesystem::path& working_directory) {
+  BuildOptions options;
+  bool source_selected = false;
+  std::filesystem::path source = working_directory;
+  for (std::size_t index = 1; index < arguments.size(); ++index) {
+    const std::string_view argument = arguments[index];
+    if (argument == "--source") {
+      RequireOnce(source_selected, argument);
+      if (++index == arguments.size() || arguments[index].empty() || arguments[index].starts_with('-')) {
+        throw UsageError("mcpp build --source requires a directory");
+      }
+      source = std::filesystem::path(arguments[index]);
+    } else if (argument == "--release") {
+      RequireOnce(options.release, argument);
+    } else if (argument == "--locked") {
+      RequireOnce(options.locked, argument);
+    } else if (argument == "--offline") {
+      RequireOnce(options.offline, argument);
+    } else if (argument == "--verbose") {
+      RequireOnce(options.verbose, argument);
+    } else if (argument == "--help" || argument == "-h") {
+      throw UsageError("help must be requested as `huxerui mcpp --help`");
+    } else {
+      throw UsageError("unknown mcpp build option: " + std::string(argument));
+    }
+  }
+  options.project_root = ResolveProjectRoot(working_directory, source);
+  return options;
+}
+
+void ExecuteCommands(std::span<const ProcessCommand> commands, std::ostream& output) {
+  for (const ProcessCommand& command : commands) {
+    output << "> " << DescribeProcess(command) << '\n';
+    output.flush();
+    const int result = RunProcess(command);
+    if (result != 0) {
+      throw std::runtime_error(
+          "mcpp command failed with exit code " + std::to_string(result) + ": " + DescribeProcess(command)
+      );
+    }
+  }
+}
+
+} // namespace
+
+std::vector<ProcessCommand> BuildCommands(const BuildOptions& options) {
+  if (options.project_root.empty()) {
+    throw std::invalid_argument("mcpp project root cannot be empty");
+  }
+
+  std::vector<std::string> arguments{"build"};
+  if (options.release) {
+    arguments.emplace_back("--release");
+  }
+  if (options.locked) {
+    arguments.emplace_back("--locked");
+  }
+  if (options.offline) {
+    arguments.emplace_back("--offline");
+  }
+  if (options.verbose) {
+    arguments.emplace_back("--verbose");
+  }
+  return {ProcessCommand{"mcpp", std::move(arguments), options.project_root}};
+}
+
+int Run(std::span<const std::string_view> arguments, const std::filesystem::path& working_directory,
+        std::ostream& output, std::ostream& error) {
+  try {
+    if (arguments.empty() || arguments[0] == "--help" || arguments[0] == "-h") {
+      PrintHelp(output);
+      return 0;
+    }
+    if (arguments[0] != "build") {
+      throw UsageError("unknown mcpp command: " + std::string(arguments[0]));
+    }
+    if (arguments.size() == 2 && (arguments[1] == "--help" || arguments[1] == "-h")) {
+      PrintHelp(output);
+      return 0;
+    }
+
+    const BuildOptions options = ParseBuildOptions(arguments, working_directory);
+    if (!FindExecutable("mcpp")) {
+      throw std::runtime_error("mcpp executable was not found on PATH");
+    }
+    output << "Building mcpp project " << options.project_root.string() << " ("
+           << (options.release ? "release" : "development") << ")\n";
+    const std::vector<ProcessCommand> commands = BuildCommands(options);
+    ExecuteCommands(commands, output);
+    return 0;
+  } catch (const UsageError& exception) {
+    error << "huxerui mcpp: " << exception.what() << '\n';
+    error << "Run 'huxerui mcpp --help' for usage.\n";
+    return 2;
+  } catch (const std::exception& exception) {
+    error << "huxerui mcpp: " << exception.what() << '\n';
+    return 1;
+  }
+}
+
+} // namespace huxerui::cli::mcpp

--- a/tools/huxerui_cli/mcpp/mcpp.h
+++ b/tools/huxerui_cli/mcpp/mcpp.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <iosfwd>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "process_runner.h"
+
+namespace huxerui::cli::mcpp {
+
+/// Options for the standalone mcpp build frontend.
+struct BuildOptions {
+  /// Root directory containing `mcpp.toml`.
+  std::filesystem::path project_root;
+  /// Selects mcpp's release profile instead of its development profile.
+  bool release = false;
+  /// Requires the mcpp lock file to be up to date.
+  bool locked = false;
+  /// Prevents mcpp from accessing the network.
+  bool offline = false;
+  /// Enables verbose mcpp output.
+  bool verbose = false;
+};
+
+/// Creates the direct child process command for an mcpp project.
+[[nodiscard]] std::vector<ProcessCommand> BuildCommands(const BuildOptions& options);
+
+/// Runs the standalone `huxerui mcpp` command.
+///
+/// The argument span starts with `build`, and the command does not use the HuxerUI SDK or project discovery.
+[[nodiscard]] int Run(std::span<const std::string_view> arguments, const std::filesystem::path& working_directory,
+                      std::ostream& output, std::ostream& error);
+
+} // namespace huxerui::cli::mcpp


### PR DESCRIPTION
Adds an independent huxerui mcpp build frontend, a C++26 HuxerUI demo, CLI coverage, and documentation.

Non-invasive build integration:
- `huxerui build <platform>` keeps its existing behavior and code path.
- `huxerui mcpp build ...` is a separate CLI subcommand implemented as an independent module and delegates the project build to mcpp.
- Existing platform build flows, CMake targets, and SDK project discovery are not replaced or rerouted by this addition.

ABI note:
- CMake can detect the SDK compiler and build settings, but this PR does not yet export or automatically select ABI metadata for mcpp.
- The demo pins GCC 16.1.0 to match the SDK's libstdc++ ABI. Future work can export compiler, standard library, target, and runtime metadata for CLI validation or toolchain selection.

Validation: HuxerUICliTests passed; mcpp C++26 demo build passed with GCC 16.1.0; git diff --check passed.