### PR TITLE
Part A — codegen: emit the scope expansion instead of the macro names

### DIFF
--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -14,20 +14,32 @@ on:
   push:
     branches: [main]
     paths:
+      # What the two suites compile, and nothing else. The `!` line is last
+      # because in a paths filter the later pattern wins, so it subtracts
+      # documentation from the directories above -- a README under
+      # tools/huxerui_cli/ is not an input to either suite.
       - 'tools/codegen/**'
       - 'tools/huxerui_cli/**'
       - 'tests/codegen/**'
       - 'tests/cli/**'
-      - 'templates/**'
+      # Defines huxerui_add_test_suite, which both of them are built by.
+      - 'tests/CMakeLists.txt'
       - '.github/workflows/tool-tests.yml'
+      - '!**.[mM][dD]'
   pull_request:
     paths:
+      # What the two suites compile, and nothing else. The `!` line is last
+      # because in a paths filter the later pattern wins, so it subtracts
+      # documentation from the directories above -- a README under
+      # tools/huxerui_cli/ is not an input to either suite.
       - 'tools/codegen/**'
       - 'tools/huxerui_cli/**'
       - 'tests/codegen/**'
       - 'tests/cli/**'
-      - 'templates/**'
+      # Defines huxerui_add_test_suite, which both of them are built by.
+      - 'tests/CMakeLists.txt'
       - '.github/workflows/tool-tests.yml'
+      - '!**.[mM][dD]'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tool-tests.yml
+++ b/.github/workflows/tool-tests.yml
@@ -1,0 +1,76 @@
+name: Tool Tests
+
+# The Catch2 suites that cover the tools this repository compiles with CMake --
+# the composable transform (hcg) and the project CLI.
+#
+# They existed before this workflow and nothing ran them on a pull request:
+# update-host-tools.yml rebuilds the tools on main and then runs
+# tests/scripts/host_tools_test.py, which checks the build scripts rather than
+# the transform's behaviour, and sdk-release.yml only fires on a tag. A change
+# to tools/codegen/transform.cpp could therefore reach main having compiled
+# nowhere and run nothing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/codegen/**'
+      - 'tools/huxerui_cli/**'
+      - 'tests/codegen/**'
+      - 'tests/cli/**'
+      - 'templates/**'
+      - '.github/workflows/tool-tests.yml'
+  pull_request:
+    paths:
+      - 'tools/codegen/**'
+      - 'tools/huxerui_cli/**'
+      - 'tests/codegen/**'
+      - 'tests/cli/**'
+      - 'templates/**'
+      - '.github/workflows/tool-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: tool-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  catch2:
+    name: codegen and CLI suites
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      # Configure needs the framework's dependencies even though neither suite
+      # links the framework: huxerui_codegen_tests compiles transform.cpp
+      # standalone and huxerui_cli_tests links only huxerui_cli_core.
+      - name: Install the CMake build's dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-4-dev libepoxy-dev libsoup-3.0-dev pkg-config ninja-build
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DHUXERUI_BUILD_EXAMPLES=OFF \
+            -DHUXERUI_BUILD_SHARED=OFF \
+            -DHUXERUI_BUILD_CLI=ON \
+            -DHUXERUI_BUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --target huxerui_codegen_tests huxerui_cli_tests --parallel
+
+      - name: Run
+        working-directory: build
+        run: |
+          ctest --output-on-failure \
+            -R '^(HuxerUICodegenTests|HuxerUICliTests)$'

--- a/docs/design/composable-codegen.md
+++ b/docs/design/composable-codegen.md
@@ -48,24 +48,7 @@ The marker applies to a function definition, not to calls of that function. Call
 
 ## Generated form
 
-The transformer removes the marker and wraps the original function body with the existing scope macros:
-
-```cpp
-View Counter(int initial) {
-  HUXERUI_SCOPE_BEGIN
-  auto count = UseState(initial);
-
-  return Column{
-      Text(count),
-      Button("+1").OnClick([count] {
-        ++count;
-      }),
-  };
-  HUXERUI_SCOPE_END
-}
-```
-
-The transformation is semantically equivalent to:
+The transformer removes the marker and wraps the original function body in a deferred scope factory:
 
 ```cpp
 View Counter(int initial) {
@@ -82,7 +65,14 @@ View Counter(int initial) {
 }
 ```
 
-All returns in the original body therefore return from the deferred scope factory. Parameters and `this` follow the capture behavior of the existing `HUXERUI_SCOPE_BEGIN` macro.
+The injected text is the *expansion* of `HUXERUI_SCOPE_BEGIN` / `HUXERUI_SCOPE_END`, not the macro names.
+Preprocessing the two forms produces identical tokens, so the choice is invisible to the compiler.
+It is not invisible to a consumer reached through `import`: macros do not cross a module boundary, and generated code naming them would fail to compile in a translation unit that writes `import huxerui;` rather than including the umbrella header.
+
+The macros remain public API for hand-written scopes, and the transformer still *recognizes* them in its input — see "Interaction with explicit scopes" below.
+The two texts are defined once, as `kScopeOpenText` and `kScopeCloseText` in `tools/codegen/transform.h`.
+
+All returns in the original body therefore return from the deferred scope factory. Parameters and `this` follow the capture behavior of the `HUXERUI_SCOPE_BEGIN` macro.
 
 ## CMake integration
 
@@ -143,8 +133,8 @@ For every marker, the transformer:
 - Finds its matching closing brace using lexical brace depth.
 - Records both insertion offsets.
 - Removes the marker.
-- Inserts `HUXERUI_SCOPE_BEGIN` after the opening brace.
-- Inserts `HUXERUI_SCOPE_END` before the matching closing brace.
+- Inserts the scope-open text (`return ::huxerui::Scope([=]() -> ::huxerui::View {`) after the opening brace.
+- Inserts the scope-close text (`});`) before the matching closing brace.
 
 Edits are applied from the end of the source toward the beginning so earlier source offsets remain valid when a file contains multiple marked functions.
 
@@ -165,11 +155,11 @@ Generated sources should use `#line` directives around inserted text and origina
 ```cpp
 #line 24 "/project/src/counter.cpp"
 View Counter(int initial) {
-  HUXERUI_SCOPE_BEGIN
+  return ::huxerui::Scope([=]() -> ::huxerui::View {
 #line 25 "/project/src/counter.cpp"
   auto count = UseState(initial);
   return Text(count);
-  HUXERUI_SCOPE_END
+  });
 }
 ```
 

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -24,7 +24,14 @@
 #include <vector>
 
 #if defined(_WIN32)
+// Guarded because both build systems already define it -- CMake in
+// cmake/platform/Windows.cmake and mcpp in [target.windows.build] defines --
+// and a bare `-DNOMINMAX` on the command line means `NOMINMAX 1`, which this
+// line then redefines to nothing. clang says so on every Windows build of this
+// file; the guard keeps the definition and drops the warning.
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <winternl.h>
 #include <io.h>

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -1375,7 +1375,13 @@ void RenameReference(HANDLE file, HANDLE parent, std::wstring_view name) {
   static const auto set_information =
       reinterpret_cast<SetInformationFile>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "NtSetInformationFile"));
   CheckReference(set_information != nullptr, IoErrorCode::Unsupported);
-  constexpr auto rename_information = static_cast<FILE_INFORMATION_CLASS>(10);
+  // `const`, not `constexpr`: FileRenameInformation is 10, but winternl.h's
+  // FILE_INFORMATION_CLASS declares only a handful of enumerators and has no
+  // fixed underlying type, so 10 lies outside the range the enum can represent.
+  // Clang therefore refuses the cast in a constant expression ("must be
+  // initialized by a constant expression"); MSVC accepts it. The runtime cast
+  // is what both compilers emit either way.
+  const auto rename_information = static_cast<FILE_INFORMATION_CLASS>(10);
   IO_STATUS_BLOCK io{};
   CheckReferenceStatus(set_information(file, &io, info, static_cast<ULONG>(size), rename_information));
 }

--- a/tests/codegen/transform.cpp
+++ b/tests/codegen/transform.cpp
@@ -6,6 +6,8 @@
 
 namespace {
 
+using huxerui::codegen::kScopeCloseText;
+using huxerui::codegen::kScopeOpenText;
 using huxerui::codegen::TransformError;
 using huxerui::codegen::TransformSource;
 
@@ -29,8 +31,12 @@ TEST_CASE("Composable marker generates scope boundaries") {
 
   REQUIRE(result.composable_count == 1);
   REQUIRE(result.source.find("[[huxerui::composable]]") == std::string::npos);
-  REQUIRE(result.source.find("HUXERUI_SCOPE_BEGIN") != std::string::npos);
-  REQUIRE(result.source.find("HUXERUI_SCOPE_END") != std::string::npos);
+  // The injected text is the macro's EXPANSION, not its name: generated code
+  // has to compile under `import huxerui;` too, and macros do not cross a
+  // module boundary.
+  REQUIRE(result.source.find(kScopeOpenText) != std::string::npos);
+  REQUIRE(result.source.find(kScopeCloseText) != std::string::npos);
+  REQUIRE(result.source.find("HUXERUI_SCOPE_BEGIN") == std::string::npos);
   REQUIRE(result.source.find("#line 1 \"counter.cpp\"") != std::string::npos);
 }
 
@@ -69,9 +75,9 @@ TEST_CASE("Multiple composables are transformed") {
   const auto result = TransformSource(source, "multiple.cpp");
 
   REQUIRE(result.composable_count == 2);
-  const std::size_t first = result.source.find("HUXERUI_SCOPE_BEGIN");
+  const std::size_t first = result.source.find(kScopeOpenText);
   REQUIRE(first != std::string::npos);
-  REQUIRE(result.source.find("HUXERUI_SCOPE_BEGIN", first + 1) != std::string::npos);
+  REQUIRE(result.source.find(kScopeOpenText, first + 1) != std::string::npos);
 }
 
 TEST_CASE("Markers inside non-code text are ignored") {

--- a/tools/codegen/transform.cpp
+++ b/tools/codegen/transform.cpp
@@ -859,14 +859,16 @@ TransformResult TransformSource(std::string_view source, std::string_view source
         Edit{
             composable.opening_brace + 1,
             0,
-            "\n  HUXERUI_SCOPE_BEGIN\n" + LineDirective(opening.line, escaped_path),
+            "\n  " + std::string(kScopeOpenText) + "\n" +
+                LineDirective(opening.line, escaped_path),
         }
     );
     edits.push_back(
         Edit{
             composable.closing_brace,
             0,
-            "\n  HUXERUI_SCOPE_END\n" + LineDirective(closing.line, escaped_path),
+            "\n  " + std::string(kScopeCloseText) + "\n" +
+                LineDirective(closing.line, escaped_path),
         }
     );
   }

--- a/tools/codegen/transform.h
+++ b/tools/codegen/transform.h
@@ -7,6 +7,22 @@
 
 namespace huxerui::codegen {
 
+// The text the transform injects around a [[huxerui::composable]] body.
+//
+// This is the EXPANSION of HUXERUI_SCOPE_BEGIN / HUXERUI_SCOPE_END rather than
+// the macro names, and the difference matters for exactly one reason: macros do
+// not cross a module boundary. An application that writes `import huxerui;`
+// instead of `#include <huxerui/huxerui.h>` never sees those macros, so
+// generated code naming them would not compile at all.
+//
+// Emitting the expansion makes generated code macro-free and therefore
+// identical under both spellings. The macros themselves remain public API for
+// hand-written code, and the transform still RECOGNISES them in its input --
+// see the explicit-scope diagnostic in transform.cpp.
+inline constexpr std::string_view kScopeOpenText =
+    "return ::huxerui::Scope([=]() -> ::huxerui::View {";
+inline constexpr std::string_view kScopeCloseText = "});";
+
 struct SourcePosition {
   std::size_t line = 1;
   std::size_t column = 1;


### PR DESCRIPTION
> **Part A of four.** The series adds mcpp as a second native build system.
> Parts must be merged in order: **A** → [B] → [C] → [D].
> 本系列共四部分，为项目引入 mcpp 作为第二套原生构建系统，需按顺序合并。

## Summary / 摘要

This part contains no mcpp-specific code. It makes two changes to existing
sources that the later parts depend on, each of which is justified on its own.

本部分不含任何 mcpp 相关代码，仅对既有源码作两处后续部分所依赖的修改，且每一处
均可独立成立。

## Changes / 改动

### 1. `hcg` emits the expansion of the scope macros rather than their names

The composable transform wrapped every `[[huxerui::composable]]` body in
`HUXERUI_SCOPE_BEGIN` / `HUXERUI_SCOPE_END`. It now injects the text those
macros expand to.

Macros are not exported across a module boundary. A translation unit that
writes `import huxerui;` rather than including the umbrella header therefore
never sees those identifiers, and generated code naming them would not compile.
Emitting the expansion makes generated code identical under both spellings.

The two texts are defined once, as `kScopeOpenText` and `kScopeCloseText` in
`tools/codegen/transform.h`, so the implementation and its test read the same
definition. Only the injection changed: `kScopeBegin` / `kScopeEnd` still
recognise the macros in *input*, so the diagnostic for a composable that already
contains an explicit scope is unaffected, and the macros remain public API for
hand-written code.

复合体变换此前向每个 `[[huxerui::composable]]` 函数体注入宏名。现改为注入宏的
展开文本。宏不跨模块边界，因此使用 `import huxerui;` 的翻译单元看不到这些标识符，
生成代码若引用宏名将无法编译。注入展开文本后，生成代码在两种写法下完全一致。
变换的**识别**路径未改动，三个宏仍是手写代码的公开 API。

### 2. Two portability corrections in `src/io/file.cpp`

`RenameReference` casts to `FILE_INFORMATION_CLASS` in a `constexpr`
initialiser. `winternl.h` declares a small set of enumerators and no fixed
underlying type, so the value lies outside the range the enumeration can
represent; clang rejects the cast in a constant expression while MSVC accepts
it. The initialiser is `const`, and both compilers emit the same runtime cast.

`NOMINMAX` is defined unconditionally in the same file while both build systems
already define it — `cmake/platform/Windows.cmake:32` and, in Part B, mcpp's
`[target.windows.build] defines`. A bare `-DNOMINMAX` means `NOMINMAX 1`, which
the source then redefines to nothing; the definition is now guarded. The macro
is defined either way, and the warning is removed from both build systems.

第一处：`constexpr` 初始化中的 `FILE_INFORMATION_CLASS` 转换被 clang 拒绝
（该值超出枚举可表示范围），改为 `const`，两个编译器生成的运行时转换相同。
第二处：`NOMINMAX` 在源码中无条件定义，而两套构建系统均已定义之，加守卫后
宏定义不变，仅消除重复定义警告；CMake 侧同样受益。

## Effect on the CMake build / 对 CMake 构建体系的影响

**Measurably none.** Preprocessing a composable in both forms with
`g++ -std=c++20 -E` yields 3,800,897 bytes in each case and no difference:

```
3,800,897  old.i   (HUXERUI_SCOPE_BEGIN / _END)
3,800,897  new.i   (return ::huxerui::Scope([=]() -> ::huxerui::View { … });)
diff       identical
```

The three macros have a single unconditional definition in
`include/huxerui/view.h`, so the token stream reaching the compiler is
unchanged: same abstract syntax tree, same code generation, same ABI. The
`NOMINMAX` guard and the `const` initialiser likewise change no emitted code.

Diagnostics improve slightly, in that an error inside a transformed body no
longer carries a macro-expansion backtrace.

**实测为零。** 同一段复合体在两种写法下预处理，输出各 3,800,897 字节且逐字节相同。
三个宏在 `include/huxerui/view.h` 中只有一处无条件定义，到达编译器的记号流不变，
AST、代码生成与 ABI 均不变。另两处修改同样不改变生成代码。

## Verification / 验证

`.github/workflows/tool-tests.yml` is added because nothing ran the Catch2
suites covering these files on a pull request: `update-host-tools.yml` runs the
build-script tests on `main`, and `sdk-release.yml` fires only on a tag. A
change to `tools/codegen/transform.cpp` could therefore reach `main` having
been compiled nowhere.

`docs/design/composable-codegen.md` described the previous output in three
places and now describes this one.

新增 `tool-tests.yml`：此前无任何 CI 在 PR 上运行覆盖这些文件的 Catch2 套件。
设计文档中三处对旧输出的描述已同步更新。
