### PR TITLE
fix(mcpp): declare graphite2 Linux payload

### DIFF
--- a/.github/workflows/mcpp-build.yml
+++ b/.github/workflows/mcpp-build.yml
@@ -197,7 +197,7 @@ jobs:
           path: |
             ~/.xlings
             ~/.mcpp
-          # The payload store holds the whole GTK closure (36 packages), so
+          # The payload store holds the whole GTK closure (37 packages), so
           # the key names the manifest that selects them.
           key: mcpp-${{ runner.os }}-${{ runner.arch }}-v2-${{ env.MCPP_VERSION }}-${{ hashFiles('mcpp.toml') }}
           restore-keys: |

--- a/build.mcpp
+++ b/build.mcpp
@@ -41,11 +41,13 @@ constexpr std::string_view kLinuxPayloads[] = {
 // location, which is what makes a relocatable payload store work at all.
 std::string pkg_config_libdir() {
     std::string dirs;
-    std::size_t found = 0;
+    std::vector<std::string_view> missing;
     for (std::string_view name : kLinuxPayloads) {
         const std::string root = mcpp::xpkg_dir("xim", std::string(name).c_str());
-        if (root.empty()) continue;
-        ++found;
+        if (root.empty()) {
+            missing.push_back(name);
+            continue;
+        }
         // xorgproto and friends install their .pc under share/, not lib/.
         for (const char* sub : { "/lib/pkgconfig", "/share/pkgconfig", "/lib64/pkgconfig" }) {
             const std::string d = root + sub;
@@ -54,10 +56,12 @@ std::string pkg_config_libdir() {
             dirs += d;
         }
     }
-    if (found != std::size(kLinuxPayloads)) {
-        std::cerr << "huxerui: " << (std::size(kLinuxPayloads) - found)
+    if (!missing.empty()) {
+        std::cerr << "huxerui: " << missing.size()
                   << " of " << std::size(kLinuxPayloads)
-                  << " xlings payloads did not resolve; check "
+                  << " xlings payloads did not resolve:";
+        for (std::string_view name : missing) std::cerr << ' ' << name;
+        std::cerr << "; check "
                      "[target.'cfg(linux)'.xlings.workspace] in mcpp.toml\n";
     }
     return dirs;

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -117,6 +117,7 @@ sources = ["platform/linux/*.cpp"]
 "xim:gdk-pixbuf" = "2.44.8"
 "xim:glib" = "2.88.3"
 "xim:graphene" = "1.10.8"
+"xim:graphite2" = "1.3.14"
 "xim:gtk4" = "4.16.13"
 "xim:harfbuzz" = "14.4.0"
 "xim:libX11" = "1.8.10"


### PR DESCRIPTION
## Summary

- declare xim:graphite2 1.3.14 in the Linux xlings workspace
- name every unresolved Linux payload in the build diagnostic
- update the CI cache comment for the 37-package GTK closure

## Validation

- parsed mcpp.toml with Python tomllib
- verified build.mcpp and mcpp.toml contain the same 37 Linux payload names
- git diff --check
- not run: mcpp build (mcpp/xlings is not installed in the current environment)

Closes #131